### PR TITLE
Fix remnants from SelinuxProcessLabel to SelinuxLabel rename

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -132,8 +132,8 @@
                     "id": "https://opencontainers.org/schema/bundle/process/linux/apparmorProfile",
                     "type": "string"
                 },
-                "selinuxProcessLabel": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/selinuxProcessLabel",
+                "selinuxLabel": {
+                    "id": "https://opencontainers.org/schema/bundle/process/linux/selinuxLabel",
                     "type": "string"
                 },
                 "noNewPrivileges": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -49,7 +49,7 @@ type Process struct {
 
 	// ApparmorProfile specified the apparmor profile for the container. (this field is platform dependent)
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
-	// SelinuxProcessLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
+	// SelinuxLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 


### PR DESCRIPTION
These were missed when we moved the field to Process struct.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>