### PR TITLE
runtime: Add an 'event' operation for subscribing to pushes

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -15,9 +15,10 @@ This MUST be unique across all containers on this host.
 There is no requirement that it be unique across hosts.
 * **`status`**: (string) is the runtime state of the container.
 The value MAY be one of:
-  * `created` : the container process has neither exited nor executed the user-specified code
-  * `running` : the container process has executed the user-specified code but has not exited
-  * `stopped` : the container process has exited
+  * `creating` : the container is being created (step 2 in the [lifecycle](#lifecycle))
+  * `created` : the runtime has finished the [create operation](#create) (after step 2 in the [lifecycle](#lifecycle)), and the container process has neither exited nor executed the user-specified code
+  * `running` : the container process has executed the user-specified code but has not exited (after step 4 in the [lifecycle](#lifecycle))
+  * `stopped` : the container process has exited (step 5 in the [lifecycle](#lifecycle))
 
   Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`**: (int) is the ID of the main process within the container, as seen by the host.

--- a/runtime.md
+++ b/runtime.md
@@ -89,6 +89,8 @@ This operation MUST return the state of a container as specified in the [State](
 This operation MUST generate an error if it is not provided the ID of a container.
 Attempting to query a container that does not exist MUST generate an error.
 This operation MUST subscribe the caller to push-notification about future events in chronological order.
+If the container's [create operation](#create) requested an event buffer, the buffered events MUST be published in chronological order before any future events are published.
+If the runtime could not perform the requested buffering, it MUST generate an error.
 Events MUST be published when the container's [`status`](#state) changes, and MAY be published for additional events.
 Events MUST include, at least, the following properties:
 
@@ -111,7 +113,7 @@ So the `timestamp` and event publication may not exactly match the associated ke
 
 ### Create
 
-`create <container-id> <path-to-bundle>`
+`create <container-id> <path-to-bundle> <event-buffer>`
 
 This operation MUST generate an error if it is not provided a path to the bundle and the container ID to associate with the container.
 If the ID provided is not unique across all containers within the scope of the runtime, or is not valid in any other way, the implementation MUST generate an error and a new container MUST not be created.
@@ -124,6 +126,8 @@ The runtime MAY validate `config.json` against this spec, either generically or 
 Runtime callers who are interested in pre-create validation can run [bundle-validation tools](implementations.md#testing--tools) before invoking the create operation.
 
 Any changes made to the [`config.json`](config.md) file after this operation will not have an effect on the container.
+
+Runtime callers MAY request an event buffer, in which case the runtime MUST buffer events associated with the container.
 
 ### Start
 `start <container-id>`

--- a/runtime.md
+++ b/runtime.md
@@ -7,13 +7,13 @@ Whether other entities using the same, or other, instance of the runtime can see
 
 ## State
 
-The state of a container MUST include, at least, the following properties:
+The state of a container includes the following properties:
 
-* **`ociVersion`**: (string) is the OCI specification version used when creating the container.
-* **`id`**: (string) is the container's ID.
+* **`ociVersion`** (string, required) is the OCI specification version used when creating the container.
+* **`id`** (string, required) is the container's ID.
 This MUST be unique across all containers on this host.
 There is no requirement that it be unique across hosts.
-* **`status`**: (string) is the runtime state of the container.
+* **`status`** (string, required) is the runtime state of the container.
 The value MAY be one of:
   * `creating` : the container is being created (step 2 in the [lifecycle](#lifecycle))
   * `created` : the runtime has finished the [create operation](#create) (after step 2 in the [lifecycle](#lifecycle)), and the container process has neither exited nor executed the user-specified code
@@ -21,11 +21,13 @@ The value MAY be one of:
   * `stopped` : the container process has exited (step 5 in the [lifecycle](#lifecycle))
 
   Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
-* **`pid`**: (int) is the ID of the main process within the container, as seen by the host.
-* **`bundlePath`**: (string) is the absolute path to the container's bundle directory.
+* **`pid`** (int, required when `status` is `created` or `running`) is the ID of the main process within the container, as seen by the host.
+* **`bundlePath`**: (string, required) is the absolute path to the container's bundle directory.
 This is provided so that consumers can find the container's configuration and root filesystem on the host.
-* **`annotations`**: (map) contains the list of annotations associated with the container.
+* **`annotations`**: (map, required) contains the list of annotations associated with the container.
 If no annotations were provided then this property MAY either be absent or an empty map.
+
+The state MAY include additional properties.
 
 When serialized in JSON, the format MUST adhere to the following pattern:
 

--- a/runtime.md
+++ b/runtime.md
@@ -15,9 +15,9 @@ This MUST be unique across all containers on this host.
 There is no requirement that it be unique across hosts.
 * **`status`**: (string) is the runtime state of the container.
 The value MAY be one of:
-  * `created` : the container has been created but the user-specified code has not yet been executed
-  * `running` : the container has been created and the user-specified code is running
-  * `stopped` : the container has been created and the user-specified code has been executed but is no longer running
+  * `created` : the container process has neither exited nor executed the user-specified code
+  * `running` : the container process has executed the user-specified code but has not exited
+  * `stopped` : the container process has exited
 
   Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`**: (int) is the ID of the main process within the container, as seen by the host.
@@ -55,8 +55,8 @@ The lifecycle describes the timeline of events that happen from when a container
    However, some actions might only be available based on the current state of the container (e.g. only available while it is started).
 4. Runtime's `start` command is invoked with the unique identifier of the container.
    The runtime MUST run the user-specified code, as specified by [`process`](config.md#process-configuration).
-5. The container's process is stopped.
-   This MAY happen due to them erroring out, exiting, crashing or the runtime's `kill` operation being invoked.
+5. The container process exits.
+   This MAY happen due to erroring out, exiting, crashing or the runtime's `kill` operation being invoked.
 6. Runtime's `delete` command is invoked with the unique identifier of the container.
    The container MUST be destroyed by undoing the steps performed during create phase (step 2).
 


### PR DESCRIPTION
The current [state](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#query-state) operation allows callers to poll for the state, but for some workflows polling is inefficient (how frequently do you poll to balance the cost of polling against the timeliness of the response?) and push notifications make more sense.

The runtime's [create](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#create) process is in a unique position to detect these status transitions.
- As the actor carrying out container creation, it should have a clear idea of when that creation completes (for the `created` event).
- It may setup a communication channel with the container process to orchestrate creation, and that channel may be used to report the start event.
- It knows (or is) the parent of the container process, and POSIX's [wait(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html), [waitpid(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html), and [waitid(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/waitid.html) only work for child processes.  From [wait(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html):
  
  > Nothing in this volume of POSIX.1-2008 prevents an
  > implementation from providing extensions that permit a process
  > to get status from a grandchild or any other process, but a
  > process that does not use such extensions must be guaranteed to
  > see status from only its direct children.
  
  So the runtime can setup (or be) the parent waiting on the container process, and arrange for the 'stopped' event to be published on container exit.

I've tried to phrase the requirements conservatively to allow for runtimes that have to poll their kernel or some such to notice these changes.  I see the following runtime-support cases:
1. The runtime can easily supply a push-based event operation.  In this case, exposing that operation to callers faciliates push-based workflows without much cost.
2. The runtime cannot supply a push-based event operation, and has to emulate it by polling.  In this case, the runtime can pick a polling strategy that makes sense to its maintainers, and callers who aren't satisfied with that strategy can roll their own state poller without a big efficiency hit (in a lesser of two evils way).
   
   The requirement is currently worded so weakly that a runtime would be compliant with:
   1. Container process dies at noon.
   2. User calls [state](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#query-state) at 5pm.
   3. Runtime checks kernel, and sees that the container process is dead.
   4. Runtime publishes `stopped` event with a 5pm (and some microseconds) timestamp.
   5. Runtime returns state to the user with `stopped` in `status`.
   
   which is a pretty low bar.
3. The runtime could supply a push-based event operation, but it would be a lot of work.  These runtimes can use polling (2) as a quick-and-dirty solution until someone has time to implement a push-based solution (1).  The improvement is transparent to users, who can use the same event operation throughout and passively reap the benefits of the implementation improvements.

Without an operation like this, higher levels that need to trigger on these transitions without polling need to exercise a lot of control over the system:
- They must be the parent of (or on Linux, the nearest [`PR_SET_CHILD_SUBREAPER`](http://man7.org/linux/man-pages/man2/prctl.2.html) ancestor of) the [create](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#create) process, and the [create](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#create) process needs to exit after creation completes, if they want to block on the `created` event.
- They must proxy all [start](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#start) and [delete](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#delete) requests if they want to block on the `started` or `deleted` events.
- On Linux, they must be the nearest ancestor of the [create](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#create) operation to set [`PR_SET_CHILD_SUBREAPER`](http://man7.org/linux/man-pages/man2/prctl.2.html) if they want to block on the `stopped` event.

By making `event` a runtime requirement, we allow for efficient cross-platform push-based workflows while avoiding the need for tight orchestrator gate-keeping.  Runtimes that have implementation difficulties have an easy out that allows their callers to benefit from future implemenation improvements.  And callers that are not satisfied can always fall back to polling state or the proxy/`waitid`/`PR_SET_CHILD_SUBREAPER` approaches.

The buffering requirement is very generic, and I expect more details to land in the runtime API specification.  Requirements around the buffer-request semantics (e.g. “buffer for 15 seconds” or “buffer the last 5 events” or “buffer the `created` event”) seemed out of place at the level of detail in this specification.

The goal is to allow for:

```
$ funC create --event-buffer created ID &
$ funC event --event created ID && hook1 && hook2 && funC start ID
$ fg
```

To support blocking on the event without racing on “maybe the `created` event happened before the event operation attached”.

Given the small number of required events, this buffering should not be a large resource concern, and `--event-buffer created` would only ever require a single event to be buffered per container.

There is still a race on “maybe the container has already been destroyed and a second container has been created with the same ID before the event operation attached”, but that seems much less likely (especially since the caller is free to pick UUIDs).

This builds on #507, so that should be reviewed first.

**UPDATE**: note that this pub/sub model _does not_ require an additional long-running process.  For an example implementation based on shared access to a directory (like runC uses for [state](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#query-state)) and inotify, see [wking/inotify-pubsub](https://github.com/wking/inotify-pubsub).
