### PR TITLE
config-linux.md: Reword kernelTCP docs and mention bytes

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -259,7 +259,7 @@ The following parameters can be specified to setup the controller:
 
 * **`kernel`** *(uint64, optional)* - sets hard limit for kernel memory
 
-* **`kernelTCP`** *(uint64, optional)* - sets hard limit for kernel memory in tcp using
+* **`kernelTCP`** *(uint64, optional)* - sets hard limit in bytes for kernel TCP buffer memory
 
 * **`swappiness`** *(uint64, optional)* - sets swappiness parameter of vmscan (See sysctl's vm.swappiness)
 


### PR DESCRIPTION
Avoid the dangling “using” from e9a6d948 (cgroup: Add support for
`memory.kmem.tcp.limit_in_bytes`, 2015-10-26, #235).  I've tried to
echo the [kernel docs][1] by mentioning buffer memory.  I'd personally
prefer linking to the kernel docs and mentioning
`memory.kmem.tcp.limit_in_bytes`, but that seemed like too big of a
break from the existing style for this commit.

[1]: https://kernel.org/doc/Documentation/cgroup-v1/memory.txt