### PR TITLE
schema: Replace "bundle" with "runtime configuration"

### DIFF
--- a/schema/schema-linux.json
+++ b/schema/schema-linux.json
@@ -1,11 +1,11 @@
 {
     "linux": {
         "description": "Linux platform-specific configurations",
-        "id": "https://opencontainers.org/schema/bundle/linux",
+        "id": "https://opencontainers.org/schema/runtime/config/linux",
         "type": "object",
         "properties": {
             "devices": {
-                "id": "https://opencontainers.org/schema/bundle/linux/devices",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/devices",
                 "oneOf": [
                     {
                         "type": "array",
@@ -19,7 +19,7 @@
                 ]
             },
             "uidMappings": {
-                "id": "https://opencontainers.org/schema/bundle/linux/uidMappings",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/uidMappings",
                 "oneOf": [
                     {
                         "type": "array",
@@ -33,7 +33,7 @@
                 ]
             },
             "gidMappings": {
-                "id": "https://opencontainers.org/schema/bundle/linux/gidMappings",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/gidMappings",
                 "oneOf": [
                     {
                         "type": "array",
@@ -47,7 +47,7 @@
                 ]
             },
             "namespaces": {
-                "id": "https://opencontainers.org/schema/bundle/linux/namespaces",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/namespaces",
                 "type": "array",
                 "items": {
                     "anyOf": [
@@ -58,38 +58,38 @@
                 }
             },
             "resources": {
-                "id": "https://opencontainers.org/schema/bundle/linux/resources",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/resources",
                 "type": "object",
                 "properties": {
                     "oomScoreAdj": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/oomScoreAdj",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/resources/oomScoreAdj",
                         "type": "integer",
                         "minimum": -1000,
                         "maximum": 1000
                     },
                     "pids": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/pids",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/resources/pids",
                         "properties": {
                             "limit": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/pids/limit",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/pids/limit",
                                 "$ref": "defs.json#/definitions/int64"
                             }
                         }
                     },
                     "blockIO": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/resources/blockIO",
                         "type": "object",
                         "properties": {
                             "blkioWeight": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioWeight",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/blockIO/blkioWeight",
                                 "$ref": "defs-linux.json#/definitions/blkioWeightPointer"
                             },
                             "blkioLeafWeight": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioLeafWeight",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/blockIO/blkioLeafWeight",
                                 "$ref": "defs-linux.json#/definitions/blkioWeightPointer"
                             },
                             "blkioThrottleReadBpsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleReadBpsDevice",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/blockIO/blkioThrottleReadBpsDevice",
                                 "oneOf": [
                                     {
                                         "type": "array",
@@ -105,7 +105,7 @@
                                 ]
                             },
                             "blkioThrottleWriteBpsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleWriteBpsDevice",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/blockIO/blkioThrottleWriteBpsDevice",
                                 "oneOf": [
                                     {
                                         "type": "array",
@@ -119,7 +119,7 @@
                                 ]
                             },
                             "blkioThrottleReadIopsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleReadIopsDevice",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/blockIO/blkioThrottleReadIopsDevice",
                                 "oneOf": [
                                     {
                                         "type": "array",
@@ -133,7 +133,7 @@
                                 ]
                             },
                             "blkioThrottleWriteIopsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleWriteIopsDevice",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/blockIO/blkioThrottleWriteIopsDevice",
                                 "oneOf": [
                                     {
                                         "type": "array",
@@ -147,7 +147,7 @@
                                 ]
                             },
                             "blkioWeightDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioWeightDevice",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/blockIO/blkioWeightDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceWeightPointer"
@@ -156,45 +156,45 @@
                         }
                     },
                     "cpu": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/resources/cpu",
                         "properties": {
                             "cpus": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/cpus",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/cpu/cpus",
                                 "$ref": "defs.json#/definitions/stringPointer"
                             },
                             "mems": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/mems",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/cpu/mems",
                                 "$ref": "defs.json#/definitions/stringPointer"
                             },
                             "period": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/period",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/cpu/period",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "quota": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/quota",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/cpu/quota",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "realtimePeriod": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimePeriod",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/cpu/realtimePeriod",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "realtimeRuntime": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimeRuntime",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/cpu/realtimeRuntime",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "shares": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/shares",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/cpu/shares",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             }
                         },
                         "type": "object"
                     },
                     "disableOOMKiller": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/disableOOMKiller",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/resources/disableOOMKiller",
                         "type": "boolean"
                     },
                     "hugepageLimits": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/hugepageLimits",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/resources/hugepageLimits",
                         "oneOf": [
                             {
                                 "type": "array",
@@ -216,41 +216,41 @@
                         ]
                     },
                     "memory": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/memory",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/resources/memory",
                         "type": "object",
                         "properties": {
                             "kernel": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/kernel",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/memory/kernel",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "limit": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/limit",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/memory/limit",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "reservation": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/reservation",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/memory/reservation",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "swap": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swap",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/memory/swap",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "swappiness": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swappiness",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/memory/swappiness",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             }
                         }
                     },
                     "network": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/network",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/resources/network",
                         "type": "object",
                         "properties": {
                             "classID": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/network/classId",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/network/classId",
                                 "$ref": "defs.json#/definitions/uint32"
                             },
                             "priorities": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/network/priorities",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/resources/network/priorities",
                                 "oneOf": [
                                     {
                                         "type": "array",
@@ -278,18 +278,18 @@
                 ]
             },
             "rootfsPropagation": {
-                "id": "https://opencontainers.org/schema/bundle/linux/rootfsPropagation",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/rootfsPropagation",
                 "type": "string"
             },
             "seccomp": {
-                "id": "https://opencontainers.org/schema/bundle/linux/seccomp",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/seccomp",
                 "properties": {
                     "defaultAction": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/seccomp/defaultAction",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/seccomp/defaultAction",
                         "type": "string"
                     },
                     "architectures": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/seccomp/architectures",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/seccomp/architectures",
                         "oneOf": [
                             {
                                 "type": "array",
@@ -303,7 +303,7 @@
                         ]
                     },
                     "syscalls": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/seccomp/syscalls",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/seccomp/syscalls",
                         "type": "array",
                         "items": {
                             "$ref": "defs-linux.json#/definitions/Syscall"
@@ -313,7 +313,7 @@
                 "type": "object"
             },
             "sysctl": {
-                "id": "https://opencontainers.org/schema/bundle/linux/sysctl",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/sysctl",
                 "oneOf": [
                     {
                         "$ref": "defs.json#/definitions/mapStringString"
@@ -324,15 +324,15 @@
                 ]
             },
             "maskedPaths": {
-                "id": "https://opencontainers.org/schema/bundle/linux/maskedPaths",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/maskedPaths",
                 "$ref": "defs.json#/definitions/ArrayOfStrings"
             },
             "readonlyPaths": {
-                "id": "https://opencontainers.org/schema/bundle/linux/readonlyPaths",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/readonlyPaths",
                 "$ref": "defs.json#/definitions/ArrayOfStrings"
             },
             "mountLabel": {
-                "id": "https://opencontainers.org/schema/bundle/linux/mountLabel",
+                "id": "https://opencontainers.org/schema/runtime/config/linux/mountLabel",
                 "type": "string"
             }
         }

--- a/schema/schema-solaris.json
+++ b/schema/schema-solaris.json
@@ -1,31 +1,31 @@
 {
     "solaris": {
         "description": "Solaris platform-specific configurations",
-        "id": "https://opencontainers.org/schema/bundle/solaris",
+        "id": "https://opencontainers.org/schema/runtime/config/solaris",
         "type": "object",
         "properties": {
             "milestone": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/milestone",
+                "id": "https://opencontainers.org/schema/runtime/config/solaris/milestone",
                 "type": "string"
             },
             "limitpriv": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/limitpriv",
+                "id": "https://opencontainers.org/schema/runtime/config/solaris/limitpriv",
                 "type": "string"
             },
             "maxShmMemory": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/maxShmMemory",
+                "id": "https://opencontainers.org/schema/runtime/config/solaris/maxShmMemory",
                 "type": "string"
             },
             "cappedCPU": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/cappedCPU",
+                "id": "https://opencontainers.org/schema/runtime/config/solaris/cappedCPU",
                 "$ref": "defs.json#/definitions/mapStringString"
             },
             "cappedMemory": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/cappedMemory",
