### PR TITLE
config: Add consoleSize to process

### DIFF
--- a/config.md
+++ b/config.md
@@ -95,6 +95,9 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
 **`process`** (object, REQUIRED) configures the container process.
 
 * **`terminal`** (bool, OPTIONAL) specifies whether you want a terminal attached to that process, defaults to false.
+* **`consoleSize`** (object, OPTIONAL) specifies the console size of the terminal if attached, containing the following properties:
+  * **`height`** (uint, REQUIRED)
+  * **`width`** (uint, REQUIRED)
 * **`cwd`** (string, REQUIRED) is the working directory that will be set for the executable.
   This value MUST be an absolute path.
 * **`env`** (array of strings, OPTIONAL) contains a list of variables that will be set in the process's environment prior to execution.
@@ -139,6 +142,10 @@ _Note: For Solaris, uid and gid specify the uid and gid of the process inside th
 ```json
 "process": {
     "terminal": true,
+    "consoleSize": {
+        "height": 25,
+        "width": 80
+    },
     "user": {
         "uid": 1,
         "gid": 1,
@@ -174,6 +181,10 @@ _Note: For Solaris, uid and gid specify the uid and gid of the process inside th
 ```json
 "process": {
     "terminal": true,
+    "consoleSize": {
+        "height": 25,
+        "width": 80
+    },
     "user": {
         "uid": 1,
         "gid": 1,

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -31,6 +31,8 @@ type Spec struct {
 type Process struct {
 	// Terminal creates an interactive terminal for the container.
 	Terminal bool `json:"terminal,omitempty"`
+	// ConsoleSize specifies the size of the console.
+	ConsoleSize Box `json:"consoleSize,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
@@ -50,6 +52,14 @@ type Process struct {
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
+}
+
+// Box specifies dimensions of a rectangle. Used for specifying the size of a console.
+type Box struct {
+	// Height is the vertical dimension of a box.
+	Height uint `json:"height"`
+	// Width is the horizontal dimension of a box.
+	Width uint `json:"width"`
 }
 
 // User specifies specific user (and group) information for the container process.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Extracting pieces from the proof of concept PR for Windows OCI support at https://github.com/opencontainers/runtime-spec/pull/504. This adds the `consoleSize` platform specific field to the `Process` structure.