### PR TITLE
runtime: Add 'creating' to state status

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -16,9 +16,10 @@ There is no requirement that it be unique across hosts.
 * **`status`**: (string) is the runtime state of the container.
 The value MAY be one of:
 
-    * `created`: the container process has neither exited nor executed the user-specified program
-    * `running`: the container process has executed the user-specified program but has not exited
-    * `stopped`: the container process has exited
+    * `creating`: the container is being created (step 2 in the [lifecycle](#lifecycle))
+    * `created`: the runtime has finished the [create operation](#create) (after step 2 in the [lifecycle](#lifecycle)), and the container process has neither exited nor executed the user-specified program
+    * `running`: the container process has executed the user-specified program but has not exited (after step 4 in the [lifecycle](#lifecycle))
+    * `stopped`: the container process has exited (step 5 in the [lifecycle](#lifecycle))
 
     Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`**: (int) is the ID of the container process, as seen by the host.


### PR DESCRIPTION
To distinguish between "we're still setting this container up" and
"we're finished setting up; you can call 'start' if you like".

Also reference the lifecycle steps, because you can't be too explicit

Also relax the `pid` requirement from “always” to “only for `created`
and `running`”.  During the `creating` phase we may not have a
container process yet (e.g. if we're still reading the configuration
or setting up cgroups), and in the `stopped` phase the PID is no
longer meaningful.

Some discussion with @mikebrow around this starting [here](http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/latest.log.html#t2016-06-23T20:00:17).

This PR builds on #465, so that should get reviewed first.
