### PR TITLE
Replace " : " with ": "

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -10,7 +10,7 @@ The definition of a bundle is only concerned with how a container, and its confi
 A Standard Container bundle contains all the information needed to load and run a container.
 This MUST include the following artifacts:
 
-1. `config.json` : contains configuration data.
+1. `config.json`: contains configuration data.
 This REQUIRED file MUST reside in the root of the bundle directory and MUST be named `config.json`.
 See [`config.json`](config.md) for more details.
 

--- a/config.md
+++ b/config.md
@@ -289,7 +289,7 @@ If a hook returns a non-zero exit code, then an error is logged and the remainin
 ### Example
 
 ```json
-    "hooks" : {
+    "hooks": {
         "prestart": [
             {
                 "path": "/usr/bin/fix-mounts",
@@ -334,7 +334,7 @@ Implementations that are reading/processing this configuration file MUST NOT gen
 
 ```json
 "annotations": {
-    "com.example.gpu-cores" : "2"
+    "com.example.gpu-cores": "2"
 }
 ```
 

--- a/runtime.md
+++ b/runtime.md
@@ -15,9 +15,9 @@ This MUST be unique across all containers on this host.
 There is no requirement that it be unique across hosts.
 * **`status`**: (string) is the runtime state of the container.
 The value MAY be one of:
-    * `created` : the container has been created but the user-specified code has not yet been executed
-    * `running` : the container has been created and the user-specified code is running
-    * `stopped` : the container has been created and the user-specified code has been executed but is no longer running
+    * `created`: the container has been created but the user-specified code has not yet been executed
+    * `running`: the container has been created and the user-specified code is running
+    * `stopped`: the container has been created and the user-specified code has been executed but is no longer running
 
   Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`**: (int) is the ID of the container process, as seen by the host.


### PR DESCRIPTION
There's an outside change that these are intentional, since [I pointed one of these out earlier][1] and it wasn't fixed.  But I haven't seen ` : ` used intentionally outside of this project, and don't think we want to break ground in that direction ;).

[1]: https://github.com/opencontainers/runtime-spec/pull/510#discussion_r77291554