### PR TITLE
specs-go/config: Drop "this field is platform dependent" (again)

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -61,7 +61,7 @@ type User struct {
 	GID uint32 `json:"gid" platform:"linux,solaris"`
 	// AdditionalGids are additional group ids set for the container's process.
 	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
-	// Username is the user name. (this field is platform dependent)
+	// Username is the user name.
 	Username string `json:"username,omitempty" platform:"windows"`
 }
 


### PR DESCRIPTION
We dropped these in #568 but #565 was developed in parallel and brought in a new one.