### PR TITLE
*: Remove hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,8 @@ To provide context for users the following section gives example use cases for e
 #### Application Bundle Builders
 
 Application bundle builders can create a [bundle](bundle.md) directory that includes all of the files required for launching an application as a container.
-The bundle contains an OCI [configuration file](config.md) where the builder can specify host-independent details such as [which executable to launch](config.md#process-configuration) and host-specific settings such as [mount](config.md#mounts) locations, [hook](config.md#hooks) paths, Linux [namespaces](config-linux.md#namespaces) and [cgroups](config-linux.md#control-groups).
+The bundle contains an OCI [configuration file](config.md) where the builder can specify host-independent details such as [which executable to launch](config.md#process-configuration) and host-specific settings such as [mount](config.md#mounts) locations, Linux [namespaces](config-linux.md#namespaces) and [cgroups](config-linux.md#control-groups).
 Because the configuration includes host-specific settings, application bundle directories copied between two hosts may require configuration adjustments.
-
-#### Hook Developers
-
-[Hook](config.md#hooks) developers can extend the functionality of an OCI-compliant runtime by hooking into a container's lifecycle with an external application.
-Example use cases include sophisticated network configuration, volume garbage collection, etc.
 
 #### Runtime Developers
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,11 +45,3 @@ Systems:
 * Linux
 
 *Owner:* robdolinms as lead coordinator
-
-### Full Lifecycle Hooks
-
-Ensure that we have lifecycle hooks in the correct places with full coverage over the container lifecycle.
-
-Will probably go away with Vish's work on splitting create and start, and if we have exec.
-
-*Owner:*

--- a/config.md
+++ b/config.md
@@ -245,76 +245,6 @@ _Note: For Solaris, uid and gid specify the uid and gid of the process inside th
 }
 ```
 
-## Hooks
-
-Lifecycle hooks allow custom events for different points in a container's runtime.
-Presently there are `Prestart`, `Poststart` and `Poststop`.
-
-* [`Prestart`](#prestart) is a list of hooks to be run before the container process is executed
-* [`Poststart`](#poststart) is a list of hooks to be run immediately after the container process is started
-* [`Poststop`](#poststop) is a list of hooks to be run after the container process exits
-
-Hooks allow one to run code before/after various lifecycle events of the container.
-Hooks MUST be called in the listed order.
-The state of the container is passed to the hooks over stdin, so the hooks could get the information they need to do their work.
-
-Hook paths are absolute and are executed from the host's filesystem in the [runtime namespace][runtime-namespace].
-
-### Prestart
-
-The pre-start hooks are called after the container process is spawned, but before the user supplied command is executed.
-They are called after the container namespaces are created on Linux, so they provide an opportunity to customize the container.
-In Linux, for e.g., the network namespace could be configured in this hook.
-
-If a hook returns a non-zero exit code, then an error including the exit code and the stderr is returned to the caller and the container is torn down.
-
-### Poststart
-
-The post-start hooks are called after the user process is started.
-For example this hook can notify user that real process is spawned.
-
-If a hook returns a non-zero exit code, then an error is logged and the remaining hooks are executed.
-
-### Poststop
-
-The post-stop hooks are called after the container process is stopped.
-Cleanup or debugging could be performed in such a hook.
-If a hook returns a non-zero exit code, then an error is logged and the remaining hooks are executed.
-
-### Example
-
-```json
-    "hooks" : {
-        "prestart": [
-            {
-                "path": "/usr/bin/fix-mounts",
-                "args": ["fix-mounts", "arg1", "arg2"],
-                "env":  [ "key1=value1"]
-            },
-            {
-                "path": "/usr/bin/setup-network"
-            }
-        ],
-        "poststart": [
-            {
-                "path": "/usr/bin/notify-start",
-                "timeout": 5
-            }
-        ],
-        "poststop": [
-            {
-                "path": "/usr/sbin/cleanup.sh",
-                "args": ["cleanup.sh", "-f"]
-            }
-        ]
-    }
-```
-
-`path` is required for a hook.
-`args` and `env` are optional.
-`timeout` is the number of seconds before aborting the hook.
-The semantics are the same as `Path`, `Args` and `Env` in [golang Cmd](https://golang.org/pkg/os/exec/#Cmd).
-
 ## Annotations
 
 This OPTIONAL property contains arbitrary metadata for the container.
@@ -458,39 +388,6 @@ Here is a full example `config.json` for reference.
             ]
         }
     ],
-    "hooks": {
-        "prestart": [
-            {
-                "path": "/usr/bin/fix-mounts",
-                "args": [
-                    "fix-mounts",
-                    "arg1",
-                    "arg2"
-                ],
-                "env": [
-                    "key1=value1"
-                ]
-            },
-            {
-                "path": "/usr/bin/setup-network"
-            }
-        ],
-        "poststart": [
-            {
-                "path": "/usr/bin/notify-start",
-                "timeout": 5
-            }
-        ],
-        "poststop": [
-            {
-                "path": "/usr/sbin/cleanup.sh",
-                "args": [
-                    "cleanup.sh",
-                    "-f"
-                ]
-            }
-        ]
-    },
     "linux": {
         "devices": [
             {

--- a/runtime.md
+++ b/runtime.md
@@ -123,8 +123,3 @@ Attempting to delete a container whose process is still running MUST generate an
 Deleting a container MUST delete the resources that were created during the `create` step.
 Note that resources associated with the container, but not created by this container, MUST NOT be deleted.
 Once a container is deleted its ID MAY be used by a subsequent container.
-
-
-## Hooks
-Many of the operations specified in this specification have "hooks" that allow for additional actions to be taken before or after each operation.
-See [runtime configuration for hooks](./config.md#hooks) for more information.

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -8,21 +8,6 @@
             "id": "https://opencontainers.org/schema/bundle/ociVersion",
             "$ref": "defs.json#/definitions/ociVersion"
         },
-        "hooks": {
-            "id": "https://opencontainers.org/schema/bundle/hooks",
-            "type": "object",
-            "properties": {
-                "prestart": {
-                    "$ref": "defs.json#/definitions/ArrayOfHooks"
-                },
-                "poststart": {
-                    "$ref": "defs.json#/definitions/ArrayOfHooks"
-                },
-                "poststop": {
-                    "$ref": "defs.json#/definitions/ArrayOfHooks"
-                }
-            }
-        },
         "annotations": {
             "$ref": "defs.json#/definitions/annotations"
         },
@@ -168,7 +153,6 @@
         "platform",
         "process",
         "root",
-        "mounts",
-        "hooks"
+        "mounts"
     ]
 }

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -103,25 +103,6 @@
         "Env": {
             "$ref": "#/definitions/ArrayOfStrings"
         },
-        "Hook": {
-            "properties": {
-                "path": {
-                    "$ref": "#/definitions/FilePath"
-                },
-                "args": {
-                    "$ref": "#/definitions/ArrayOfStrings"
-                },
-                "env": {
-                    "$ref": "#/definitions/Env"
-                }
-            }
-        },
-        "ArrayOfHooks": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Hook"
-            }
-        },
         "IDMapping": {
             "properties": {
                 "hostID": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -16,8 +16,6 @@ type Spec struct {
 	Hostname string `json:"hostname,omitempty"`
 	// Mounts profile configuration for adding mounts to the container's filesystem.
 	Mounts []Mount `json:"mounts,omitempty"`
-	// Hooks are the commands run at various lifecycle events of the container.
-	Hooks Hooks `json:"hooks"`
 	// Annotations is an unstructured key value map that may be set by external tools to store and retrieve arbitrary metadata.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
@@ -92,25 +90,6 @@ type Mount struct {
 	Source string `json:"source"`
 	// Options are fstab style mount options.
 	Options []string `json:"options,omitempty"`
-}
-
-// Hook specifies a command that is run at a particular event in the lifecycle of a container
-type Hook struct {
-	Path    string   `json:"path"`
-	Args    []string `json:"args,omitempty"`
-	Env     []string `json:"env,omitempty"`
-	Timeout *int     `json:"timeout,omitempty"`
-}
-
-// Hooks for container setup and teardown
-type Hooks struct {
-	// Prestart is a list of hooks to be run before the container process is executed.
-	// On Linux, they are run after the container namespaces are created.
-	Prestart []Hook `json:"prestart,omitempty"`
-	// Poststart is a list of hooks to be run after the container process is started.
-	Poststart []Hook `json:"poststart,omitempty"`
-	// Poststop is a list of hooks to be run after the container process exits.
-	Poststop []Hook `json:"poststop,omitempty"`
 }
 
 // Linux contains platform specific configuration for Linux based containers.


### PR DESCRIPTION
This drops all instances (outside the ChangeLog) turned up by
case-insensitive searches for 'hook'.

The desire to drop hooks has been around [for a while now][1], but it
took a while to land a create/start split.  By the time that split did
land, dropping hooks was still [part of its motivation][2].  Hooks are
hard to [support robustly][3], and after the create/start split,
callers can do whatever they like at those times without having to [go
through the runtime][4].  There is still a use-case for folks who
prefer the old all-in-one UX, but we can support those folks with a
[higher-level wrapper built on hookless create/start primatives][5].
There was some last-minute discussion of [pre-pivot mount propagation
needing pre-start hooks][6], but that use case can be addressed by
[manipulating the mounts array][7].  With those arguments in place, the
consensus at today's meeting seemed in favor of [removing hooks from
the spec][8].

Fixes #473.
Fixes #472.
Fixes #427.
Fixes #395.
Fixes #20.

[1]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2015/opencontainers.2015-10-28-17.02.log.html#l-71
[2]: https://github.com/opencontainers/runtime-spec/pull/384#issue-147984345
[3]: https://github.com/opencontainers/runtime-spec/pull/265
[4]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2016-03-24.log.html#t2016-03-24T18:56:15
[5]: https://groups.google.com/a/opencontainers.org/d/msg/dev/Y7p6YW8zr4s/OVaAI_WDBAAJ
[6]: https://github.com/opencontainers/runtime-spec/pull/384#issuecomment-220038190
[7]: https://github.com/opencontainers/runtime-spec/pull/384#issuecomment-220740126
[8]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2016/opencontainers.2016-06-01-17.01.log.html#l-83