### PR TITLE
improve validate usage message

### DIFF
--- a/schema/validate.go
+++ b/schema/validate.go
@@ -10,30 +10,53 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
+const usage = `Validate is used to check document with specified schema.
+You can use validate in following ways:
+
+   1.specify document file as an argument
+      validate <schema.json> <document.json>
+
+   2.pass document content through a pipe
+      cat <document.json> | validate <schema.json>
+
+   3.input document content manually, ended with ctrl+d(or your self-defined EOF keys)
+      validate <schema.json>
+      [INPUT DOCUMENT CONTENT HERE]
+`
+
 func main() {
 	nargs := len(os.Args[1:])
 	if nargs == 0 || nargs > 2 {
-		fmt.Printf("ERROR: usage is: %s <schema.json> [<document.json>]\n", os.Args[0])
+		fmt.Printf("ERROR: invalid arguments number\n\n%s\n", usage)
+		os.Exit(1)
+	}
+
+	if os.Args[1] == "help" ||
+		os.Args[1] == "--help" ||
+		os.Args[1] == "-h" {
+		fmt.Printf("%s\n", usage)
 		os.Exit(1)
 	}
 
 	schemaPath := os.Args[1]
 	if !strings.Contains(schemaPath, "://") {
-		schemaPath, err := filepath.Abs(schemaPath)
+		var err error
+		schemaPath, err = formatFilePath(schemaPath)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Printf("ERROR: invalid schema-file path: %s\n", err)
 			os.Exit(1)
 		}
 		schemaPath = "file://" + schemaPath
 	}
+
 	schemaLoader := gojsonschema.NewReferenceLoader(schemaPath)
 
 	var documentLoader gojsonschema.JSONLoader
 
 	if nargs > 1 {
-		documentPath, err := filepath.Abs(os.Args[2])
+		documentPath, err := formatFilePath(os.Args[2])
 		if err != nil {
-			fmt.Println(err)
+			fmt.Printf("ERROR: invalid document-file path: %s\n", err)
 			os.Exit(1)
 		}
 		documentLoader = gojsonschema.NewReferenceLoader("file://" + documentPath)
@@ -49,7 +72,8 @@ func main() {
 
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
-		panic(err.Error())
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	if result.Valid() {
@@ -61,4 +85,16 @@ func main() {
 		}
 		os.Exit(1)
 	}
+}
+
+func formatFilePath(path string) (string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return absPath, nil
 }


### PR DESCRIPTION
add usage message to validate:
    'cat document.json | validate schema.json'
validate would block in such case:
    'validate schema.json'
add stdin status check to avoid this.

Signed-off-by: Deng Guangxing dengguangxing@huawei.com
before:

```
$ ./validate config-schema.json 


^C$
```

after:

```
$ ./validate config-schema.json 
Error: document.json not specified

Usage:
     ./validate <schema.json> <document.json>
or
    cat <document.json> | ./validate <schema.json>

```
