### PR TITLE
Add masked and readonly paths

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -443,7 +443,7 @@ The following parameters can be specified to setup the controller:
 
 ## Sysctl
 
-sysctl allows kernel parameters to be modified at runtime for the container.
+`sysctl` allows kernel parameters to be modified at runtime for the container.
 For more information, see [the man page](http://man7.org/linux/man-pages/man8/sysctl.8.html)
 
 ###### Example
@@ -511,7 +511,7 @@ Operator Constants:
 
 ## Rootfs Mount Propagation
 
-rootfsPropagation sets the rootfs's mount propagation.
+`rootfsPropagation` sets the rootfs's mount propagation.
 Its value is either slave, private, or shared.
 [The kernel doc](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) has more information about mount propagation.
 
@@ -519,6 +519,30 @@ Its value is either slave, private, or shared.
 
 ```json
     "rootfsPropagation": "slave",
+```
+
+## Masked Paths
+
+`maskedPaths` will mask over the provided paths inside the container so that they cannot be read.
+
+###### Example
+
+```json
+    "maskedPaths": [
+        "/proc/kcore"
+    ]
+```
+
+## Readonly Paths
+
+`readonlyPaths` will set the provided paths as readonly inside the container.
+
+###### Example
+
+```json
+    "readonlyPaths": [
+        "/proc/sys"
+    ]
 ```
 
 [cgroup-v1]: https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt

--- a/schema/schema-linux.json
+++ b/schema/schema-linux.json
@@ -337,6 +337,14 @@
                         "type": "null"
                     }
                 ]
+            },
+            "maskedPaths": {
+                "id": "https://opencontainers.org/schema/bundle/linux/maskedPaths",
+                "$ref": "defs.json#/definitions/ArrayOfStrings"
+            },
+            "readonlyPaths": {
+                "id": "https://opencontainers.org/schema/bundle/linux/readonlyPaths",
+                "$ref": "defs.json#/definitions/ArrayOfStrings"
             }
         }
     }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -136,6 +136,10 @@ type Linux struct {
 	Seccomp *Seccomp `json:"seccomp,omitempty"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container.
 	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
+	// MaskedPaths masks over the provided paths inside the container.
+	MaskedPaths []string `json:"maskedPaths,omitempty"`
+	// ReadonlyPaths sets the provided paths as RO inside the container.
+	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
 }
 
 // Namespace is the configuration for a Linux namespace


### PR DESCRIPTION
Fixes #320

This adds the maskedPaths and readonlyPaths fields to the spec so that
proper masking and setting of files in /proc can be configured.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>