### PR TITLE
runtime: Replace "user-specified process" with "user-specified code" in 'create'

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -35,12 +35,12 @@ The lifecycle describes the timeline of events that happen from when a container
 1. OCI compliant runtime's `create` command is invoked with a reference to the location of the bundle and a unique identifier.
    How these references are passed to the runtime is an implementation detail.
 2. The container's runtime environment MUST be created according to the configuration in [`config.json`](config.md).
-   While the resources requested in the [`config.json`](config.md) MUST be created, the user-specified code (from [`process`](config.md#process-configuration) MUST NOT be run at this time.
+   While the resources requested in the [`config.json`](config.md) MUST be created, the user-specified code (from [`process`][process]) MUST NOT be run at this time.
    Any updates to `config.json` after this step MUST NOT affect the container.
 3. Once the container is created additional actions MAY be performed based on the features the runtime chooses to support.
   However, some actions might only be available based on the current state of the container (e.g. only available while it is started).
 4. Runtime's `start` command is invoked with the unique identifier of the container.
-   The runtime MUST run the user-specified code, as specified by [`process`](config.md#process-configuration).
+   The runtime MUST run the user-specified code, as specified by [`process`][process].
 5. The container's process is stopped.
    This MAY happen due to them erroring out, exiting, crashing or the runtime's `kill` operation being invoked.
 6. Runtime's `delete` command is invoked with the unique identifier of the container.
@@ -72,7 +72,7 @@ This operation MUST return the state of a container as specified in the [State](
 This operation MUST generate an error if it is not provided a path to the bundle and the container ID to associate with the container.
 If the ID provided is not unique across all containers within the scope of the runtime, or is not valid in any other way, the implementation MUST generate an error and a new container MUST not be created.
 Using the data in [`config.json`](config.md), this operation MUST create a new container.
-This means that all of the resources associated with the container MUST be created, however, the user-specified process MUST NOT be run at this time.
+This means that all of the resources associated with the container MUST be created, however, the user-specified code (from [`process`][process]) MUST NOT be run at this time.
 
 The runtime MAY validate `config.json` against this spec, either generically or with respect to the local system capabilities, before creating the container ([step 2](#lifecycle)).
 Runtime callers who are interested in pre-create validation can run [bundle-validation tools](implementations.md#testing--tools) before invoking the create operation.
@@ -85,7 +85,7 @@ Any changes made to the [`config.json`](config.md) file after this operation wil
 This operation MUST generate an error if it is not provided the container ID.
 Attempting to start a container that does not exist MUST generate an error.
 Attempting to start an already started container MUST have no effect on the container and MUST generate an error.
-This operation MUST run the user-specified code as specified by [`process`](config.md#process-configuration).
+This operation MUST run the user-specified code as specified by [`process`][process].
 If the runtime fails to run the code as specified, an error MUST be generated.
 
 ### Kill
@@ -109,3 +109,5 @@ Once a container is deleted its ID MAY be used by a subsequent container.
 ## Hooks
 Many of the operations specified in this specification have "hooks" that allow for additional actions to be taken before or after each operation.
 See [runtime configuration for hooks](./config.md#hooks) for more information.
+
+[process]: config.md#process-configuration


### PR DESCRIPTION
Because we _do_ want to create the process at create-time, we just
want to idle it running runtime-specified code until start-time.  The
language I'm changing to already exists in the lifecycle and start
sections.

Since there were a number of links to the process spec, I replaced the
inline targets with a reference-style target.  And while I was doing
that, I added a missing close-paren to lifecycle step 2.
