### PR TITLE
README: Change meeting time from 10am to 2pm Pacific

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ When in doubt, start on the [mailing-list](#mailing-list).
 
 ## Weekly Call
 
-The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 10:00 AM (USA Pacific.)
+The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 2:00 PM (USA Pacific).
 Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: 415-968-0849 (no PIN needed.)
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
 Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki](https://github.com/opencontainers/runtime-spec/wiki) for those who are unable to join the call.


### PR DESCRIPTION
[Catch up][1] now that we're having 2pm meetings two weeks in a row.  There's also some earlier discussion [here][2].

[1]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/VlwOuGh2y84
[2]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/HXO-FplpEKM