### PR TITLE
config: Make 'process.args' optional

### DIFF
--- a/config.md
+++ b/config.md
@@ -99,6 +99,8 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
   * **`args`** (array of strings, optional) executable to launch and any flags as an array.
     The executable is the first element and MUST be available at the given path inside of the rootfs.
     If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
+  * **`user`** (object, required) the process user.
+    The properties for this object are [platform dependent](#user).
 
   For Linux-based systems the process structure supports the following process specific fields:
 

--- a/config.md
+++ b/config.md
@@ -84,26 +84,35 @@ For the Windows operating system, one mount destination MUST NOT be nested withi
 See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx) in Windows.
 
 
-## Process configuration
+## Process
 
-* **`terminal`** (bool, optional) specifies whether you want a terminal attached to that process. Defaults to false.
-* **`cwd`** (string, required) is the working directory that will be set for the executable. This value MUST be an absolute path.
-* **`env`** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side MUST consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
-* **`args`** (array of strings, required) executable to launch and any flags as an array. The executable is the first element and MUST be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
+* **`process`** (object, required) configures the container process.
+  It supports the following properties:
 
-For Linux-based systems the process structure supports the following process specific fields:
+  * **`terminal`** (bool, optional) specifies whether you want a terminal attached to that process.
+    Defaults to false.
+  * **`cwd`** (string, required) is the working directory that will be set for the executable.
+    This value MUST be an absolute path.
+  * **`env`** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution.
+    Elements in the array are specified as Strings in the form "KEY=value".
+    The left hand side MUST consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
+  * **`args`** (array of strings, optional) executable to launch and any flags as an array.
+    The executable is the first element and MUST be available at the given path inside of the rootfs.
+    If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
 
