### PR TITLE
[Runtime] Fix formatting and clarify status values

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -18,8 +18,8 @@ The value MAY be one of:
     * `created`: the container has been created but the user-specified code has not yet been executed
     * `running`: the container has been created and the user-specified code is running
     * `stopped`: the container has been created and the user-specified code has been executed but is no longer running
+    * Additional `status` values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 
-  Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`**: (int) is the ID of the container process, as seen by the host.
 * **`bundlePath`**: (string) is the absolute path to the container's bundle directory.
 This is provided so that consumers can find the container's configuration and root filesystem on the host.


### PR DESCRIPTION
When reading the PDF, this line is not clear if it applies just to status or to all state values

Signed-off-by: Rob Dolin robdolin@microsoft.com
