### PR TITLE
Adding link in README.md to Solaris configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Table of Contents
 - Configuration
   - [General Configuration](config.md)
   - [Linux-specific Configuration](config-linux.md)
+  - [Solaris-specific Configuration](config-solaris.md)
 - [Glossary](glossary.md)
 
 In the specifications in the above table of contents, the keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119) (Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997).


### PR DESCRIPTION
This PR just adds a link to Solaris configuration in the README.md missed by initial PR,
"Introducing Solaris in OCI" , #411  

Signed-off-by: Abhijeeth Nuthan <abhijeeth.nuthan@oracle.com>