### PR TITLE
specs: linux: add intel_rdt cgroup support in specs

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -163,7 +163,7 @@ In addition to any devices configured with this setting, the runtime MUST also s
 ## Control groups
 
 Also known as cgroups, they are used to restrict resource usage for a container and handle device access.
-cgroups provide controls to restrict cpu, memory, IO, pids and network for the container.
+cgroups provide controls to restrict cpu, memory, IO, pids, network and intel_rdt for the container.
 For more information, see the [kernel cgroups documentation][cgroup-v1].
 
 The path to the cgroups can be specified in the Spec via `cgroupsPath`.
@@ -451,6 +451,23 @@ The following paramters can be specified to setup the controller:
 ```json
    "pids": {
         "limit": 32771
+   }
+```
+
+#### Intel rdt 
+
+`intelRdt` represents the cgroup subsystem `intel_rdt`.
+For more information, see [the intel_rdt cgroup man page](https://lkml.org/lkml/2015/12/17/574).
+
+The following paramters can be specified to setup the controller:
+
+* **`l3Cbm`** *(uint64, optional)* - specifies L3 cache capacity bitmask (CBM) in the cgroup
+
+###### Example
+
+```json
+   "intelRdt": {
+        "l3Cbm": 4080 
    }
 ```
 

--- a/config_linux.go
+++ b/config_linux.go
@@ -211,6 +211,12 @@ type Network struct {
 	Priorities []InterfacePriority `json:"priorities,omitempty"`
 }
 
+// IntelRdt for Linux cgroup 'intel_rdt' resource management
+type IntelRdt struct {
+	// L3 cache capacity bitmask (CBM) for container
+	L3Cbm *uint64 `json:"l3Cbm,omitempty"`
+}
+
 // Resources has container runtime resource constraints
 type Resources struct {
 	// Devices are a list of device rules for the whitelist controller
@@ -231,6 +237,8 @@ type Resources struct {
 	HugepageLimits []HugepageLimit `json:"hugepageLimits,omitempty"`
 	// Network restriction configuration
 	Network *Network `json:"network,omitempty"`
+	// IntelRdt restriction configuration
+	IntelRdt *IntelRdt `json:"intelRdt,omitempty"`
 }
 
 // Device represents the mknod information for a Linux special device file


### PR DESCRIPTION
Add support for the intel_rdt cgroup resource in Linux-specific
configuration to support config.json.

The intel_rdt cgroup subsystem will be available in Linux 4.6 (or later).

Signed-off-by: Xiaochen Shen xiaochen.shen@intel.com

This is the prerequisite of this runc proposal: https://github.com/opencontainers/runc/issues/433
For more information about intel_rdt cgroup, please refer to: https://github.com/opencontainers/runc/issues/433
