### PR TITLE
Revert "Clarify backwards compatibility for major version 0"

### DIFF
--- a/config.md
+++ b/config.md
@@ -13,7 +13,6 @@ Below is a detailed description of each field defined in the configuration forma
 * **`ociVersion`** (string, required) MUST be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OpenContainer specification with which the bundle complies.
 The OpenContainer spec follows semantic versioning and retains forward and backward compatibility within major versions.
 For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
-NOTE that there is no guarantee for forward or backward compatibility for version 0.x.
 
 ### Example
 


### PR DESCRIPTION
This reverts commit 0f25f18b9b6dd315ba357d7f4f10d636474d7994 (#253).  Now that we're on to 1.0, we don't need to talk about 0.x.  And the lack of 0.x backwards compatability is covered by [SemVer 2.0 section 4][1]:

> Major version zero (0.y.z) is for initial development.  Anything may change at any time.  The public API should not be considered stable.

so removing the echo from our spec doesn't actually change anything.

[1]: http://semver.org/spec/v2.0.0.html