-* **`capabilities`** (array of strings, optional) capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
-Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)
-* **`rlimits`** (array of rlimits, optional) rlimits is an array of rlimits that allows setting resource limits for a process inside the container.
-The kernel enforces the `soft` limit for a resource while the `hard` limit acts as a ceiling for that value that could be set by an unprivileged process.
-Valid values for the 'type' field are the resources defined in [the man page](http://man7.org/linux/man-pages/man2/setrlimit.2.html).
-* **`apparmorProfile`** (string, optional) apparmor profile specifies the name of the apparmor profile that will be used for the container.
-For more information about Apparmor, see [Apparmor documentation](https://wiki.ubuntu.com/AppArmor)
-* **`selinuxLabel`** (string, optional) SELinux process label specifies the label with which the processes in a container are run.
-For more information about SELinux, see  [Selinux documentation](http://selinuxproject.org/page/Main_Page)
-* **`noNewPrivileges`** (bool, optional) setting `noNewPrivileges` to true prevents the processes in the container from gaining additional privileges.
-[The kernel doc](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) has more information on how this is achieved using a prctl system call.
+  For Linux-based systems the process structure supports the following process specific fields:
+
+  * **`capabilities`** (array of strings, optional) capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
+    Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)
+  * **`rlimits`** (array of rlimits, optional) rlimits is an array of rlimits that allows setting resource limits for a process inside the container.
+    The kernel enforces the `soft` limit for a resource while the `hard` limit acts as a ceiling for that value that could be set by an unprivileged process.
+    Valid values for the 'type' field are the resources defined in [the man page](http://man7.org/linux/man-pages/man2/setrlimit.2.html).
+  * **`apparmorProfile`** (string, optional) apparmor profile specifies the name of the apparmor profile that will be used for the container.
+    For more information about Apparmor, see [Apparmor documentation](https://wiki.ubuntu.com/AppArmor)
+  * **`selinuxLabel`** (string, optional) SELinux process label specifies the label with which the processes in a container are run.
+    For more information about SELinux, see  [Selinux documentation](http://selinuxproject.org/page/Main_Page)
+  * **`noNewPrivileges`** (bool, optional) setting `noNewPrivileges` to true prevents the processes in the container from gaining additional privileges.
+    [The kernel doc](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) has more information on how this is achieved using a prctl system call.
 
 ### User
 

--- a/runtime.md
+++ b/runtime.md
@@ -102,6 +102,7 @@ This operation MUST generate an error if it is not provided the container ID.
 Attempting to start a container that does not exist MUST generate an error.
 Attempting to start an already started container MUST have no effect on the container and MUST generate an error.
 This operation MUST run the user-specified code as specified by [`process`](config.md#process-configuration).
+If `process.args` was not configured, the runtime MUST generate an error.
 
 Upon successful completion of this operation the `status` property of this container MUST be `running`.
 

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -1,5 +1,23 @@
 {
     "definitions": {
+        "user": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "$ref": "defs.json#/definitions/UID"
+                },
+                "gid": {
+                    "$ref": "defs.json#/definitions/GID"
+                },
+                "additionalGids": {
+                    "$ref": "defs.json#/definitions/ArrayOfGIDs"
+                }
+            },
+           "required": [
+               "uid",
+               "gid"
+           ]
+        },
         "SeccompArch": {
             "type": "string",
             "enum": [

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -83,7 +83,8 @@
             "id": "https://opencontainers.org/schema/bundle/process",
             "type": "object",
             "required": [
-                "cwd"
+                "cwd",
+                "user"
             ],
             "properties": {
                 "args": {
@@ -104,21 +105,11 @@
                 },
                 "user": {
                     "id": "https://opencontainers.org/schema/bundle/process/user",
-                    "type": "object",
-                    "properties": {
-                        "uid": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/uid",
-                            "$ref": "defs.json#/definitions/UID"
-                        },
-                        "gid": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/gid",
-                            "$ref": "defs.json#/definitions/GID"
-                        },
-                        "additionalGids": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/additionalGids",
-                            "$ref": "defs.json#/definitions/ArrayOfGIDs"
+                    "oneOf": [
+                        {
+                            "$ref": "defs-linux.json#/definitions/user"
                         }
-                    }
+                    ]
                 },
                 "capabilities": {
                     "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -83,8 +83,7 @@
             "id": "https://opencontainers.org/schema/bundle/process",
             "type": "object",
             "required": [
-                "cwd",
-                "args"
+                "cwd"
             ],
             "properties": {
                 "args": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -34,7 +34,7 @@ type Process struct {
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
-	Args []string `json:"args"`
+	Args []string `json:"args,omitempty"`
 	// Env populates the process environment for the process.
 	Env []string `json:"env,omitempty"`
 	// Cwd is the current working directory for the process and must be


### PR DESCRIPTION
Since be59415 (Split create and start, 2016-04-01, #384), it's possible for a container process to never execute user-specified code (e.g. you can call ‘create’, ‘kill’, ‘delete’ without calling ‘start’).  For folks who expect to do that, there’s no reason to define`process.args`.

The only other `process` property required for all platforms is `cwd`, but the runtime's idler code isn't specified in sufficient detail for the configuration author to have an opinion about what its working directory should be.

On Linux and Solaris, `uid` and `gid` are also required.  My preferred approach here is to [make those optional](https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/DWdystx5X3A) and [use platform defaults](https://github.com/opencontainers/runtime-spec/pull/417#issuecomment-216076069):

> If unset, the runtime will not attempt to manipulate the user ID (e.g. not calling setuid(2) or similar).

But the maintainer consensus is that they want those to be [explicitly](http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2016/opencontainers.2016-05-04-17.00.log.html#l-44) [required](https://github.com/opencontainers/runtime-spec/pull/417#issuecomment-216937010) [properties](https://github.com/opencontainers/runtime-spec/pull/417#issuecomment-216937090).  With the current spec, one option could be to make process optional (with the idler's working directory unspecified) for OSes besides Linux and Solaris, but the main reason that Windows doesn't have a user property is that [we don't know how to specify it](https://github.com/opencontainers/runtime-spec/pull/96#issuecomment-128410585).  I expect all platforms will have some sort of required user field, which means they'll all have to define `process`.

While I'm indenting the sub-properties, also wrap them to [one line per sentence](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/style.md#one-sentence-per-line).

There was also some [related discussion](https://github.com/opencontainers/runc/pull/827#discussion_r63464201) in opencontainers/runc#827, although I'm not clear on the intended policy after that discussion.
