### PR TITLE
config-linux: Make Linux 'devices' explicitly optional

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -198,7 +198,7 @@ However, a runtime MAY attach the container process to additional cgroup control
 
 #### Device whitelist
 
-`devices` is an array of entries to control the [device whitelist][cgroup-v1-devices].
+**`devices`** (array, optional) configures the [device whitelist][cgroup-v1-devices].
 The runtime MUST apply entries in the listed order.
 
 The following parameters can be specified:

--- a/config-linux.md
+++ b/config-linux.md
@@ -98,7 +98,7 @@ There is a limit of 5 mappings which is the Linux kernel hard limit.
 
 ## Devices
 
-`devices` is an array specifying the list of devices that MUST be available in the container.
+**`devices`** (array, optional) lists devices that MUST be available in the container.
 The runtime may supply them however it likes (with [mknod][mknod.2], by bind mounting from the runtime mount namespace, etc.).
 
 The following parameters can be specified:

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -301,8 +301,8 @@ type Network struct {
 
 // Resources has container runtime resource constraints
 type Resources struct {
-	// Devices are a list of device rules for the whitelist controller
-	Devices []DeviceCgroup `json:"devices"`
+	// Devices configures the device whitelist.
+	Devices []DeviceCgroup `json:"devices,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Specify an oom_score_adj for the container.


### PR DESCRIPTION
Both `linux.devices` and `linux.resources.devices`.  Details in the commit messages.