### PR TITLE
[Config | Hooks] Add "if supported by the platform"

### DIFF
--- a/config.md
+++ b/config.md
@@ -245,7 +245,7 @@ Presently there are `Prestart`, `Poststart` and `Poststop`.
 * [`Poststop`](#poststop) is a list of hooks to be run after the container process exits
 
 Hooks allow one to run code before/after various lifecycle events of the container.
-Hooks MUST be called in the listed order.
+Hooks MUST be called in the listed order if supported by the platform.
 The state of the container is passed to the hooks over stdin, so the hooks could get the information they need to do their work.
 
 Hook paths are absolute and are executed from the host's filesystem in the [runtime namespace][runtime-namespace].


### PR DESCRIPTION
The spec currently suggests "Hooks MUST be called in the listed order."

If hooks are not supported by the platform, this would be a requirement that could not be met.

This PR adds "if supported by the platform" so that we're not imposing an impossible requirement on platforms that might not (currently) have support for hooks.  

Signed-off-by: Rob Dolin RobDolin@microsoft.com
