### PR TITLE
config.md: Rename ociVersion -> ociRuntimeVersion

### DIFF
--- a/config.md
+++ b/config.md
@@ -10,7 +10,7 @@ Below is a detailed description of each field defined in the configuration forma
 
 ## Specification version
 
-* **`ociVersion`** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OpenContainer specification with which the bundle complies.
+* **`ociRuntimeVersion`** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OpenContainer specification with which the bundle complies.
 The OpenContainer spec follows semantic versioning and retains forward and backward compatibility within major versions.
 For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
 NOTE that there is no guarantee for forward or backward compatibility for version 0.x.
@@ -18,7 +18,7 @@ NOTE that there is no guarantee for forward or backward compatibility for versio
 *Example*
 
 ```json
-    "ociVersion": "0.1.0"
+    "ociRuntimeVersion": "0.1.0"
 ```
 
 ## Root Configuration
@@ -269,7 +269,7 @@ Here is a full example `config.json` for reference.
 
 ```json
 {
-    "ociVersion": "0.3.0",
+    "ociRuntimeVersion": "0.3.0",
     "platform": {
         "os": "linux",
         "arch": "amd64"

--- a/runtime.md
+++ b/runtime.md
@@ -9,7 +9,7 @@ Whether other entities using the same, or other, instance of the runtime can see
 
 The state of a container MUST include, at least, the following propeties:
 
-* **`ociVersion`**: (string) is the OCI specification version used when creating the container.
+* **`ociRuntimeVersion`**: (string) is the OCI specification version used when creating the container.
 * **`id`**: (string) is the container's ID.
 This MUST be unique across all containers on this host.
 There is no requirement that it be unique across hosts.
@@ -22,7 +22,7 @@ This is provided so that consumers can find the container's configuration and ro
 When serialized in JSON, the format MUST adhere to the following pattern:
 ```json
 {
-    "ociVersion": "0.2.0",
+    "ociRuntimeVersion": "0.2.0",
     "id": "oci-container1",
     "pid": 4422,
     "bundlePath": "/containers/redis"

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4,9 +4,9 @@
     "id": "https://opencontainers.org/schema/bundle",
     "type": "object",
     "properties": {
-        "ociVersion": {
+        "ociRuntimeVersion": {
             "description": "The version of OpenContainer specification configuration complies with",
-            "id": "https://opencontainers.org/schema/bundle/ociVersion",
+            "id": "https://opencontainers.org/schema/bundle/ociRuntimeVersion",
             "type": "string"
         },
         "hooks": {
@@ -147,7 +147,7 @@
         }
     },
     "required": [
-        "ociVersion",
+        "ociRuntimeVersion",
         "platform",
         "process",
         "root",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -7,7 +7,7 @@ import "os"
 // bundle is packaged for distribution.
 type Spec struct {
 	// Version is the version of the specification that is supported.
-	Version string `json:"ociVersion"`
+	Version string `json:"ociRuntimeVersion"`
 	// Platform is the host information for OS and Arch.
 	Platform Platform `json:"platform"`
 	// Process is the container's main process.

--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -3,7 +3,7 @@ package specs
 // State holds information about the runtime state of the container.
 type State struct {
 	// Version is the version of the specification that is supported.
-	Version string `json:"version"`
+	Version string `json:"ociVersion"`
 	// ID is the container ID
 	ID string `json:"id"`
 	// Pid is the process id for the container's main process.

--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -3,7 +3,7 @@ package specs
 // State holds information about the runtime state of the container.
 type State struct {
 	// Version is the version of the specification that is supported.
-	Version string `json:"ociVersion"`
+	Version string `json:"ociRuntimeVersion"`
 	// ID is the container ID
 	ID string `json:"id"`
 	// Pid is the process id for the container's main process.


### PR DESCRIPTION
Now that we have [multiple][1] [OCI][2] specs.  [Reported][3] by
@jonboulle.

Generated with:

    $ sed -i 's/ociVersion/ociRuntimeVersion/g' $(git grep -l ociVersion)

[1]: https://github.com/opencontainers/image-spec
[2]: https://github.com/opencontainers/runtime-spec
[3]: https://github.com/opencontainers/image-spec/pull/6/files/bf5c3f6b30cf326ee3e64849c8eb4c953500dd25#r58699357