### PR TITLE
config: Shift Linux-namespace no-tweaking rule to a generic rule

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -39,7 +39,6 @@ The following parameters can be specified to setup namespaces:
 
 If a path is specified, that particular file is used to join that type of namespace.
 If a namespace type is not specified in the `namespaces` array, the container MUST inherit the [runtime namespace](glossary.md#runtime-namespace) of that type.
-If a new namespace is not created (because the namespace type is not listed, or because it is listed with a `path`), runtimes MUST assume that the setup for that namespace has already been done and error out if the config specifies anything else related to that namespace.
 
 ###### Example
 

--- a/config.md
+++ b/config.md
@@ -8,6 +8,22 @@ This includes the process to run, environment variables to inject, sandboxing fe
 
 Below is a detailed description of each field defined in the configuration format.
 
+## Ownership
+
+This specification treats system attributes as belonging to a particular container.
+It does not support one container adjusting attributes that belong to another container.
+Runtimes MUST generate an error if the configuration sets an attribute that belongs to another container.
+
+For example, the following are valid:
+
+* A Linux configuration that creates a new [UTS namespace](config-linux.md#namespaces) and sets [`hostname`](#hostname).
+* A Linux configuration that sets [network limits][config-linux.md#network] with a new [control group][config-linux.md#control-groups], regardless of whether it creates a new [network namespace](config-linux.md#namespaces).
+
+While the following are invalid:
+
+* A Linux configuration that sets [`hostname`](#hostname) but does not create a new [UTS namespace](config-linux.md#namespaces).
+* A Linux configuration that sets [network limits][config-linux.md#network] with an existing [control group][config-linux.md#control-groups].
+
 ## Specification version
 
 * **`ociVersion`** (string, required) MUST be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the Open Container Runtime Specification with which the bundle complies.


### PR DESCRIPTION
There are more background references for the Linux-namespaces no-tweaking rule in 01c2d55f (config-linux: Extend no-tweak requirement to runtime namespaces, 2016-08-24, #538).  But the old rule's:

> ... error out if the config specifies anything else related to that namespace.

was overly broad.  For example, it [arguably blocked you from setting network interface priorities for interfaces belonging to an old network namespace](https://github.com/opencontainers/ocitools/pull/200/files#r75907957) even if you were setting those priorities in a new cgroup (because the interfaces and therefore priorities for them are related to the old network namespace).

The new rule tries to apply the spirit of the old rule (“don't touch things that already exist”) more generally so we have a consistent approach that clearly _does_ allow you to configure a new cgroup without having to care about new/old namespaces.

I'm personally fine with join-and-tweak, but the maintainer consensus is that it's [too](https://github.com/opencontainers/runtime-spec/pull/158) [complicated](https://github.com/opencontainers/runtime-spec/issues/537#issuecomment-242132288) to allow (at least for now, some folks [want](https://github.com/opencontainers/runtime-spec/issues/305) [it](https://github.com/opencontainers/runtime-spec/issues/17)).
