### PR TITLE
[ Runtime ] Allow for excluding pid from state

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -16,6 +16,7 @@ There is no requirement that it be unique across hosts.
 The ID is provided in the state because hooks will be executed with the state as the payload.
 This allows the hooks to perform cleanup and teardown logic after the runtime destroys its own state.
 * **`pid`**: (int) is the ID of the main process within the container, as seen by the host.
+The pid MAY be excluded or set to a value indicating empty or null if it is not seen by the host.
 * **`bundlePath`**: (string) is the absolute path to the container's bundle directory.
 This is provided so that consumers can find the container's configuration and root filesystem on the host.
 


### PR DESCRIPTION
There may be cases where the pid may not be visible to the host.  
Windows Hyper-V Containers is an example of this.  

The proposed additional clause allows for pid to not be include (or set to an appropriate null/empty value) if this is the case.  

Signed-off-by: Rob Dolin RobDolin@microsoft.com
