### PR TITLE
config-linux: Extend no-tweak requirement to runtime namespaces

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -38,7 +38,8 @@ The following parameters can be specified to setup namespaces:
 * **`path`** *(string, optional)* - path to namespace file in the [runtime mount namespace](glossary.md#runtime-namespace)
 
 If a path is specified, that particular file is used to join that type of namespace.
-Also, when a path is specified, a runtime MUST assume that the setup for that particular namespace has already been done and error out if the config specifies anything else related to that namespace.
+If a namespace type is not specified in the `namespaces` array, the container MUST inherit the [runtime namespace](glossary.md#runtime-namespace) of that type.
+If a new namespace is not created (because the namespace type is not listed, or because it is listed with a `path`), runtimes MUST assume that the setup for that namespace has already been done and error out if the config specifies anything else related to that namespace.
 
 ###### Example
 


### PR DESCRIPTION
Implement (b) from #537.  Also make it explicit that not listing a
namespace type will cause the container to inherit the runtime
namespace of that type.  More details in the commit message, although
that mostly summarizes the discussion from #537.