### PR TITLE
specs-go/config: Drop platform-independent comment

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -2,9 +2,7 @@ package specs
 
 import "os"
 
-// Spec is the base configuration for the container.  It specifies platform
-// independent configuration. This information must be included when the
-// bundle is packaged for distribution.
+// Spec is the base configuration for the container.
 type Spec struct {
 	// Version is the version of the specification that is supported.
 	Version string `json:"ociVersion"`


### PR DESCRIPTION
This has been stale since cb2da543 (config: Single, unified config file, 2015-12-28, #284), when we dropped the attempt to distinguish between platform-independent and platform-dependent configuration.

This PR nibbles another commit off from #423 (which worked fairly well for #435).