### PR TITLE
config: Explicitly put hooks in the runtime namespace

### DIFF
--- a/config.md
+++ b/config.md
@@ -195,7 +195,7 @@ Hooks allow one to run code before/after various lifecycle events of the contain
 Hooks MUST be called in the listed order.
 The state of the container is passed to the hooks over stdin, so the hooks could get the information they need to do their work.
 
-Hook paths are absolute and are executed from the host's filesystem.
+Hook paths are absolute and are executed from the host's filesystem in the [runtime namespace][runtime-namespace].
 
 ### Prestart
 
@@ -615,5 +615,5 @@ Here is a full example `config.json` for reference.
 }
 ```
 
-
+[runtime-namespace]: glossary.md#runtime-namespace
 [uts-namespace]: http://man7.org/linux/man-pages/man7/namespaces.7.html


### PR DESCRIPTION
The language from 15dee2e0 (runtime: Add prestart/poststop hooks,
2015-08-03, #34) landed well before we had glossary entries for the
runtime and container namespaces (from 5dad1255, config-linux: Specify
host mount namespace for namespace paths, 2015-12-18, #275).  Now that
we do have language to cover that concept, it's better to explicitly
say that hooks run in the runtime namespace instead of leaving it to
the reader to extrapolate from the filesystem requirement.

With the new namespace wording, the "host's filesystem" wording is
somewhat redundant.  I've left it in though, because I think it helps
to have a more gradual transition from hook paths to namespaces.

The most recent instance of reader uncertainty is [here][1].

[1]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2016-04-30.log.html#t2016-04-30T01:46:27