### PR TITLE
runtime: Remove start's "fails to run" monitoring

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -86,7 +86,6 @@ This operation MUST generate an error if it is not provided the container ID.
 Attempting to start a container that does not exist MUST generate an error.
 Attempting to start an already started container MUST have no effect on the container and MUST generate an error.
 This operation MUST run the user-specified code as specified by [`process`](config.md#process-configuration).
-If the runtime fails to run the code as specified, an error MUST be generated.
 
 ### Kill
 `kill <container-id> <signal>`


### PR DESCRIPTION
The in-flight runC implementation just [fires][1] [a signal][2] at the
container.  It doesn't wait around to see if the signal has an
effect, or if it causes the container to crash, etc., etc.

[1]: https://github.com/opencontainers/runc/blob/28126f8039e226952d099f7376ba11cd9d00a59f/start.go#L29-L30
[2]: https://github.com/opencontainers/runc/blob/28126f8039e226952d099f7376ba11cd9d00a59f/libcontainer/container_linux.go#L253-L258