### PR TITLE
UID and GID for the main process are not optional

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -59,9 +59,9 @@ type Process struct {
 // main process.
 type User struct {
 	// UID is the user id. (this field is platform dependent)
-	UID uint32 `json:"uid,omitempty" platform:"linux"`
+	UID uint32 `json:"uid" platform:"linux"`
 	// GID is the group id. (this field is platform dependent)
-	GID uint32 `json:"gid,omitempty" platform:"linux"`
+	GID uint32 `json:"gid" platform:"linux"`
 	// AdditionalGids are additional group ids set for the container's process. (this field is platform dependent)
 	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux"`
 }


### PR DESCRIPTION
The spec requires UID and GID to be specified, so we shouldn't ignore if they are not specified.

Signed-off-by: Amit Saha <amitsaha.in@gmail.com>