### PR TITLE
Windows: User struct changes

### DIFF
--- a/config.md
+++ b/config.md
@@ -186,7 +186,31 @@ _Note: For Solaris, uid and gid specify the uid and gid of the process inside th
     "cwd": "/root",
     "args": [
         "/usr/bin/bash"
+    ]
+}
+```
+
+#### Windows User
+
+For Windows based systems the user structure has the following fields:
+
+* **`username`** (string, optional) specifies the user name for the process.
+
+### Example (Windows)
+
+```json
+"process": {
+    "terminal": true,
+    "user": {
+        "username": "containeradministrator"
+    },
+    "env": [
+        "VARIABLE=1"
     ],
+    "cwd": "c:\\foo",
+    "args": [
+        "someapp.exe",
+    ]
 }
 ```
 

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -53,8 +53,7 @@ type Process struct {
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// User specifies Linux/Solaris specific user and group information
-// for the container process.
+// User specifies specific user (and group) information for the container process.
 type User struct {
 	// UID is the user id. (this field is platform dependent)
 	UID uint32 `json:"uid" platform:"linux,solaris"`
@@ -62,6 +61,8 @@ type User struct {
 	GID uint32 `json:"gid" platform:"linux,solaris"`
 	// AdditionalGids are additional group ids set for the container's process. (this field is platform dependent)
 	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
+	// Username is the user name. (this field is platform dependent)
+	Username string `json:"username,omitempty" platform:"windows"`
 }
 
 // Root contains information about the container's root filesystem on the host.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Extracting pieces from the proof of concept PR for Windows OCI support at #504. This PR modified the `User` struct by fixing the description, adding a Windows-specific `user` field, and updating the documentation to include the changes, plus provide a sample JSON in the context of the `Process` structure.