### PR TITLE
*: add support for cgroup namespace

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -27,12 +27,13 @@ Namespaces are specified as an array of entries inside the `namespaces` root fie
 The following parameters can be specified to setup namespaces:
 
 * **`type`** *(string, required)* - namespace type. The following namespaces types are supported:
-    * **`pid`** processes inside the container will only be able to see other processes inside the same container
-    * **`network`** the container will have its own network stack
-    * **`mount`** the container will have an isolated mount table
-    * **`ipc`** processes inside the container will only be able to communicate to other processes inside the same container via system level IPC
-    * **`uts`** the container will be able to have its own hostname and domain name
-    * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container
+    * **`pid`** processes inside the container will only be able to see other processes inside the same container.
+    * **`network`** the container will have its own network stack.
+    * **`mount`** the container will have an isolated mount table.
+    * **`ipc`** processes inside the container will only be able to communicate to other processes inside the same container via system level IPC.
+    * **`uts`** the container will be able to have its own hostname and domain name.
+    * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container.
+    * **`cgroup`** the container will have an isolated view of the cgroup hierarchy.
 
 * **`path`** *(string, optional)* - path to namespace file in the [runtime mount namespace](glossary.md#runtime-namespace)
 
@@ -62,6 +63,9 @@ Also, when a path is specified, a runtime MUST assume that the setup for that pa
         },
         {
             "type": "user"
+        },
+        {
+            "type": "cgroup"
         }
     ]
 ```

--- a/config.md
+++ b/config.md
@@ -643,6 +643,12 @@ Here is a full example `config.json` for reference.
             },
             {
                 "type": "mount"
+            },
+            {
+                "type": "user"
+            },
+            {
+                "type": "cgroup"
             }
         ],
         "maskedPaths": [

--- a/runtime.md
+++ b/runtime.md
@@ -34,6 +34,7 @@ See [Query State](#query-state) for information on retrieving the state of a con
 The lifecycle describes the timeline of events that happen from when a container is created to when it ceases to exist.
 1. OCI compliant runtime's `create` command is invoked with a reference to the location of the bundle and a unique identifier.
 2. The container's runtime environment MUST be created according to the configuration in [`config.json`](config.md).
+   If the runtime is unable to create the environment specified in the [`config.json`](config.md), it MUST generate an error.
    While the resources requested in the [`config.json`](config.md) MUST be created, the user-specified code (from [`process`](config.md#process-configuration) MUST NOT be run at this time.
    Any updates to `config.json` after this step MUST NOT affect the container.
 3. Once the container is created additional actions MAY be performed based on the features the runtime chooses to support.

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -224,7 +224,8 @@
                 "network",
                 "uts",
                 "ipc",
-                "user"
+                "user",
+                "cgroup"
             ]
         },
         "NamespaceReference": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -169,6 +169,8 @@ const (
 	UTSNamespace = "uts"
 	// UserNamespace for isolating user and group IDs
 	UserNamespace = "user"
+	// CgroupNamespace for isolating cgroup hierarchies
+	CgroupNamespace = "cgroup"
 )
 
 // IDMapping specifies UID/GID mappings


### PR DESCRIPTION
The cgroup namespace is a new kernel feature available in 4.6+ that
allows a container to isolate its cgroup hierarchy. This currently only
allows you to hide information from /proc/self/cgroup. But I'm currently
working with upstream on expanding it so that you can modify your
hierarchy inside a user namespace (even a rootless container).

Signed-off-by: Aleksa Sarai <asarai@suse.de>