### PR TITLE
Remove one JSON related MUST requirement

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -65,8 +65,6 @@ Unless otherwise stated, generating an error MUST leave the state of the environ
 
 This operation MUST generate an error if it is not provided the ID of a container.
 This operation MUST return the state of a container as specified in the [State](#state) section.
-In particular, the state MUST be serialized as JSON.
-
 
 ### Start
 


### PR DESCRIPTION
JSON is not a mandatory format, we should not use MUST
requirement on this.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>