### PR TITLE
specs-go/config.go: Make Process.Terminal omitempty

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -32,7 +32,7 @@ type Spec struct {
 // Process contains information to start a specific application inside the container.
 type Process struct {
 	// Terminal creates an interactive terminal for the container.
-	Terminal bool `json:"terminal"`
+	Terminal bool `json:"terminal,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.


### PR DESCRIPTION
It's an optional setting, and this change will fix the wordy:

    $ ocitools generate --template <(echo '{}')
    $ grep terminal config.json
        "terminal": false,

Instead, `config.json` will not contain a `terminal` entry at all.