### PR TITLE
specs-go/config: Make Linux and Solaris omitempty (again)

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -22,9 +22,9 @@ type Spec struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Linux is platform specific configuration for Linux based containers.
-	Linux Linux `json:"linux" platform:"linux,omitempty"`
+	Linux *Linux `json:"linux,omitempty" platform:"linux"`
 	// Solaris is platform specific configuration for Solaris containers.
-	Solaris Solaris `json:"solaris" platform:"solaris,omitempty"`
+	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
 }
 
 // Process contains information to start a specific application inside the container.
@@ -371,9 +371,9 @@ type Solaris struct {
 	// Specification for automatic creation of network resources for this container.
 	Anet []Anet `json:"anet,omitempty"`
 	// Set limit on the amount of CPU time that can be used by container.
-	CappedCPU CappedCPU `json:"cappedCPU,omitempty"`
+	CappedCPU *CappedCPU `json:"cappedCPU,omitempty"`
 	// The physical and swap caps on the memory that can be used by this container.
-	CappedMemory CappedMemory `json:"cappedMemory,omitempty"`
+	CappedMemory *CappedMemory `json:"cappedMemory,omitempty"`
 }
 
 // CappedCPU allows users to set limit on the amount of CPU time that can be used by container.


### PR DESCRIPTION
I'd added some omitempties in 5c2193f3 (specs-go/config: Make Linux and Solaris omitempty, 2016-05-06, #431), but it turns out to not have the intended effect unless the field is also a pointer type (even after I shifted the `omitempty` from the `platform` tag to the `json` tag ;).  Before this commit:

    $ ./ocitools generate --template <(echo '{}')
    $ jq . config.json
    {
      "ociVersion": "1.0.0-rc1-dev",
      "platform": {
        "os": "linux",
        "arch": "amd64"
      },
      "process": {
        "user": {
          "uid": 0,
          "gid": 0
        },
        "args": [],
        "cwd": "/"
      },
      "root": {
        "path": "rootfs"
      },
      "hooks": {},
      "linux": {
        "cgroupsPath": ""
      },
      "solaris": {
        "cappedCPU": {},
        "cappedMemory": {}
      }
    }

And after this commit:

    $ ./ocitools generate --template <(echo '{}')
    $ jq . config.json
    {
      "ociVersion": "1.0.0-rc1-dev",
      "platform": {
        "os": "linux",
        "arch": "amd64"
      },
      "process": {
        "user": {
          "uid": 0,
          "gid": 0
        },
        "args": [],
        "cwd": "/"
      },
      "root": {
        "path": "rootfs"
      },
      "hooks": {},
    }

The remaining useless properties are addressed by other in-flight pull requests:

* 5ca74df (config: Make 'process.args' optional, 2016-06-04, #489)
* ad33f9c (config: Explicitly list 'hooks' as optional, 2016-05-06, #427)

So I've left them alone here.