### PR TITLE
Add PullApprove checks

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,9 @@
+approve_by_comment: true
+approve_regex: ^LGTM
+reject_regex: ^Rejected
+reset_on_push: true
+reviewers:
+  teams:
+  - runtime-spec-maintainers
+  name: default
+  required: 2


### PR DESCRIPTION
Taking advantage of PullApprove will allow us to enforce the rules of 2 LGTMs from the maintainers before anything is merged.

https://pullapprove.com/opencontainers/runtime-spec/