### PR TITLE
State the default user a container process runs

### DIFF
--- a/config.md
+++ b/config.md
@@ -154,6 +154,7 @@ _Note: symbolic name for uid and gid, such as uname and gname respectively, are 
 }
 ```
 
+If left empty, the user id and group id both defaults to 0 (root), and no additional group IDs are added.
 
 ## Hostname
 


### PR DESCRIPTION
This patch adds information about the default user/group a process runs on Linux. 

Signed-off-by: Amit Saha <amitsaha.in@gmail.com>