+                "id": "https://opencontainers.org/schema/runtime/config/solaris/cappedMemory",
                 "$ref": "defs.json#/definitions/mapStringString"
             },
             "anet": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/anet",
+                "id": "https://opencontainers.org/schema/runtime/config/solaris/anet",
                 "type": "array",
                 "items": {
                     "$ref": "defs.json#/definitions/mapStringString"

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,16 +1,16 @@
 {
-    "description": "Schema for OpenContainer bundle configuration file",
+    "description": "Schema for OpenContainer runtime configuration file",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://opencontainers.org/schema/bundle",
+    "id": "https://opencontainers.org/schema/runtime/config",
     "type": "object",
     "properties": {
         "ociVersion": {
             "description": "The version of OpenContainer specification configuration complies with",
-            "id": "https://opencontainers.org/schema/bundle/ociVersion",
+            "id": "https://opencontainers.org/schema/runtime/config/ociVersion",
             "type": "string"
         },
         "hooks": {
-            "id": "https://opencontainers.org/schema/bundle/hooks",
+            "id": "https://opencontainers.org/schema/runtime/config/hooks",
             "type": "object",
             "properties": {
                 "prestart": {
@@ -25,7 +25,7 @@
             }
         },
         "annotations": {
-            "id": "https://opencontainers.org/schema/bundle/annotations",
+            "id": "https://opencontainers.org/schema/runtime/config/annotations",
             "oneOf": [
                 {
                     "$ref": "defs.json#/definitions/mapStringString"
@@ -36,18 +36,18 @@
             ]
         },
         "hostname": {
-            "id": "https://opencontainers.org/schema/bundle/hostname",
+            "id": "https://opencontainers.org/schema/runtime/config/hostname",
             "type": "string"
         },
         "mounts": {
-            "id": "https://opencontainers.org/schema/bundle/mounts",
+            "id": "https://opencontainers.org/schema/runtime/config/mounts",
             "type": "array",
             "items": {
                 "$ref": "defs.json#/definitions/Mount"
             }
         },
         "platform": {
-            "id": "https://opencontainers.org/schema/bundle/platform",
+            "id": "https://opencontainers.org/schema/runtime/config/platform",
             "type": "object",
             "required": [
                 "arch",
@@ -55,32 +55,32 @@
             ],
             "properties": {
                 "arch": {
-                    "id": "https://opencontainers.org/schema/bundle/platform/arch",
+                    "id": "https://opencontainers.org/schema/runtime/config/platform/arch",
                     "type": "string"
                 },
                 "os": {
-                    "id": "https://opencontainers.org/schema/bundle/platform/os",
+                    "id": "https://opencontainers.org/schema/runtime/config/platform/os",
                     "type": "string"
                 }
             }
         },
         "root": {
-            "description": "the root filesystem the container's bundle",
-            "id": "https://opencontainers.org/schema/bundle/root",
+            "description": "the container's root filesystem",
+            "id": "https://opencontainers.org/schema/runtime/config/root",
             "type": "object",
             "properties": {
                 "path": {
-                    "id": "https://opencontainers.org/schema/bundle/root/path",
+                    "id": "https://opencontainers.org/schema/runtime/config/root/path",
                     "$ref": "defs.json#/definitions/FilePath"
                 },
                 "readonly": {
-                    "id": "https://opencontainers.org/schema/bundle/root/readonly",
+                    "id": "https://opencontainers.org/schema/runtime/config/root/readonly",
                     "type": "boolean"
                 }
             }
         },
         "process": {
-            "id": "https://opencontainers.org/schema/bundle/process",
+            "id": "https://opencontainers.org/schema/runtime/config/process",
             "type": "object",
             "required": [
                 "cwd",
@@ -88,75 +88,75 @@
             ],
             "properties": {
                 "args": {
-                    "id": "https://opencontainers.org/schema/bundle/process/args",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/args",
                     "$ref": "defs.json#/definitions/ArrayOfStrings"
                 },
                 "cwd": {
-                    "id": "https://opencontainers.org/schema/bundle/process/cwd",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/cwd",
                     "type": "string"
                 },
                 "env": {
-                    "id": "https://opencontainers.org/schema/bundle/process/env",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/env",
                     "$ref": "defs.json#/definitions/Env"
                 },
                 "terminal": {
-                    "id": "https://opencontainers.org/schema/bundle/process/terminal",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/terminal",
                     "type": "boolean"
                 },
                 "user": {
-                    "id": "https://opencontainers.org/schema/bundle/process/user",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/user",
                     "type": "object",
                     "properties": {
                         "uid": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/uid",
+                            "id": "https://opencontainers.org/schema/runtime/config/process/user/uid",
                             "$ref": "defs.json#/definitions/UID"
                         },
                         "gid": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/gid",
+                            "id": "https://opencontainers.org/schema/runtime/config/process/user/gid",
                             "$ref": "defs.json#/definitions/GID"
                         },
                         "additionalGids": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/additionalGids",
+                            "id": "https://opencontainers.org/schema/runtime/config/process/user/additionalGids",
                             "$ref": "defs.json#/definitions/ArrayOfGIDs"
                         }
                     }
                 },
                 "capabilities": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/linux/capabilities",
                     "type": "array",
                     "items": {
                         "$ref": "defs-linux.json#/definitions/Capability"
                     }
                 },
                 "apparmorProfile": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/apparmorProfile",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/linux/apparmorProfile",
                     "type": "string"
                 },
                 "selinuxLabel": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/selinuxLabel",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/linux/selinuxLabel",
                     "type": "string"
                 },
                 "noNewPrivileges": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/noNewPrivileges",
+                    "id": "https://opencontainers.org/schema/runtime/config/process/linux/noNewPrivileges",
                     "type": "boolean"
                 },
                 "rlimits": {
-                    "id": "https://opencontainers.org/schema/bundle/linux/rlimits",
+                    "id": "https://opencontainers.org/schema/runtime/config/linux/rlimits",
                     "type": "array",
                     "items": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0",
+                        "id": "https://opencontainers.org/schema/runtime/config/linux/rlimits/0",
                         "type": "object",
                         "properties": {
                             "hard": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/hard",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/rlimits/0/hard",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "soft": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/soft",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/rlimits/0/soft",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "type": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/type",
+                                "id": "https://opencontainers.org/schema/runtime/config/linux/rlimits/0/type",
                                 "type": "string",
                                 "pattern": "^RLIMIT_[A-Z]+$"
                             }


### PR DESCRIPTION
The bundle contains `config.json` and other things, but this schema is just for `config.json`.  This is mostly:

    $ sed -i 's|/bundle|/runtime/config|' schema/*.json

for the `id` fields, but I also tweaked `root.description` and `config.json`'s `description`.