### PR TITLE
.travis: Convert TRAVIS_COMMIT_RANGE base...head to base..head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 install: true
 
 script:
+  - env | grep TRAVIS_
   - make .govet
   - make .golint
   - echo "${TRAVIS_COMMIT_RANGE} -> ${TRAVIS_COMMIT_RANGE/.../..} (travis-ci/travis-ci#4596)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ install: true
 script:
   - make .govet
   - make .golint
-  - make .gitvalidation
+  - echo "${TRAVIS_COMMIT_RANGE} -> ${TRAVIS_COMMIT_RANGE/.../..} (travis-ci/travis-ci#4596)"
+  - TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make .gitvalidation
   - make docs

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 # When this is running in travis, it will only check the travis commit range
 .gitvalidation:
 	@which git-validation > /dev/null 2>/dev/null || (echo "ERROR: git-validation not found. Consider 'make install.tools' target" && false)
-ifeq ($(TRAVIS),true)
+ifdef TRAVIS_COMMIT_RANGE
 	git-validation -q -run DCO,short-subject,dangling-whitespace
 else
 	git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD


### PR DESCRIPTION
Work around travis-ci/travis-ci#4596 until that is fixed upstream.
This avoids pulling in commits from the base tip that aren't reachable
from the head tip (e.g. if master has advanced since the PR branched
off, and the PR is against master).  We only want to check commits
that are in the head branch but not in the base branch (more details
on the range syntax [here](http://git-scm.com/docs/gitrevisions#_specifying_ranges)).

Once the Travis bug does get fixed, the shell replacement will be a
no-op.  So we don't have to worry about checks breaking once the bug
gets fixed, and can periodically poll the bug and remove the
workaround at out leisure after the fix.

Spun off from #182 now that #215 has landed.
