### PR TITLE
specs-go/config: Make consoleSize a pointer

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -32,7 +32,7 @@ type Process struct {
 	// Terminal creates an interactive terminal for the container.
 	Terminal bool `json:"terminal,omitempty"`
 	// ConsoleSize specifies the size of the console.
-	ConsoleSize Box `json:"consoleSize,omitempty"`
+	ConsoleSize *Box `json:"consoleSize,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.


### PR DESCRIPTION
Otherwise we it will never be omitted when empty.  This is the same case as 6323157 (specs-go/config: Make Linux and Solaris omitempty (again), 2016-06-17, #502).