### PR TITLE
specs-go/config: Make Spec.Mounts omitempty

### DIFF
--- a/config.md
+++ b/config.md
@@ -39,7 +39,7 @@ Each container has exactly one *root filesystem*, specified in the *root* object
 
 ## Mounts
 
-You can add array of mount points inside container as `mounts`.
+You MAY add array of mount points inside container as `mounts`.
 The runtime MUST mount entries in the listed order.
 The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
 

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -17,7 +17,7 @@ type Spec struct {
 	// Hostname is the container's host name.
 	Hostname string `json:"hostname,omitempty"`
 	// Mounts profile configuration for adding mounts to the container's filesystem.
-	Mounts []Mount `json:"mounts"`
+	Mounts []Mount `json:"mounts,omitempty"`
 	// Hooks are the commands run at various lifecycle events of the container.
 	Hooks Hooks `json:"hooks"`
 	// Annotations is an unstructured key value map that may be set by external tools to store and retrieve arbitrary metadata.


### PR DESCRIPTION
And use “MAY” (RFC 2119) instead of “can” in the Markdown docs.

Otherwise:

    $ ocitools generate --mount-cgroups=no --template <(echo {})
    $ grep mounts config.json
            "mounts": null,