### PR TITLE
runtime.md: Require 'create' to fail if config.json asks for the impossible

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -84,9 +84,10 @@ This operation MUST return the state of a container as specified in the [State](
 `create <container-id> <path-to-bundle>`
 
 This operation MUST generate an error if it is not provided a path to the bundle and the container ID to associate with the container.
-If the ID provided is not unique across all containers within the scope of the runtime, or is not valid in any other way, the implementation MUST generate an error and a new container MUST not be created.
+If the ID provided is not unique across all containers within the scope of the runtime, or is not valid in any other way, the implementation MUST generate an error and a new container MUST NOT be created.
 Using the data in [`config.json`](config.md), this operation MUST create a new container.
 This means that all of the resources associated with the container MUST be created, however, the user-specified code MUST NOT be run at this time.
+If the runtime cannot create the container as specified in `config.md`, it MUST generate an error and a new container MUST NOT be created.
 
 Upon successful completion of this operation the `status` property of this container MUST be `created`.
 


### PR DESCRIPTION
We [don't want to silently ignore settings that we understand but cannot implement][1] (we [*do* want to ignore settings that we don't understand][2], but that's a separate issue).

This raises a slightly sticky certification issue.  If a runtime *always* exits `create` with an error:

    func create() err {
      return fmt.Errorf("nope, I cannot create that container either.")
    }

it would be neither complaint nor non-compliant.  It would not fail any MUSTs, but availing itself of the "cannot create the maintainer" option specified in this commit would mean the test suite could not test the deeper requirements around the config properties themselves.

So with this change, making Microsoft certifiable will still need an explicit weakening around root.path.  The easiest way to do that might be to have separate annotations for whether a setting is optional for config authors and whether it's optional for runtime authors (supported):

    * **`readonly`** (bool, config:optional, support:optional) ...

But I'll leave hashing that out to #476 or other PR.  Regardless of the  certification impact, we want to be clear that silently ignoring known parameters is wrong.

[1]: https://github.com/opencontainers/runtime-spec/pull/476/files/9b8e21826cc9887f51f095604120cfbb788078b2#r65400731
[2]: https://github.com/opencontainers/runtime-spec/pull/510