### PR TITLE
config: Update schema.json -> config-schema.json

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Container Configuration file
 
 The container's top-level directory MUST contain a configuration file called `config.json`.
-The canonical schema is defined in this document, but there is a JSON Schema in [`schema/schema.json`](schema/schema.json) and Go bindings in [`specs-go/config.go`](specs-go/config.go).
+The canonical schema is defined in this document, but there is a JSON Schema in [`schema/config-schema.json`](schema/config-schema.json) and Go bindings in [`specs-go/config.go`](specs-go/config.go).
 
 The configuration file contains metadata necessary to implement standard operations against the container.
 This includes the process to run, environment variables to inject, sandboxing features to use, etc.


### PR DESCRIPTION
This slipped through the rename in 2a5986f7 (schema/state-schema.json:
Add a JSON Schema for the state JSON, 2016-06-01, #481) and the first
round of fixes in dfb85b16 (schema/README: Fix links to
(config|state)-schema.json, 2016-06-13, #498).

Fixes #517.