### PR TITLE
Add support for Windows based containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Table of Contents
   - [General Configuration](config.md)
   - [Linux-specific Configuration](config-linux.md)
   - [Solaris-specific Configuration](config-solaris.md)
+  - [Windows-specific Configuration](config-windows.md)
 - [Glossary](glossary.md)
 
 In the specifications in the above table of contents, the keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119) (Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997).
@@ -30,6 +31,7 @@ An implementation is compliant for a given CPU architecture if it satisfies all 
 Protocols defined by this specification are:
 * Linux containers: [runtime.md](runtime.md), [config.md](config.md), [config-linux.md](config-linux.md), and [runtime-linux.md](runtime-linux.md).
 * Solaris containers: [runtime.md](runtime.md), [config.md](config.md), and [config-solaris.md](config-solaris.md).
+* Windows containers: [runtime.md](runtime.md), [config.md](config.md), and [config-windows.md](config-windows.md).
 
 # Use Cases
 

--- a/config-windows.md
+++ b/config-windows.md
@@ -1,0 +1,99 @@
+# Windows-specific Container Configuration
+
+This document describes the schema for the [Windows-specific section](config.md#platform-specific-configuration) of the [container configuration](config.md).
+The Windows container specification uses APIs provided by the Windows Host Compute Service (HCS) to fulfill the spec.
+
+## Resources
+
+You can configure a container's resource limits via the OPTIONAL `resources` field of the Windows configuration.
+
+### Memory
+
+`memory` is an OPTIONAL configuration for the container's memory usage.
+
+The following parameters can be specified:
+
+* **`limit`** *(uint64, OPTIONAL)* - sets limit of memory usage in bytes.
+
+* **`reservation`** *(uint64, OPTIONAL)* - sets the guaranteed minimum amount of memory for a container in bytes.
+
+#### Example
+
+```json
+    "windows": {
+        "resources": {
+            "memory": {
+                "limit": 2097152,
+                "reservation": 524288
+            }
+        }
+    }
+```
+
+### CPU
+
+`cpu` is an OPTIONAL configuration for the container's CPU usage.
+
+The following parameters can be specified:
+
+* **`count`** *(uint64, OPTIONAL)* - specifies the number of CPUs available to the container.
+
+* **`shares`** *(uint16, OPTIONAL)* - specifies the relative weight to other containers with CPU shares. The range is from 1 to 10000.
+
+* **`percent`** *(uint, OPTIONAL)* - specifies the percentage of available CPUs usable by the container.
+
+#### Example
+
+```json
+    "windows": {
+        "resources": {
+            "cpu": {
+                "percent": 50
+            }
+        }
+    }
+```
+
+### Storage
+
+`storage` is an OPTIONAL configuration for the container's storage usage.
+
+The following parameters can be specified:
+
+* **`iops`** *(uint64, OPTIONAL)* - specifies the maximum IO operations per second for the system drive of the container.
+
+* **`bps`** *(uint64, OPTIONAL)* - specifies the maximum bytes per second for the system drive of the container.
+
+* **`sandboxSize`** *(uint64, OPTIONAL)* - specifies the minimum size of the system drive in bytes.
+
+#### Example
+
+```json
+    "windows": {
+        "resources": {
+            "storage": {
+                "iops": 50
+            }
+        }
+    }
+```
+
+### Network
+
+`network` is an OPTIONAL configuration for the container's network usage.
+
+The following parameters can be specified:
+
+* **`egressBandwidth`** *(uint64, OPTIONAL)* - specified the maximum egress bandwidth in bytes per second for the container.
+
+#### Example
+
+```json
+    "windows": {
+        "resources": {
+            "network": {
+                "egressBandwidth": 1048577
+            }
+        }
+   }
+```

--- a/config.md
+++ b/config.md
@@ -256,6 +256,8 @@ For Windows based systems the user structure has the following fields:
   This SHOULD only be set if **`platform.os`** is `linux`.
 * **`solaris`** (object, optional) [Solaris-specific configuration](config-solaris.md).
   This SHOULD only be set if **`platform.os`** is `solaris`.
+* **`windows`** (object, optional) [Windows-specific configuration](config-windows.md).
+  This SHOULD only be set if **`platform.os`** is `windows`.
 
 ### Example (Linux)
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -9,6 +9,7 @@ The layout of the files is as follows:
 * [config-schema.json](config-schema.json) - the primary entrypoint for the [configuration](../config.md) schema
 * [config-linux.json](config-linux.json) - the [Linux-specific configuration sub-structure](../config-linux.md)
 * [config-solaris.json](config-solaris.json) - the [Solaris-specific configuration sub-structure](../config-solaris.md)
+* [config-windows.json](config-windows.json) - the [Windows-specific configuration sub-structure](../config-windows.md)
 * [state-schema.json](state-schema.json) - the primary entrypoint for the [state JSON](../runtime.md#state) schema
 * [defs.json](defs.json) - definitions for general types
 * [defs-linux.json](defs-linux.json) - definitions for Linux-specific types

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -161,6 +161,9 @@
         },
         "solaris": {
             "$ref": "config-solaris.json#/solaris"
+        },
+        "windows": {
+            "$ref": "config-windows.json#/windows"
         }
     },
     "required": [

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -1,0 +1,75 @@
+{
+    "windows": {
+        "description": "Windows platform-specific configurations",
+        "id": "https://opencontainers.org/schema/bundle/windows",
+        "type": "object",
+        "properties": {
+            "resources": {
+                "id": "https://opencontainers.org/schema/bundle/windows/resources",
+                "type": "object",
+                "properties": {
+                    "memory": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/resources/memory",
+                        "type": "object",
+                        "properties": {
+                            "limit": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/memory/limit",
+                                "$ref": "defs.json#/definitions/uint64Pointer"
+                            },
+                            "reservation": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/memory/reservation",
+                                "$ref": "defs.json#/definitions/uint64Pointer"
+                            }
+                        }
+                    },
+                    "cpu": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu",
+                        "type": "object",
+                        "properties": {
+                            "count": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/count",
+                                "$ref": "defs.json#/definitions/uint64Pointer"
+                            },
+                            "shares": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/shares",
+                                "$ref": "defs-windows.json#/definitions/cpuSharesPointer"
+                            },
+                            "percent": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/percent",
+                                "$ref": "defs.json#/definitions/percentPointer"
+                            }
+                        }
+                    },
+                    "storage": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/resources/storage",
+                        "type": "object",
+                        "properties": {
+                            "iops": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/iops",
+                                "$ref": "defs.json#/definitions/uint64Pointer"
+                            },
+                            "bps": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/bps",
+                                "$ref": "defs.json#/definitions/uint64Pointer"
+                            },
+                            "sandboxSize": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/sandboxSize",
+                                "$ref": "defs.json#/definitions/uint64Pointer"
+                            }
+                        }
+                    },
+                    "network": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/resources/network",
+                        "type": "object",
+                        "properties": {
+                            "egressBandwidth": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/network/egressBandwidth",
+                                "$ref": "defs.json#/definitions/uint64Pointer"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/defs-windows.json
+++ b/schema/defs-windows.json
@@ -1,0 +1,20 @@
+{
+    "definitions": {
+        "cpuShares": {
+            "description": "Relative weight to other containers with CPU Shares defined",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10000
+        },
+        "cpuSharesPointer": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/cpuShares"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        }
+    }
+}

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -41,6 +41,11 @@
             "minimum": 0,
             "maximum": 18446744073709552000
         },
