### PR TITLE
[ Config ] Simplify language for Windows

### DIFF
--- a/config.md
+++ b/config.md
@@ -46,7 +46,8 @@ The parameters are similar to the ones in [the Linux mount system call](http://m
 * **`destination`** (string, required) Destination of mount point: path inside container.
 For the Windows operating system, one mount destination MUST NOT be nested within another mount.  (Ex: c:\\foo and c:\\foo\\bar).
 * **`type`** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
-* **`source`** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
+* **`source`** (string, required) a device name, but can also be a directory name or a dummy. 
+On Windows, this MUST be a directory name.
 * **`options`** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
 
 ### Example (Linux)


### PR DESCRIPTION
Current language seems confusing:

> Windows, the volume name that is the target of the mount point. \?\Volume{GUID}\ (on Windows source is called target)

This PR proposes a simplification per conversation John Howard:

> On Windows, this MUST be a directory name.

Signed-off-by: Rob Dolin RobDolin@microsoft.com
