### PR TITLE
ROADMAP: Remove stale targets (landed PRs, image-spec, ocitools, etc.)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,26 +10,6 @@ Listed topics may defer to the [project wiki](https://github.com/opencontainers/
 
 ## 1.0
 
-### Digest and Hashing
-
-A bundle is designed to be moved between hosts.
-Although OCI doesn't define a transport method we should have a cryptographic digest of the on-disk bundle that can be used to verify that a bundle is not corrupted and in an expected configuration.
-
-*Owner:* philips
-
-### Define Container Lifecycle
-
-Containers have a lifecycle and being able to identify and document the lifecycle of a container is very helpful for implementations of the spec.
-The lifecycle events of a container also help identify areas to implement hooks that are portable across various implementations and platforms.
-
-*Owner:* mrunalp
-
-### Define Standard Container Actions (Target release: v0.3.0)
-
-Define what type of actions a runtime can perform on a container without imposing hardships on authors of platforms that do not support advanced options.
-
-*Owner:* duglin
-
 ### Container Definition
 
 Define what a software container is and its attributes in a cross platform way.
@@ -46,33 +26,11 @@ Proposal: make it an optional feature
 
 *Owner:* hqhq (was vishh) robdolinms, bcorrie
 
-### Validation Tooling (Target release: v0.3.0)
-
-Provide validation tooling for compliance with OCI spec and runtime environment.
-
-*Owner:* mrunalp
-
-### Testing Framework
-
-Provide a testing framework for compliance with OCI spec and runtime environment.
-
-*Owner:* liangchenye
-
 ### Version Schema
 
 Decide on a robust versioning schema for the spec as it evolves.
 
 Resolved but release process could evolve. Resolved for v0.2.0, expect to revisit near v1.0.0
-
-*Owner:* vbatts
-
-### Printable/Compiled Spec
-
-Regardless of how the spec is written, ensure that it is easy to read and follow for first time users.
-
-Part of this is resolved.  Produces an html & pdf.
-Done
-Would be nice to publish to the OCI web site as part of our release process.
 
 *Owner:* vbatts
 
@@ -95,9 +53,3 @@ Ensure that we have lifecycle hooks in the correct places with full coverage ove
 Will probably go away with Vish's work on splitting create and start, and if we have exec.
 
 *Owner:*
-
-### Distributable Format
-
-A common format for serializing and distributing bundles.
-
-*Owner:* vbatts


### PR DESCRIPTION
This PR cherry-picks the first two from #423 and adds additional
target-removal commits with the reasoning I posted [to the list][1].
I'm happy to pull out any contentious and/or obvious commits into
separate PRs if that makes reviewing and landing this easier.

[1]: https://groups.google.com/a/opencontainers.org/forum/#!original/dev/pghr1WFU5KI/NDFTvMDiFAAJ