### PR TITLE
bundle: Remove distribution references

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -12,12 +12,10 @@ This MUST include the following artifacts:
 
 1. `config.json` : contains configuration data.
 This REQUIRED file MUST reside in the root of the bundle directory and MUST be named `config.json`.
-When the bundle is packaged up for distribution, this file MUST be included.
 See [`config.json`](config.md) for more details.
 
 2. A directory representing the root filesystem of the container.
 While the name of this REQUIRED directory may be arbitrary, users should consider using a conventional name, such as `rootfs`.
-When the bundle is packaged up for distribution, this directory MUST be included.
 This directory MUST be referenced from within the `config.json` file.
 
 While these artifacts MUST all be present in a single directory on the local filesystem, that directory itself is not part of the bundle.


### PR DESCRIPTION
These distribution requirements belong in image-spec or similar.  They
don't apply to runtimes or filesystem bundles (the latter are covered
by the earlier "This MUST include the following artifacts"), which are
the two entities tested for compliance with this spec.