### PR TITLE
config: Clarify MUST for platform.os and .arch

### DIFF
--- a/config.md
+++ b/config.md
@@ -190,8 +190,14 @@ _Note: For Solaris, uid and gid specify the uid and gid of the process inside th
 
 ## Platform
 
-* **`os`** (string, required) specifies the operating system family this image MUST run on. Values for os MUST be in the list specified by the Go Language document for [`$GOOS`](https://golang.org/doc/install/source#environment).
-* **`arch`** (string, required) specifies the instruction set for which the binaries in the image have been compiled. Values for arch MUST be in the list specified by the Go Language document for [`$GOARCH`](https://golang.org/doc/install/source#environment).
+* **`os`** (string, required) specifies the operating system family this image targets.
+  The runtime MUST generate an error if it does not support the configured **`os`**.
+  Bundles SHOULD use, and runtimes SHOULD understand, **`os`** entries listed in the Go Language document for [`$GOOS`][go-environment].
+  If an operating system is not included in the `$GOOS` documentation, it SHOULD be submitted to this specification for standardization.
+* **`arch`** (string, required) specifies the instruction set for which the binaries in the image have been compiled.
+  The runtime MUST generate an error if it does not support the configured **`arch`**.
+  Values for **`arch`** SHOULD use, and runtimes SHOULD understand, **`arch`** entries listed in the Go Language document for [`$GOARCH`][go-environment].
+  If an architecture is not included in the `$GOARCH` documentation, it SHOULD be submitted to this specification for standardization.
 
 ### Example
 
@@ -664,3 +670,4 @@ Here is a full example `config.json` for reference.
 
 [runtime-namespace]: glossary.md#runtime-namespace
 [uts-namespace]: http://man7.org/linux/man-pages/man7/namespaces.7.html
+[go-environment]: https://golang.org/doc/install/source#environment


### PR DESCRIPTION
The old platform.os text had two MUST conditions.  The first could
have been read "the runtime MUST generate an error if invoked with a
config.json whose platform.os is incompatible with the host platform"
(which is the direction I'm going with this commit).  However, it
could also have been read "the bundle-validator MUST generate an error
if platform.os is incompatible with the content the bundle's other
content (e.g. 'linux' in platform.os, but only Windows binaries in the
bundle's rootfs).

For the second MUST, I doubt we want to require a compliant runtime
support all Go architectures itself.  And there is a benefit to
pointing runtime/bundle authors at the Go set, but not much benefit in
making that a hard limit (see opencontainers/image-spec#29 and
opencontainers/image-spec#60).  The rewording here follows
opencontainers/image-spec#60 in acknowledging that
process.arch-matching is something that the config author and runtime
caller have to sort out between themselves and pointing them at the Go
docs and a registration process to avoid fragmenting the community.

Spun off from a #403 [comment][1].

[1]: https://github.com/opencontainers/runtime-spec/pull/403/files#r61211144