### PR TITLE
The default value of cfs_quota_us should be -1, which is negative

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -272,7 +272,7 @@ type CPU struct {
 	// CPU shares (relative weight (ratio) vs. other cgroups with cpu shares).
 	Shares *uint64 `json:"shares,omitempty"`
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
-	Quota *uint64 `json:"quota,omitempty"`
+	Quota *int64 `json:"quota,omitempty"`
 	// CPU period to be used for hardcapping (in usecs).
 	Period *uint64 `json:"period,omitempty"`
 	// How much time realtime scheduling may use (in usecs).


### PR DESCRIPTION
The default value of cfs_quota_us should be -1, means unlimited. So, I think we need to make this field int. Because RunC has added update feature, which should let user set it back to unlimited. 
