### PR TITLE
config-linux: clarify cgroup requirements

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -175,6 +175,9 @@ You can configure a container's cgroups via the `resources` field of the Linux c
 Do not specify `resources` unless limits have to be updated.
 For example, to run a new process in an existing container without updating limits, `resources` need not be specified.
 
+A runtime MUST at least use the minimum set of cgroup controllers required to fulfill the `resources` settings.
+However, a runtime MAY attach the container process to additional cgroup controllers supported by the system.
+
 ###### Example
 
 ```json

--- a/config-linux.md
+++ b/config-linux.md
@@ -154,28 +154,27 @@ In addition to any devices configured with this setting, the runtime MUST also s
 ## Control groups
 
 Also known as cgroups, they are used to restrict resource usage for a container and handle device access.
-cgroups provide controls to restrict cpu, memory, IO, pids and network for the container.
+cgroups provide controls (through controllers) to restrict cpu, memory, IO, pids and network for the container.
 For more information, see the [kernel cgroups documentation][cgroup-v1].
 
 The path to the cgroups can be specified in the Spec via `cgroupsPath`.
+`cgroupsPath` can be used to either control the cgroup hierarchy for containers or to run a new process in an existing container.
 `cgroupsPath` is expected to be relative to the cgroups mount point.
 If `cgroupsPath` is not specified, implementations can define the default cgroup path.
 Implementations of the Spec can choose to name cgroups in any manner.
 The Spec does not include naming schema for cgroups.
-The Spec does not support [split hierarchy][cgroup-v2].
+The Spec does not support per-controller paths for the reasons discussed in the [cgroupv2 documentation][cgroup-v2].
 The cgroups will be created if they don't exist.
+
+You can configure a container's cgroups via the `resources` field of the Linux configuration.
+Do not specify `resources` unless limits have to be updated.
+For example, to run a new process in an existing container without updating limits, `resources` need not be specified.
 
 ###### Example
 
 ```json
    "cgroupsPath": "/myRuntime/myContainer"
 ```
-
-`cgroupsPath` can be used to either control the cgroups hierarchy for containers or to run a new process in an existing container.
-
-You can configure a container's cgroups via the `resources` field of the Linux configuration.
-Do not specify `resources` unless limits have to be updated.
-For example, to run a new process in an existing container without updating limits, `resources` need not be specified.
 
 #### Device whitelist
 

--- a/config-linux.md
+++ b/config-linux.md
@@ -159,8 +159,13 @@ For more information, see the [kernel cgroups documentation][cgroup-v1].
 
 The path to the cgroups can be specified in the Spec via `cgroupsPath`.
 `cgroupsPath` can be used to either control the cgroup hierarchy for containers or to run a new process in an existing container.
-`cgroupsPath` is expected to be relative to the cgroups mount point.
-If `cgroupsPath` is not specified, implementations can define the default cgroup path.
+If `cgroupsPath` is:
+* ... an absolute path (starting with `/`), the runtime MUST take the path to be relative to the cgroup mount point.
+* ... a relative path (not starting with `/`), the runtime MAY interpret the path relative to a runtime-determined location in the cgroup hierarchy.
+* ... not specified, the runtime MAY define the default cgroup path.
+Runtimes MAY consider certain `cgroupsPath` values to be invalid, and MUST generate an error if this is the case.
+If a `cgroupsPath` value is specified, the runtime MUST consistently attach to the same place in the cgroup hierarchy given the same value of `cgroupsPath`.
+
 Implementations of the Spec can choose to name cgroups in any manner.
 The Spec does not include naming schema for cgroups.
 The Spec does not support per-controller paths for the reasons discussed in the [cgroupv2 documentation][cgroup-v2].

--- a/config-linux.md
+++ b/config-linux.md
@@ -181,7 +181,19 @@ However, a runtime MAY attach the container process to additional cgroup control
 ###### Example
 
 ```json
-   "cgroupsPath": "/myRuntime/myContainer"
+   "cgroupsPath": "/myRuntime/myContainer",
+   "resources": {
+      "memory": {
+         "limit": 100000,
+         "reservation": 200000
+      },
+      "devices": [
+         {
+            "allow": false,
+            "access": "rwm"
+         }
+      ]
+   }
 ```
 
 #### Device whitelist


### PR DESCRIPTION
This helps clear up some of the vagueness around cgroupsPath in the spec. It's
loosely modeled on what runC does (as well as allowing for custom cgroup
managers in runtimes). I also updated the cgroup section to make it clear that
lazy cgroup setup (where you only attach to the bare minimum of requested
cgroups) is allowed under the spec. This all originated from an IRC discussion
on #opencontainers.

This possibly obsoletes #270 (although that has some renaming going on).

Signed-off-by: Aleksa Sarai <asarai@suse.de>

/cc @opencontainers/runtime-spec-maintainers @wking 