### PR TITLE
schema/config-linux: add min/max limit for resource memory and cpu

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -129,11 +129,28 @@
                             },
                             "period": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/period",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "oneOf": [
+                                    {
+                                        "type": "integer",
+                                        "minimum": 1000,
+                                        "maximum": 1000000
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
                             },
                             "quota": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/quota",
-                                "$ref": "defs.json#/definitions/int64Pointer"
+                                "oneOf": [
+                                    {
+                                        "type": "integer",
+                                        "minimum": 1000
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
                             },
                             "realtimePeriod": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimePeriod",
@@ -198,7 +215,16 @@
                             },
                             "swappiness": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swappiness",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "oneOf": [
+                                    {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 100
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
                             }
                         }
                     },


### PR DESCRIPTION
Signed-off-by: Ma Shimiao mashimiao.fnst@cn.fujitsu.com
