### PR TITLE
schema/schema.json: Make 'hostname' optional

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -177,7 +177,6 @@
         "platform",
         "process",
         "root",
-        "hostname",
         "mounts",
         "hooks"
     ]


### PR DESCRIPTION
The JSON Schema requirement dates back to cdcabdeb (schema: JSON
Schema and validator for `config.json`, 2016-01-19, #313), but the
property has been explicitly optional in the Markdown spec since
7ac41c69 (config.md: reformat into a standard style, 2015-06-30).

Ping @vbatts.