### PR TITLE
README: Add a link to the IRC logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can subscribe and join the mailing list on [Google Groups](https://groups.go
 
 ## IRC
 
-OCI discussion happens on #opencontainers on Freenode.
+OCI discussion happens on #opencontainers on Freenode ([logs][irc-logs]).
 
 ## Markdown style
 
@@ -158,3 +158,4 @@ Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git
 8. When possible, one keyword to scope the change in the subject (i.e. "README: ...", "runtime: ...")
 
 [UberConference]: https://www.uberconference.com/ssaul
+[irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/


### PR DESCRIPTION
We have these irclog2html.py logs [because we're part of a MeetBot
pool managed by the Linux Foundation][1], so they should be pretty
reliable.

We could have this link in the `/topic`, but there's already a lot
there and folks may want to browse the logs over HTTP without
bothering to connect to the live channel.

[1]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2015-12-29.log.html#t2015-12-29T21:51:30
