### PR TITLE
README: Update conference-call phone number

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ When in doubt, start on the [mailing-list](#mailing-list).
 ## Weekly Call
 
 The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 10:00 AM (USA Pacific.)
-Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: 888-587-9088 or 860-706-8529 (no PIN needed.)
+Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: 415-968-0849 (no PIN needed.)
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
 Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki](https://github.com/opencontainers/runtime-spec/wiki) for those who are unable to join the call.
 


### PR DESCRIPTION
On Thu, Jul 14, 2016 at 06:27:50PM -0700, Chris Aniszczyk [wrote][1]:
> There was a change in the phone number for the conference line, URL
> is the same.
>
> Join the call: https://www.uberconference.com/opencontainers
> Optional dial in number: 415-968-0849
> No PIN needed

Fixes #514.

[1]: https://github.com/opencontainers/runtime-spec/issues/514