### PR TITLE
bundle: Remove rootfs requirement

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -15,10 +15,5 @@ This REQUIRED file MUST reside in the root of the bundle directory and MUST be n
 When the bundle is packaged up for distribution, this file MUST be included.
 See [`config.json`](config.md) for more details.
 
-2. A directory representing the root filesystem of the container.
-While the name of this REQUIRED directory may be arbitrary, users should consider using a conventional name, such as `rootfs`.
-When the bundle is packaged up for distribution, this directory MUST be included.
-This directory MUST be referenced from within the `config.json` file.
-
-While these artifacts MUST all be present in a single directory on the local filesystem, that directory itself is not part of the bundle.
-In other words, a tar archive of a *bundle* will have these artifacts at the root of the archive, not nested within a top-level directory.
+While `config.json` MUST be present in a directory on the local filesystem, that directory itself is not part of the bundle.
+In other words, a tar archive of a *bundle* will have `config.json` at the root of the archive, not nested within a top-level directory.


### PR DESCRIPTION
Recently b2e9154a (Remove requirement for rootfs path to be relative,
2016-04-22, #394) relaxed the relative-path requirement on root.path
to allow absolute paths (see also discussion [here](https://github.com/opencontainers/runtime-spec/issues/389)).  The
motivation being that, while most folks will want a relative-path
pointing into the bundle directory, there are valid [use](https://github.com/opencontainers/runtime-spec/issues/389#issue-149584747)
[cases](https://github.com/opencontainers/runtime-spec/pull/394#issuecomment-213550294) that don't do that, and we want to support them too.

However, allowing absolute paths but requiring them to point to a
directory lying next to config.json seems to defeat the purpose.  This
commit removes the "root.path must point to a directory next to
config.json" restriction, so folks who want absolute paths in
root.path can use them without an unnecessary restriction.

And again, most folks will put their rootfs alongside config.json or
elsewhere inside the bundle directory.  But this list was about "This
MUST include the following artifacts", and we don't want to require
_everyone_ to do that.

This is the narrowly-scoped version of #423 with the minimum we need
to make #394 a useful change.
