### PR TITLE
Fix the build by getting rid of go get for vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@ language: go
 go:
   - 1.6
   - 1.5.3
-  - 1.4.3
-  - 1.3.3
 
 sudo: false
 
 before_install:
-  - go get golang.org/x/tools/cmd/vet
   - go version | (grep -q 'go1.[56]' || exit 0 && go get -u github.com/golang/lint/golint )
   - go get github.com/vbatts/git-validation
 


### PR DESCRIPTION
They got rid of the repo. See https://groups.google.com/forum/#!searchin/golang-announce/vet|sort:relevance/golang-announce/qu_rAphYdxY/SR5jL9IDBgAJ

Thanks to @liangchenye for reporting.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>