### PR TITLE
config: Use spaces (not tabs) to indent JSON

### DIFF
--- a/config.md
+++ b/config.md
@@ -304,8 +304,8 @@ Annotations are key-value maps.
 
 ```json
 "annotations": {
-	"key1" : "value1",
-	"key2" : "value2"
+    "key1" : "value1",
+    "key2" : "value2"
 }
 ```
 


### PR DESCRIPTION
Change made with:

    $ sed -i 's/\t/    /g' config.md

fixing tabs that were added with 1c49f4d2 (Add annotations and labels
to the Spec, 2016-03-04, #331).