### PR TITLE
specs-go/config: Make Linux and Solaris omitempty

### DIFF
--- a/config.md
+++ b/config.md
@@ -207,6 +207,8 @@ _Note: For Solaris, uid and gid specify the uid and gid of the process inside th
 
 * **`linux`** (object, optional) [Linux-specific configuration](config-linux.md).
   This should only be set if **`platform.os`** is `linux`.
+* **`solaris`** (object, optional) [Solaris-specific configuration](config-solaris.md).
+  This should only be set if **`platform.os`** is `solaris`.
 
 ### Example (Linux)
 

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -24,9 +24,9 @@ type Spec struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Linux is platform specific configuration for Linux based containers.
-	Linux Linux `json:"linux" platform:"linux"`
+	Linux Linux `json:"linux" platform:"linux,omitempty"`
 	// Solaris is platform specific configuration for Solaris containers.
-	Solaris Solaris `json:"solaris" platform:"solaris"`
+	Solaris Solaris `json:"solaris" platform:"solaris,omitempty"`
 }
 
 // Process contains information to start a specific application inside the container.


### PR DESCRIPTION
Also document `solaris` in the platform-specific configuration
section.  Details in the commit messages.