### PR TITLE
specs-go/config.go: Make Root.Readonly omitempty

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -71,7 +71,7 @@ type Root struct {
 	// Path is the absolute path to the container's root filesystem.
 	Path string `json:"path"`
 	// Readonly makes the root filesystem for the container readonly before the process is executed.
-	Readonly bool `json:"readonly"`
+	Readonly bool `json:"readonly,omitempty"`
 }
 
 // Platform specifies OS and arch information for the host system that the container


### PR DESCRIPTION
It's an optional setting, and this change will fix the wordy:

    $ ocitools generate --template <(echo '{}')
    $ grep readonly config.json
        "readonly": false,

Instead, `config.json` will not contain a `readonly` entry at all.