### PR TITLE
runtime: Require 'start' to validate the bundle

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -74,6 +74,7 @@ In particular, the state MUST be serialized as JSON.
 
 This operation MUST generate an error if it is not provided a path to the bundle and the container ID to associate with the container.
 If the ID provided is not unique across all containers within the scope of the runtime, or is not valid in any other way, the implementation MUST generate an error.
+If the bundle does not comply with [this specification](bundle.md), the implementation MUST generate an error.
 Using the data in `config.json`, that are in the bundle's directory, this operation MUST create a new container.
 This includes creating the relevant namespaces, resource limits, etc and configuring the appropriate capabilities for the container.
 A new process within the scope of the container MUST be created as specified by the `config.json` file otherwise an error MUST be generated.


### PR DESCRIPTION
This spec places RFC-2119 requirements on both bundles (bundle.md,
config.md, ...)  and runtimes (runtime.md, runtime-linux.md).  While
it's possible to envision a system where bundle validation is
decoupled and the runtime is free to blindly stumble through as far as
it can, it's likely that users will expect the runtime to perform
basic bundle validatation for them.  With the requirement landing in
this commit, the runtime MUST at least validate bundles against this
spec.  The runtime MAY also validate the bundle against the host
system's capabilities, but is not required to do so.

With this change, all RFC-2119 requirements are things the runtime is
responsible for.

I'm personally ok with the decoupled-bundle-validation approach (and
we [already link to ocitools and OCT for testing both runtimes and
bundles][1]), but figured that will be an outlier position.  If we do
want to go that way (and leave runtime activity in the face of an
invalid bundle undefined), we probably want to explicitly call that
out in the ‘start’ docs to avoid surprising people.

[1]: https://github.com/opencontainers/runtime-spec/blob/v0.5.0/implementations.md#testing--tools