### PR TITLE
[ Configuration | Version ] Capitalize MUST in ociVersion description

### DIFF
--- a/config.md
+++ b/config.md
@@ -10,7 +10,7 @@ Below is a detailed description of each field defined in the configuration forma
 
 ## Specification version
 
-* **`ociVersion`** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OpenContainer specification with which the bundle complies.
+* **`ociVersion`** (string, required) MUST be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OpenContainer specification with which the bundle complies.
 The OpenContainer spec follows semantic versioning and retains forward and backward compatibility within major versions.
 For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
 NOTE that there is no guarantee for forward or backward compatibility for version 0.x.


### PR DESCRIPTION
"ociVersion ... must be in SemVer ... format" --> "ociVersion ... MUST be in SemVer ... format"

Signed-off-by: Rob Dolin <RobDolin@microsoft.com>