### PR TITLE
schema/validate: Allow schema identifiers to contain a URL scheme

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -37,3 +37,9 @@ Then use it like:
 ```bash
 ./validate schema.json <yourpath>/config.json
 ```
+
+Or like:
+
+```bash
+./validate https://raw.githubusercontent.com/opencontainers/runtime-spec/v1.0.0-rc1/schema/schema.json <yourpath>/config.json
+```

--- a/schema/validate.go
+++ b/schema/validate.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -16,12 +17,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	schemaPath, err := filepath.Abs(os.Args[1])
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+	schemaPath := os.Args[1]
+	if !strings.Contains(schemaPath, "://") {
+		schemaPath, err := filepath.Abs(schemaPath)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		schemaPath = "file://" + schemaPath
 	}
-	schemaLoader := gojsonschema.NewReferenceLoader("file://" + schemaPath)
+	schemaLoader := gojsonschema.NewReferenceLoader(schemaPath)
+
 	var documentLoader gojsonschema.JSONLoader
 
 	if nargs > 1 {


### PR DESCRIPTION
And only fall back to assuming they're a local file if they don't
already contain :// (which is unlikely to show up in local paths).
This makes it easy to validate configurations against different
versions of the JSON Schema (e.g. v0.5.0 or v1.0.0-rc1).

Ping @vbatts.
