### PR TITLE
[Config] Mount destinations MUST NOT be nested in Windows

### DIFF
--- a/config.md
+++ b/config.md
@@ -44,7 +44,7 @@ The runtime MUST mount entries in the listed order.
 The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
 
 * **`destination`** (string, required) Destination of mount point: path inside container.
-One mount destination MUST NOT be nested within another mount (ex: /foo and /foo/bar or c:\\foo and c:\\foo\\bar).
+For the Windows operating system, one mount destination MUST NOT be nested within another mount (ex: c:\\foo and c:\\foo\\bar).
 * **`type`** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
 * **`source`** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
 * **`options`** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).

--- a/config.md
+++ b/config.md
@@ -44,6 +44,7 @@ The runtime MUST mount entries in the listed order.
 The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
 
 * **`destination`** (string, required) Destination of mount point: path inside container.
+One mount destination MUST NOT be nested within another mount (ex: /foo and /foo/bar or c:\\foo and c:\\foo\\bar).
 * **`type`** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
 * **`source`** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
 * **`options`** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).


### PR DESCRIPTION
This was raised during reviews with folks working on Windows Containers.  I suspect the prohibition against nested mount destinations applies across all operating systems, but if not please feel free to edit.

Signed-off-by: Rob Dolin <RobDolin@microsoft.com>