+        "percent": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+        },
         "intPointer": {
             "oneOf": [
                 {
@@ -65,6 +70,16 @@
             "oneOf": [
                 {
                     "$ref": "#/definitions/uint64"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "percentPointer": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/percent"
                 },
                 {
                     "type": "null"

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -25,6 +25,8 @@ type Spec struct {
 	Linux *Linux `json:"linux,omitempty" platform:"linux"`
 	// Solaris is platform specific configuration for Solaris containers.
 	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
+	// Windows is platform specific configuration for Windows based containers, including Hyper-V containers.
+	Windows *Windows `json:"windows,omitempty" platform:"windows"`
 }
 
 // Process contains information to start a specific application inside the container.
@@ -404,6 +406,58 @@ type Anet struct {
 	Linkprotection string `json:"linkProtection,omitempty"`
 	// Set the VNIC's macAddress
 	Macaddress string `json:"macAddress,omitempty"`
+}
+
+// Windows defines the runtime configuration for Windows based containers, including Hyper-V containers.
+type Windows struct {
+	// Resources contains information for handling resource constraints for the container.
+	Resources *WindowsResources `json:"resources,omitempty"`
+}
+
+// WindowsResources has container runtime resource constraints for containers running on Windows.
+type WindowsResources struct {
+	// Memory restriction configuration.
+	Memory *WindowsMemoryResources `json:"memory,omitempty"`
+	// CPU resource restriction configuration.
+	CPU *WindowsCPUResources `json:"cpu,omitempty"`
+	// Storage restriction configuration.
+	Storage *WindowsStorageResources `json:"storage,omitempty"`
+	// Network restriction configuration.
+	Network *WindowsNetworkResources `json:"network,omitempty"`
+}
+
+// WindowsMemoryResources contains memory resource management settings.
+type WindowsMemoryResources struct {
+	// Memory limit in bytes.
+	Limit *uint64 `json:"limit,omitempty"`
+	// Memory reservation in bytes.
+	Reservation *uint64 `json:"reservation,omitempty"`
+}
+
+// WindowsCPUResources contains CPU resource management settings.
+type WindowsCPUResources struct {
+	// Number of CPUs available to the container.
+	Count *uint64 `json:"count,omitempty"`
+	// CPU shares (relative weight to other containers with cpu shares). Range is from 1 to 10000.
+	Shares *uint16 `json:"shares,omitempty"`
+	// Percent of available CPUs usable by the container.
+	Percent *uint8 `json:"percent,omitempty"`
+}
+
+// WindowsStorageResources contains storage resource management settings.
+type WindowsStorageResources struct {
+	// Specifies maximum Iops for the system drive.
+	Iops *uint64 `json:"iops,omitempty"`
+	// Specifies maximum bytes per second for the system drive.
+	Bps *uint64 `json:"bps,omitempty"`
+	// Sandbox size specifies the minimum size of the system drive in bytes.
+	SandboxSize *uint64 `json:"sandboxSize,omitempty"`
+}
+
+// WindowsNetworkResources contains network resource management settings.
+type WindowsNetworkResources struct {
+	// EgressBandwidth is the maximum egress bandwidth in bytes per second.
+	EgressBandwidth *uint64 `json:"egressBandwidth,omitempty"`
 }
 
 // Arch used for additional architectures


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This adds Windows support to the OCI runtime-spec: code, JSON schema and markdown documentation. Note that the support has been added using 'aggressive namespacing', the matching changes of which for Linux and Solaris being currently out for review in https://github.com/opencontainers/runtime-spec/pull/567.

This is a formal follow-on the the previous proof-of-concept PR to add support for Windows, https://github.com/opencontainers/runtime-spec/pull/504
