### PR TITLE
Add dev symbolic links in runtime_linux.md

### DIFF
--- a/runtime-linux.md
+++ b/runtime-linux.md
@@ -1,8 +1,7 @@
 # Linux Runtime
 
 ## File descriptors
+
 By default, only the `stdin`, `stdout` and `stderr` file descriptors are kept open for the application by the runtime.
-
-The runtime may pass additional file descriptors to the application to support features such as [socket activation](http://0pointer.de/blog/projects/socket-activated-containers.html).
-
-Some of the file descriptors may be redirected to `/dev/null` even though they are open.
+The runtime MAY pass additional file descriptors to the application to support features such as [socket activation](http://0pointer.de/blog/projects/socket-activated-containers.html).
+Some of the file descriptors MAY be redirected to `/dev/null` even though they are open.

--- a/runtime-linux.md
+++ b/runtime-linux.md
@@ -5,3 +5,14 @@
 By default, only the `stdin`, `stdout` and `stderr` file descriptors are kept open for the application by the runtime.
 The runtime MAY pass additional file descriptors to the application to support features such as [socket activation](http://0pointer.de/blog/projects/socket-activated-containers.html).
 Some of the file descriptors MAY be redirected to `/dev/null` even though they are open.
+
+## Dev symbolic links
+
+After the container has `/proc` mounted, the following standard symlinks MUST be setup within `/dev/` for the io.
+
+|    Source       | Destination |
+| --------------- | ----------- |
+| /proc/self/fd   | /dev/fd     |
+| /proc/self/fd/0 | /dev/stdin  |
+| /proc/self/fd/1 | /dev/stdout |
+| /proc/self/fd/2 | /dev/stderr |


### PR DESCRIPTION
Some fixes in runtime_linux.md, and added dev symbolic links.

It's adapted from:
https://github.com/opencontainers/runc/blob/master/libcontainer/SPEC.md

Addresses: opencontainers/runc#760

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>