### PR TITLE
Aggressive namespacing

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -43,7 +43,7 @@ type Process struct {
 	// Capabilities are Linux capabilities that are kept for the container.
 	Capabilities []string `json:"capabilities,omitempty" platform:"linux"`
 	// Rlimits specifies rlimit options to apply to the process.
-	Rlimits []Rlimit `json:"rlimits,omitempty" platform:"linux"`
+	Rlimits []LinuxRlimit `json:"rlimits,omitempty" platform:"linux"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
 	// ApparmorProfile specifies the apparmor profile for the container.
@@ -116,24 +116,24 @@ type Hooks struct {
 // Linux contains platform specific configuration for Linux based containers.
 type Linux struct {
 	// UIDMapping specifies user mappings for supporting user namespaces on Linux.
-	UIDMappings []IDMapping `json:"uidMappings,omitempty"`
+	UIDMappings []LinuxIDMapping `json:"uidMappings,omitempty"`
 	// GIDMapping specifies group mappings for supporting user namespaces on Linux.
-	GIDMappings []IDMapping `json:"gidMappings,omitempty"`
+	GIDMappings []LinuxIDMapping `json:"gidMappings,omitempty"`
 	// Sysctl are a set of key value pairs that are set for the container on start
 	Sysctl map[string]string `json:"sysctl,omitempty"`
 	// Resources contain cgroup information for handling resource constraints
 	// for the container
-	Resources *Resources `json:"resources,omitempty"`
+	Resources *LinuxResources `json:"resources,omitempty"`
 	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
 	// The path is expected to be relative to the cgroups mountpoint.
 	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
 	CgroupsPath *string `json:"cgroupsPath,omitempty"`
 	// Namespaces contains the namespaces that are created and/or joined by the container
-	Namespaces []Namespace `json:"namespaces,omitempty"`
+	Namespaces []LinuxNamespace `json:"namespaces,omitempty"`
 	// Devices are a list of device nodes that are created for the container
-	Devices []Device `json:"devices,omitempty"`
+	Devices []LinuxDevice `json:"devices,omitempty"`
 	// Seccomp specifies the seccomp security settings for the container.
-	Seccomp *Seccomp `json:"seccomp,omitempty"`
+	Seccomp *LinuxSeccomp `json:"seccomp,omitempty"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container.
 	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
 	// MaskedPaths masks over the provided paths inside the container.
@@ -144,21 +144,21 @@ type Linux struct {
 	MountLabel string `json:"mountLabel,omitempty"`
 }
 
-// Namespace is the configuration for a Linux namespace
-type Namespace struct {
+// LinuxNamespace is the configuration for a Linux namespace
+type LinuxNamespace struct {
 	// Type is the type of Linux namespace
-	Type NamespaceType `json:"type"`
+	Type LinuxNamespaceType `json:"type"`
 	// Path is a path to an existing namespace persisted on disk that can be joined
 	// and is of the same type
 	Path string `json:"path,omitempty"`
 }
 
-// NamespaceType is one of the Linux namespaces
-type NamespaceType string
+// LinuxNamespaceType is one of the Linux namespaces
+type LinuxNamespaceType string
 
 const (
 	// PIDNamespace for isolating process IDs
-	PIDNamespace NamespaceType = "pid"
+	PIDNamespace LinuxNamespaceType = "pid"
 	// NetworkNamespace for isolating network devices, stacks, ports, etc
 	NetworkNamespace = "network"
 	// MountNamespace for isolating mount points
@@ -173,8 +173,8 @@ const (
 	CgroupNamespace = "cgroup"
 )
 
-// IDMapping specifies UID/GID mappings
-type IDMapping struct {
+// LinuxIDMapping specifies UID/GID mappings
+type LinuxIDMapping struct {
 	// HostID is the UID/GID of the host user or group
 	HostID uint32 `json:"hostID"`
 	// ContainerID is the UID/GID of the container's user or group
@@ -183,8 +183,8 @@ type IDMapping struct {
 	Size uint32 `json:"size"`
 }
 
-// Rlimit type and restrictions
-type Rlimit struct {
+// LinuxRlimit type and restrictions
+type LinuxRlimit struct {
 	// Type of the rlimit to set
 	Type string `json:"type"`
 	// Hard is the hard limit for the specified type
@@ -193,66 +193,66 @@ type Rlimit struct {
 	Soft uint64 `json:"soft"`
 }
 
-// HugepageLimit structure corresponds to limiting kernel hugepages
-type HugepageLimit struct {
+// LinuxHugepageLimit structure corresponds to limiting kernel hugepages
+type LinuxHugepageLimit struct {
 	// Pagesize is the hugepage size
 	Pagesize *string `json:"pageSize,omitempty"`
 	// Limit is the limit of "hugepagesize" hugetlb usage
 	Limit *uint64 `json:"limit,omitempty"`
 }
 
-// InterfacePriority for network interfaces
-type InterfacePriority struct {
+// LinuxInterfacePriority for network interfaces
+type LinuxInterfacePriority struct {
 	// Name is the name of the network interface
 	Name string `json:"name"`
 	// Priority for the interface
 	Priority uint32 `json:"priority"`
 }
 
-// blockIODevice holds major:minor format supported in blkio cgroup
-type blockIODevice struct {
+// linuxBlockIODevice holds major:minor format supported in blkio cgroup
+type linuxBlockIODevice struct {
 	// Major is the device's major number.
 	Major int64 `json:"major"`
 	// Minor is the device's minor number.
 	Minor int64 `json:"minor"`
 }
 
-// WeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
-type WeightDevice struct {
-	blockIODevice
+// LinuxWeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
+type LinuxWeightDevice struct {
+	linuxBlockIODevice
 	// Weight is the bandwidth rate for the device, range is from 10 to 1000
 	Weight *uint16 `json:"weight,omitempty"`
 	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
 	LeafWeight *uint16 `json:"leafWeight,omitempty"`
 }
 
-// ThrottleDevice struct holds a `major:minor rate_per_second` pair
-type ThrottleDevice struct {
-	blockIODevice
+// LinuxThrottleDevice struct holds a `major:minor rate_per_second` pair
+type LinuxThrottleDevice struct {
+	linuxBlockIODevice
 	// Rate is the IO rate limit per cgroup per device
 	Rate *uint64 `json:"rate,omitempty"`
 }
 
-// BlockIO for Linux cgroup 'blkio' resource management
-type BlockIO struct {
+// LinuxBlockIO for Linux cgroup 'blkio' resource management
+type LinuxBlockIO struct {
 	// Specifies per cgroup weight, range is from 10 to 1000
 	Weight *uint16 `json:"blkioWeight,omitempty"`
 	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
 	LeafWeight *uint16 `json:"blkioLeafWeight,omitempty"`
 	// Weight per cgroup per device, can override BlkioWeight
-	WeightDevice []WeightDevice `json:"blkioWeightDevice,omitempty"`
+	WeightDevice []LinuxWeightDevice `json:"blkioWeightDevice,omitempty"`
 	// IO read rate limit per cgroup per device, bytes per second
-	ThrottleReadBpsDevice []ThrottleDevice `json:"blkioThrottleReadBpsDevice,omitempty"`
+	ThrottleReadBpsDevice []LinuxThrottleDevice `json:"blkioThrottleReadBpsDevice,omitempty"`
 	// IO write rate limit per cgroup per device, bytes per second
-	ThrottleWriteBpsDevice []ThrottleDevice `json:"blkioThrottleWriteBpsDevice,omitempty"`
+	ThrottleWriteBpsDevice []LinuxThrottleDevice `json:"blkioThrottleWriteBpsDevice,omitempty"`
 	// IO read rate limit per cgroup per device, IO per second
-	ThrottleReadIOPSDevice []ThrottleDevice `json:"blkioThrottleReadIOPSDevice,omitempty"`
+	ThrottleReadIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleReadIOPSDevice,omitempty"`
 	// IO write rate limit per cgroup per device, IO per second
-	ThrottleWriteIOPSDevice []ThrottleDevice `json:"blkioThrottleWriteIOPSDevice,omitempty"`
+	ThrottleWriteIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleWriteIOPSDevice,omitempty"`
 }
 
-// Memory for Linux cgroup 'memory' resource management
-type Memory struct {
+// LinuxMemory for Linux cgroup 'memory' resource management
+type LinuxMemory struct {
 	// Memory limit (in bytes).
 	Limit *uint64 `json:"limit,omitempty"`
 	// Memory reservation or soft_limit (in bytes).
@@ -267,8 +267,8 @@ type Memory struct {
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
 
-// CPU for Linux cgroup 'cpu' resource management
-type CPU struct {
+// LinuxCPU for Linux cgroup 'cpu' resource management
+type LinuxCPU struct {
 	// CPU shares (relative weight (ratio) vs. other cgroups with cpu shares).
 	Shares *uint64 `json:"shares,omitempty"`
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
@@ -285,44 +285,44 @@ type CPU struct {
 	Mems *string `json:"mems,omitempty"`
 }
 
-// Pids for Linux cgroup 'pids' resource management (Linux 4.3)
-type Pids struct {
+// LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3)
+type LinuxPids struct {
 	// Maximum number of PIDs. Default is "no limit".
 	Limit *int64 `json:"limit,omitempty"`
 }
 
-// Network identification and priority configuration
-type Network struct {
+// LinuxNetwork identification and priority configuration
+type LinuxNetwork struct {
 	// Set class identifier for container's network packets
 	ClassID *uint32 `json:"classID,omitempty"`
 	// Set priority of network traffic for container
-	Priorities []InterfacePriority `json:"priorities,omitempty"`
+	Priorities []LinuxInterfacePriority `json:"priorities,omitempty"`
 }
 
-// Resources has container runtime resource constraints
-type Resources struct {
+// LinuxResources has container runtime resource constraints
+type LinuxResources struct {
 	// Devices configures the device whitelist.
-	Devices []DeviceCgroup `json:"devices,omitempty"`
+	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Specify an oom_score_adj for the container.
 	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
 	// Memory restriction configuration
-	Memory *Memory `json:"memory,omitempty"`
+	Memory *LinuxMemory `json:"memory,omitempty"`
 	// CPU resource restriction configuration
-	CPU *CPU `json:"cpu,omitempty"`
+	CPU *LinuxCPU `json:"cpu,omitempty"`
 	// Task resource restriction configuration.
-	Pids *Pids `json:"pids,omitempty"`
+	Pids *LinuxPids `json:"pids,omitempty"`
 	// BlockIO restriction configuration
-	BlockIO *BlockIO `json:"blockIO,omitempty"`
+	BlockIO *LinuxBlockIO `json:"blockIO,omitempty"`
 	// Hugetlb limit (in bytes)
-	HugepageLimits []HugepageLimit `json:"hugepageLimits,omitempty"`
+	HugepageLimits []LinuxHugepageLimit `json:"hugepageLimits,omitempty"`
 	// Network restriction configuration
-	Network *Network `json:"network,omitempty"`
+	Network *LinuxNetwork `json:"network,omitempty"`
 }
 
-// Device represents the mknod information for a Linux special device file
-type Device struct {
+// LinuxDevice represents the mknod information for a Linux special device file
+type LinuxDevice struct {
 	// Path to the device.
 	Path string `json:"path"`
 	// Device type, block, char, etc.
@@ -339,8 +339,8 @@ type Device struct {
 	GID *uint32 `json:"gid,omitempty"`
 }
 
-// DeviceCgroup represents a device rule for the whitelist controller
-type DeviceCgroup struct {
+// LinuxDeviceCgroup represents a device rule for the whitelist controller
+type LinuxDeviceCgroup struct {
 	// Allow or deny
 	Allow bool `json:"allow"`
 	// Device type, block, char, etc.
@@ -353,11 +353,11 @@ type DeviceCgroup struct {
 	Access *string `json:"access,omitempty"`
 }
 
-// Seccomp represents syscall restrictions
-type Seccomp struct {
-	DefaultAction Action    `json:"defaultAction"`
-	Architectures []Arch    `json:"architectures"`
-	Syscalls      []Syscall `json:"syscalls,omitempty"`
+// LinuxSeccomp represents syscall restrictions
+type LinuxSeccomp struct {
+	DefaultAction LinuxSeccompAction `json:"defaultAction"`
+	Architectures []Arch             `json:"architectures"`
+	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
 }
 
 // Solaris contains platform specific configuration for Solaris application containers.
@@ -369,26 +369,26 @@ type Solaris struct {
 	// The maximum amount of shared memory allowed for this container.
 	MaxShmMemory string `json:"maxShmMemory,omitempty"`
 	// Specification for automatic creation of network resources for this container.
-	Anet []Anet `json:"anet,omitempty"`
+	Anet []SolarisAnet `json:"anet,omitempty"`
 	// Set limit on the amount of CPU time that can be used by container.
-	CappedCPU *CappedCPU `json:"cappedCPU,omitempty"`
+	CappedCPU *SolarisCappedCPU `json:"cappedCPU,omitempty"`
 	// The physical and swap caps on the memory that can be used by this container.
-	CappedMemory *CappedMemory `json:"cappedMemory,omitempty"`
+	CappedMemory *SolarisCappedMemory `json:"cappedMemory,omitempty"`
 }
 
-// CappedCPU allows users to set limit on the amount of CPU time that can be used by container.
-type CappedCPU struct {
+// SolarisCappedCPU allows users to set limit on the amount of CPU time that can be used by container.
+type SolarisCappedCPU struct {
 	Ncpus string `json:"ncpus,omitempty"`
 }
 
-// CappedMemory allows users to set the physical and swap caps on the memory that can be used by this container.
-type CappedMemory struct {
+// SolarisCappedMemory allows users to set the physical and swap caps on the memory that can be used by this container.
+type SolarisCappedMemory struct {
 	Physical string `json:"physical,omitempty"`
 	Swap     string `json:"swap,omitempty"`
 }
 
-// Anet provides the specification for automatic creation of network resources for this container.
-type Anet struct {
+// SolarisAnet provides the specification for automatic creation of network resources for this container.
+type SolarisAnet struct {
 	// Specify a name for the automatically created VNIC datalink.
 	Linkname string `json:"linkname,omitempty"`
 	// Specify the link over which the VNIC will be created.
@@ -429,43 +429,43 @@ const (
 	ArchS390X       Arch = "SCMP_ARCH_S390X"
 )
 
-// Action taken upon Seccomp rule match
-type Action string
+// LinuxSeccompAction taken upon Seccomp rule match
+type LinuxSeccompAction string
 
 // Define actions for Seccomp rules
 const (
-	ActKill  Action = "SCMP_ACT_KILL"
-	ActTrap  Action = "SCMP_ACT_TRAP"
-	ActErrno Action = "SCMP_ACT_ERRNO"
-	ActTrace Action = "SCMP_ACT_TRACE"
-	ActAllow Action = "SCMP_ACT_ALLOW"
+	ActKill  LinuxSeccompAction = "SCMP_ACT_KILL"
+	ActTrap  LinuxSeccompAction = "SCMP_ACT_TRAP"
+	ActErrno LinuxSeccompAction = "SCMP_ACT_ERRNO"
+	ActTrace LinuxSeccompAction = "SCMP_ACT_TRACE"
+	ActAllow LinuxSeccompAction = "SCMP_ACT_ALLOW"
 )
 
-// Operator used to match syscall arguments in Seccomp
-type Operator string
+// LinuxOperatorOperator used to match syscall arguments in Seccomp
+type LinuxSeccompOperator string
 
 // Define operators for syscall arguments in Seccomp
 const (
-	OpNotEqual     Operator = "SCMP_CMP_NE"
-	OpLessThan     Operator = "SCMP_CMP_LT"
-	OpLessEqual    Operator = "SCMP_CMP_LE"
-	OpEqualTo      Operator = "SCMP_CMP_EQ"
-	OpGreaterEqual Operator = "SCMP_CMP_GE"
-	OpGreaterThan  Operator = "SCMP_CMP_GT"
-	OpMaskedEqual  Operator = "SCMP_CMP_MASKED_EQ"
+	OpNotEqual     LinuxSeccompOperator = "SCMP_CMP_NE"
+	OpLessThan     LinuxSeccompOperator = "SCMP_CMP_LT"
+	OpLessEqual    LinuxSeccompOperator = "SCMP_CMP_LE"
+	OpEqualTo      LinuxSeccompOperator = "SCMP_CMP_EQ"
+	OpGreaterEqual LinuxSeccompOperator = "SCMP_CMP_GE"
+	OpGreaterThan  LinuxSeccompOperator = "SCMP_CMP_GT"
+	OpMaskedEqual  LinuxSeccompOperator = "SCMP_CMP_MASKED_EQ"
 )
 
 // Arg used for matching specific syscall arguments in Seccomp
-type Arg struct {
-	Index    uint     `json:"index"`
-	Value    uint64   `json:"value"`
-	ValueTwo uint64   `json:"valueTwo"`
-	Op       Operator `json:"op"`
+type LinuxSeccompArg struct {
+	Index    uint                 `json:"index"`
+	Value    uint64               `json:"value"`
+	ValueTwo uint64               `json:"valueTwo"`
+	Op       LinuxSeccompOperator `json:"op"`
 }
 
-// Syscall is used to match a syscall in Seccomp
-type Syscall struct {
-	Name   string `json:"name"`
-	Action Action `json:"action"`
-	Args   []Arg  `json:"args,omitempty"`
+// LinuxSyscall is used to match a syscall in Seccomp
+type LinuxSyscall struct {
+	Name   string             `json:"name"`
+	Action LinuxSeccompAction `json:"action"`
+	Args   []LinuxSeccompArg  `json:"args,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@wking As per comment https://github.com/opencontainers/runtime-spec/pull/504#r67990890 on the proof of concept PR for adding Windows support to the OCI runtime spec, this does the "aggressive namespacing" for all Linux and Solaris structures. Fortunately it doesn't change any of the JSON in the documentation, but will unfortunately have a big knock-on effect to downstream consumers of `config.go` through the `specs` package.