### PR TITLE
Platform annotations on `Process` struct

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -43,10 +43,9 @@ type Process struct {
 	// Capabilities are Linux capabilities that are kept for the container.
 	Capabilities []string `json:"capabilities,omitempty" platform:"linux"`
 	// Rlimits specifies rlimit options to apply to the process.
-	Rlimits []Rlimit `json:"rlimits,omitempty"`
+	Rlimits []Rlimit `json:"rlimits,omitempty" platform:"linux"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
-	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
-
+	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
 	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Extracting pieces from the proof of concept PR for Windows OCI support at https://github.com/opencontainers/runtime-spec/pull/504. This PR tidies up the `Process` structure by putting annotations for platform support on `Capabilities`, `Rlimits` and `NoNewPrivileges`, none of which are used on `Windows`. In addition, it removes what appears to be an erroneous blank line that appeared to serve no purpose.

Note I'm assuming (probably incorrectly :innocent:) , that `Rlimits` and `NoNewPrivileges` are also relevant on `Solaris` too, but I'm not sure. If that is incorrect, I will update the PR to remove the `solaris` annotation.