### PR TITLE
runtime: Drop create-specific API caveat from lifecycle

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -33,7 +33,6 @@ See [Query State](#query-state) for information on retrieving the state of a con
 ## Lifecycle
 The lifecycle describes the timeline of events that happen from when a container is created to when it ceases to exist.
 1. OCI compliant runtime's `create` command is invoked with a reference to the location of the bundle and a unique identifier.
-   How these references are passed to the runtime is an implementation detail.
 2. The container's runtime environment MUST be created according to the configuration in [`config.json`](config.md).
    While the resources requested in the [`config.json`](config.md) MUST be created, the user-specified code (from [`process`](config.md#process-configuration) MUST NOT be run at this time.
    Any updates to `config.json` after this step MUST NOT affect the container.


### PR DESCRIPTION
This wording is descended from 7117ede7 (Expand on the definition of
our ops, 2015-10-13, #225), but the idea is covered generically by
e53a72b (Clarify the operation is not for command-line api,
2016-05-24, #450), so we no longer need a create-specific note.
Especially in the lifecycle docs, where there's already enough going
on without this low-level detail.