### PR TITLE
config: Link platform:"…" JSON tags with ~~protocol~~ platform slugs

### DIFF
--- a/config.md
+++ b/config.md
@@ -2,7 +2,8 @@
 
 The container's top-level directory MUST contain a configuration file called `config.json`.
 The canonical schema is defined in this document, but there is a JSON Schema in [`schema/config-schema.json`](schema/config-schema.json) and Go bindings in [`specs-go/config.go`](specs-go/config.go).
-Platform-specific configuration schema are defined in the [platform-specific documents](#platform-specific-configuration) linked below.
+[Platform](spec.md#platforms)-specific configuration schema are defined in the [platform-specific documents](#platform-specific-configuration) linked below.
+For properties that are only defined for some [platforms](spec.md#platforms), the Go property has a `platform` tag listing those protocols (e.g. `platform:"linux,solaris"`).
 
 The configuration file contains metadata necessary to implement standard operations against the container.
 This includes the process to run, environment variables to inject, sandboxing features to use, etc.

--- a/spec.md
+++ b/spec.md
@@ -3,9 +3,10 @@
 The [Open Container Initiative](http://www.opencontainers.org/) develops specifications for standards on Operating System process and application containers.
 
 Protocols defined by this specification are:
-* Linux containers: [runtime.md](runtime.md), [config.md](config.md), [config-linux.md](config-linux.md), and [runtime-linux.md](runtime-linux.md).
-* Solaris containers: [runtime.md](runtime.md), [config.md](config.md), and [config-solaris.md](config-solaris.md).
-* Windows containers: [runtime.md](runtime.md), [config.md](config.md), and [config-windows.md](config-windows.md).
+
+* `linux`: [runtime.md](runtime.md), [config.md](config.md), [config-linux.md](config-linux.md), and [runtime-linux.md](runtime-linux.md).
+* `solaris`: [runtime.md](runtime.md), [config.md](config.md), and [config-solaris.md](config-solaris.md).
+* `windows`: [runtime.md](runtime.md), [config.md](config.md), and [config-windows.md](config-windows.md).
 
 # Table of Contents
 

--- a/spec.md
+++ b/spec.md
@@ -2,7 +2,9 @@
 
 The [Open Container Initiative](http://www.opencontainers.org/) develops specifications for standards on Operating System process and application containers.
 
-Protocols defined by this specification are:
+# Platforms
+
+Platforms defined by this specification are:
 
 * `linux`: [runtime.md](runtime.md), [config.md](config.md), [config-linux.md](config-linux.md), and [runtime-linux.md](runtime-linux.md).
 * `solaris`: [runtime.md](runtime.md), [config.md](config.md), and [config-solaris.md](config-solaris.md).
@@ -28,8 +30,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 The key words "unspecified", "undefined", and "implementation-defined" are to be interpreted as described in the [rationale for the C99 standard][c99-unspecified].
 
-An implementation is not compliant for a given CPU architecture if it fails to satisfy one or more of the MUST, REQUIRED, or SHALL requirements for the protocols it implements.
-An implementation is compliant for a given CPU architecture if it satisfies all the MUST, REQUIRED, and SHALL requirements for the protocols it implements.
+An implementation is not compliant for a given CPU architecture if it fails to satisfy one or more of the MUST, REQUIRED, or SHALL requirements for the [platforms](#platforms) it implements.
+An implementation is compliant for a given CPU architecture if it satisfies all the MUST, REQUIRED, and SHALL requirements for the [platforms](#platforms) it implements.
 
 [c99-unspecified]: http://www.open-std.org/jtc1/sc22/wg14/www/C99RationaleV5.10.pdf#page=18
 [rfc2119]: http://tools.ietf.org/html/rfc2119


### PR DESCRIPTION
Spun off from [here](https://github.com/opencontainers/runtime-spec/pull/564#issuecomment-247344440).

More details on the individual pivots in the commit messages.  The
meat is the one-liner in the last commit, and the bit I'm not sure
about (also discussed in the commit message ;) is whether we want to
rename the JSON tag from `platform:"…"` to `protocol:"…"` to
consolidate around the “protocol” term used in #527 to [decouple
compliance from platforms](https://github.com/opencontainers/runtime-spec/pull/527#issuecomment-238979250).  For example, if we want to add
optional extensions (e.g. allowing Linux containers that use
namespacing but not cgroups), we could have a ‘linux’ protocol (with
the base stuff) and a ‘linux-cgroups’ protocol (with the cgroups stuff
and the base stuff).  Runtimes that implemented both would be
compliant with both ‘linux’ and ‘linux-cgroups’.
