### PR TITLE
version: include version in produced docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 output
 schema/validate
 code-of-conduct.md
+version.md

--- a/.tool/version-doc.go
+++ b/.tool/version-doc.go
@@ -1,0 +1,25 @@
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"os"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+var markdownTemplateString = `
+
+**Specification Version:** *{{.}}*
+
+`
+
+var markdownTemplate = template.Must(template.New("markdown").Parse(markdownTemplateString))
+
+func main() {
+	if err := markdownTemplate.Execute(os.Stdout, specs.Version); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 DOCKER ?= $(shell which docker)
 # These docs are in an order that determines how they show up in the PDF/HTML docs.
 DOC_FILES := \
+	version.md \
 	README.md \
 	code-of-conduct.md \
 	principles.md \
@@ -44,6 +45,9 @@ output/docs.html: $(DOC_FILES)
 
 code-of-conduct.md:
 	curl -o $@ https://raw.githubusercontent.com/opencontainers/tob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md
+
+version.md: ./specs-go/version.go
+	go run ./.tool/version-doc.go > $@
 
 HOST_GOLANG_VERSION	= $(shell go version | cut -d ' ' -f3 | cut -c 3-)
 # this variable is used like a function. First arg is the minimum version, Second arg is the version to be checked.


### PR DESCRIPTION
Fixes #398

This produces a markdown page as a header for the PDF and HTML pages.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>