### PR TITLE
Run post-stop hooks before the container sandbox is deleted.

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -46,8 +46,9 @@ The lifecycle describes the timeline of events that happen from when a container
    If any poststart hook fails, then the container MUST be stopped and the lifecycle continues at step 8.
 6. Additional actions such as pausing the container, resuming the container or signaling the container MAY be performed using the runtime interface.
    The container MAY also error out, exit or crash.
-7. The container MUST be destroyed by undoing the steps performed during create phase (step 2).
-8. The poststop hooks MUST be invoked by the runtime and errors, if any, MAY be logged.
+7. The poststop hooks MUST be invoked by the runtime and errors, if any, MAY be logged.
+8. The container MUST be destroyed by undoing the steps performed during create phase (step 2).
+
 
 Note: The lifecycle is a WIP and it will evolve as we have more use cases and more information on the viability of a separate create phase.
 


### PR DESCRIPTION
One of the main use cases of post-stop is to scrape filesystem contents with a container's mount namespace, before deleting the container.
Running post-stop after the container is deleted is equivalent to deleting the container and running the post-stop hook outside of the spec context.

cc @mrunalp @crosbymichael @philips 
