### PR TITLE
config: Move (u|g)idMappings from 'process' to 'linux'

### DIFF
--- a/config.md
+++ b/config.md
@@ -286,20 +286,6 @@ Here is a full example `config.json` for reference.
                 6
             ]
         },
-        "uidMappings": [
-            {
-                "hostID": 1000,
-                "containerID": 0,
-                "size": 32000
-            }
-        ],
-        "gidMappings": [
-            {
-                "hostID": 1000,
-                "containerID": 0,
-                "size": 32000
-            }
-        ],
         "args": [
             "sh"
         ],
@@ -461,6 +447,20 @@ Here is a full example `config.json` for reference.
                 "fileMode": 432,
                 "uid": 0,
                 "gid": 0
+            }
+        ],
+        "uidMappings": [
+            {
+                "hostID": 1000,
+                "containerID": 0,
+                "size": 32000
+            }
+        ],
+        "gidMappings": [
+            {
+                "hostID": 1000,
+                "containerID": 0,
+                "size": 32000
             }
         ],
         "sysctl": {


### PR DESCRIPTION
To match [where they're defined in the JSON Schema][1].  The old
location is from d4e7326d (config: JSON examples, 2016-04-06, #370),
and seems to have been accidental.

[1]: https://github.com/opencontainers/runtime-spec/blob/0982071b288ddddc1ae84d21c4bd682c96942f5c/schema/schema-linux.json#L21-L48