### PR TITLE
README: Remove trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Table of Contents
 
 In the specifications in the above table of contents, the keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119) (Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997).
 
-An implementation is not compliant if it fails to satisfy one or more of the MUST or REQUIRED requirements for the protocols it implements. 
+An implementation is not compliant if it fails to satisfy one or more of the MUST or REQUIRED requirements for the protocols it implements.
 An implementation that satisfies all the MUST or REQUIRED and all the SHOULD requirements for its protocols is said to be "unconditionally compliant".
 
 # Use Cases


### PR DESCRIPTION
With:

    $ sed -i 's/[[:space:]]*$//' README.md

fixing some trailing whitespace that snuck in with ca0803d1
(Additional language for conformance statement, 2016-04-06, #374).
Future occurrences should be caught by git-validation, which checks
for [whitespace][1] [issues][2] now.

[1]: https://github.com/vbatts/git-validation/pull/7
[2]: https://github.com/vbatts/git-validation/pull/9