### PR TITLE
Remove code-of-conduct.md and version.md when clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,4 +114,5 @@ endif
 .PHONY: clean
 clean:
 	rm -rf $(OUTPUT_DIRNAME) *~
+	rm -f code-of-conduct.md version.md
 


### PR DESCRIPTION
So we can use latest files after make clean.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>