### PR TITLE
config.md: Remove 'solaris' from full example

### DIFF
--- a/config.md
+++ b/config.md
@@ -654,29 +654,6 @@ Here is a full example `config.json` for reference.
         ],
         "mountLabel": "system_u:object_r:svirt_sandbox_file_t:s0:c715,c811"
     },
-    "solaris": {
-        "anet": [
-            {
-                "allowedAddress": "172.17.0.2/16",
-                "configureAllowedAddress": "true",
-                "defrouter": "172.17.0.1/16",
-                "linkProtection": "mac-nospoof, ip-nospoof",
-                "linkname": "net0",
-                "lowerLink": "net2",
-                "macAddress": "02:42:f8:52:c7:16"
-            }
-        ],
-        "cappedCPU": {
-            "ncpus": "0.8"
-        },
-        "cappedMemory": {
-            "physical": "1G",
-            "swap": "512m"
-        },
-        "maxShmMemory": "256m",
-        "limitpriv": "default",
-        "milestone": "svc:/milestone/container:default"
-    },
     "annotations": {
         "key1": "value1",
         "key2": "value2"


### PR DESCRIPTION
This should have been part of 759ee79c (config: Add platform-specific entry for 'solaris', 2016-05-06, #431), since the example has `platform.os` set to `linux`.

There was some (brief) [discussion][1] of this point before the `solaris` section landed, but the “should only be set if” wording landed in parallel via b373a15 (config: Split platform-specific configuration into its own section, 2016-05-02, #414), and I'd forgotten to go back and apply that logic to #411.

Having a full Solaris example would be useful, but I think it should be a separate, Solaris-only example.

[1]: https://github.com/opencontainers/runtime-spec/pull/411#discussion_r61621001