### PR TITLE
specs-go/config: Make KernelTCP and ClassID omitempty

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -262,7 +262,7 @@ type Memory struct {
 	// Kernel memory limit (in bytes).
 	Kernel *uint64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
-	KernelTCP *uint64 `json:"kernelTCP"`
+	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
 	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
@@ -294,7 +294,7 @@ type Pids struct {
 // Network identification and priority configuration
 type Network struct {
 	// Set class identifier for container's network packets
-	ClassID *uint32 `json:"classID"`
+	ClassID *uint32 `json:"classID,omitempty"`
 	// Set priority of network traffic for container
 	Priorities []InterfacePriority `json:"priorities,omitempty"`
 }


### PR DESCRIPTION
Found with:

    $ git grep ' \*' origin/master -- specs-go/*.go | grep -v omitempty
    origin/master:specs-go/config.go:       KernelTCP *uint64 `json:"kernelTCP"`
    origin/master:specs-go/config.go:       ClassID *uint32 `json:"classID"`

Both settings are optional:

    $ git grep '`kernelTCP`\|`classID`' origin/master
    origin/master:config-linux.md:* **`kernelTCP`** *(uint64, optional)* - ...
    origin/master:config-linux.md:* **`classID`** *(uint32, optional)* - ...