### PR TITLE
config-linux: Require no cgroup tweaks when linux.resources is unset

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -172,9 +172,9 @@ The Spec does not include naming schema for cgroups.
 The Spec does not support per-controller paths for the reasons discussed in the [cgroupv2 documentation][cgroup-v2].
 The cgroups will be created if they don't exist.
 
-You can configure a container's cgroups via the `resources` field of the Linux configuration.
-Do not specify `resources` unless limits have to be updated.
-For example, to run a new process in an existing container without updating limits, `resources` need not be specified.
+You can configure a container's cgroups via the OPTIONAL `resources` property.
+When `resources` is empty or unset, the runtime MUST NOT alter properties of existing cgroups.
+When a subset of `resources` is empty or unset, the runtime MUST NOT alter the properties of existing cgroups covered by that subset.
 
 A runtime MUST at least use the minimum set of cgroup controllers required to fulfill the `resources` settings.
 However, a runtime MAY attach the container process to additional cgroup controllers supported by the system.


### PR DESCRIPTION
Or empty.  Using:

    "resources": {}

should mean the same thing as:

    "resources": null

or as not specifying `resources` at all, so we can drop the “Do not specify” requirement.

It's good to be clear about what leaving the properties unset/empty means though.  I'd prefer a [config-wide rule about explosing platform defaults for empty/unset properties][1], but if that is too much to bite off I expect we can at least do that for cases where a new container is joining an existing cgroup.  With the wording I'm proposing here, runtimes would still be free to clobber settings on new cgroups in an unspecified manner as they see fit.

Spun off from [the Windows discussion][2].  #540 is also in-flight in the no-tweaking space, although it is orthogonal to this change.

[1]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/DWdystx5X3A
[2]: https://github.com/opencontainers/runtime-spec/pull/573#r79297553