### PR TITLE
Fix example in schema README

### DIFF
--- a/schema/Makefile
+++ b/schema/Makefile
@@ -11,5 +11,6 @@ fmt:
 	for i in *.json ; do jq --indent 4 -M . "$${i}" > xx && cat xx > "$${i}" && rm xx ; done
 
 validate: validate.go
+	go get -d ./...
 	go build ./validate.go
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -20,7 +20,7 @@ There is also included a simple utility for facilitating validation of a
 
 ```bash
 export GOPATH=`mktemp -d`
-go get ./...
+go get -d ./...
 go build .
 rm -rf $GOPATH
 ```

--- a/schema/README.md
+++ b/schema/README.md
@@ -21,12 +21,18 @@ There is also included a simple utility for facilitating validation of a
 ```bash
 export GOPATH=`mktemp -d`
 go get -d ./...
-go build .
+go build ./validate.go
 rm -rf $GOPATH
+```
+
+Or you can just use make command to create the utility:
+
+```bash
+make validate
 ```
 
 Then use it like:
 
 ```bash
-./schema schema.json <yourpath>/config.json
+./validate schema.json <yourpath>/config.json
 ```


### PR DESCRIPTION
We should only download dependence without installing,
otherwise we'll probably get error:
go install: no install location for directory /home/qhuang/specs/schema outside GOPATH
        For more details see: go help gopath

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>