### PR TITLE
Add missing `"type": "object"`

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -69,6 +69,7 @@
                     },
                     "pids": {
                         "id": "https://opencontainers.org/schema/bundle/linux/resources/pids",
+                        "type": "object",
                         "properties": {
                             "limit": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/pids/limit",
@@ -157,6 +158,7 @@
                     },
                     "cpu": {
                         "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu",
+                        "type": "object",
                         "properties": {
                             "cpus": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/cpus",
@@ -283,6 +285,7 @@
             },
             "seccomp": {
                 "id": "https://opencontainers.org/schema/bundle/linux/seccomp",
+                "type": "object",
                 "properties": {
                     "defaultAction": {
                         "id": "https://opencontainers.org/schema/bundle/linux/seccomp/defaultAction",

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -44,6 +44,7 @@
             ]
         },
         "SyscallArg": {
+            "type": "object",
             "properties": {
                 "index": {
                     "$ref": "defs.json#/definitions/uint32"
@@ -60,6 +61,7 @@
             }
         },
         "Syscall": {
+            "type": "object",
             "properties": {
                 "name": {
                     "type": "string"
@@ -103,6 +105,7 @@
             "pattern": "^[cbup]$"
         },
         "Device": {
+            "type": "object",
             "properties": {
                 "type": {
                     "$ref": "#/definitions/FileType"
@@ -146,6 +149,7 @@
             ]
         },
         "blockIODevice": {
+            "type": "object",
             "properties": {
                 "major": {
                     "$ref": "#/definitions/Major"
@@ -166,6 +170,7 @@
                     "$ref": "#/definitions/blockIODevice"
                 },
                 {
+                    "type": "object",
                     "properties": {
                         "weight": {
                             "$ref": "#/definitions/blkioWeightPointer"
@@ -193,6 +198,7 @@
                     "$ref": "#/definitions/blockIODevice"
                 },
                 {
+                    "type": "object",
                     "properties": {
                         "rate": {
                             "$ref": "defs.json#/definitions/uint64Pointer"
@@ -212,6 +218,7 @@
             ]
         },
         "NetworkInterfacePriority": {
+            "type": "object",
             "properties": {
                 "name": {
                     "type": "string"
@@ -234,6 +241,7 @@
             ]
         },
         "NamespaceReference": {
+            "type": "object",
             "properties": {
                 "type": {
                     "$ref": "#/definitions/NamespaceType"

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -104,6 +104,7 @@
             "$ref": "#/definitions/ArrayOfStrings"
         },
         "Hook": {
+            "type": "object",
             "properties": {
                 "path": {
                     "$ref": "#/definitions/FilePath"
@@ -123,6 +124,7 @@
             }
         },
         "IDMapping": {
+            "type": "object",
             "properties": {
                 "hostID": {
                     "$ref": "#/definitions/uint32"
@@ -136,6 +138,7 @@
             }
         },
         "Mount": {
+            "type": "object",
             "properties": {
                 "source": {
                     "$ref": "#/definitions/FilePath"


### PR DESCRIPTION
Clearly, ignoring `"type": "object"` does not really break `validate`. 
However, currently we set `"type": "object"` in some object-type schemas, and ignore it in other object-type schemas.
This PR aims to make it consistent by adding the missing `"type": "object"`.
 
Signed-off-by: Haiyan Meng <haiyanalady@gmail.com>