### PR TITLE
style: Move one-sentence-per-line rule over from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,6 @@ You can subscribe and join the mailing list on [Google Groups](https://groups.go
 
 OCI discussion happens on #opencontainers on Freenode ([logs][irc-logs]).
 
-## Markdown style
-
-To keep consistency throughout the Markdown files in the Open Container spec all files should be formatted one sentence per line.
-This fixes two things: it makes diffing easier with git and it resolves fights about line wrapping length.
-For example, this paragraph will span three lines in the Markdown source.
-
 ## Git commit
 
 ### Sign your work

--- a/style.md
+++ b/style.md
@@ -1,5 +1,11 @@
 # Style and conventions
 
+## One sentence per line
+
+To keep consistency throughout the Markdown files in the Open Container spec all files should be formatted one sentence per line.
+This fixes two things: it makes diffing easier with git and it resolves fights about line wrapping length.
+For example, this paragraph will span three lines in the Markdown source.
+
 ## Traditionally hex settings should use JSON integers, not JSON strings
 
 For example, [`"classID": 1048577`][class-id] instead of `"classID": "0x100001"`.


### PR DESCRIPTION
This is style information, even though it's about the spec and not
about the behavior covered by the spec.  The Go-pointer rule is also
about more peripheral stuff though, and the README has a lot of stuff
in it, so it seems like a better fit after the move.