### PR TITLE
Makefile: Use a POSIX-compatible test ('==' -> '=')

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 EPOCH_TEST_COMMIT	:= 78e6667ae2d67aad100b28ee9580b41b7a24e667
 OUTPUT_DIRNAME		?= output/
 DOC_FILENAME		?= oci-runtime-spec
-SHELL			?= $(shell command -v bash 2>/dev/null)
 DOCKER			?= $(shell command -v docker 2>/dev/null)
 PANDOC			?= $(shell command -v pandoc 2>/dev/null)
 ifeq "$(strip $(PANDOC))" ''
@@ -63,7 +62,7 @@ version.md: ./specs-go/version.go
 
 HOST_GOLANG_VERSION	= $(shell go version | cut -d ' ' -f3 | cut -c 3-)
 # this variable is used like a function. First arg is the minimum version, Second arg is the version to be checked.
-ALLOWED_GO_VERSION	= $(shell test '$(shell /bin/echo -e "$(1)\n$(2)" | sort -V | head -n1)' == '$(1)' && echo 'true')
+ALLOWED_GO_VERSION	= $(shell test '$(shell /bin/echo -e "$(1)\n$(2)" | sort -V | head -n1)' = '$(1)' && echo 'true')
 
 .PHONY: test .govet .golint .gitvalidation
 


### PR DESCRIPTION
With dash 0.5.7:

    # make docs
    /bin/sh: 1: test: 1.3.3: unexpected operator
    /bin/sh: 1: test: 1.3.3: unexpected operator
    /bin/sh: 1: test: 1.3.3: unexpected operator
    Makefile:47: *** cannot build output//oci-runtime-spec.pdf without either pandoc or docker.  Stop.
    # command -V test
    test is a shell builtin

POSIX [defines `=` for string comparison][1]; the `==` form is a Bashism.

SHELL was added in f3fdf03 (Makefile: prefer bash, 2016-05-25, #455) to avoid these "unexpected operator" errors, but there's no reason to require Bash when we can make the comparison's POSIX compliant.

This PR is an alternative to #534.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html