### PR TITLE
config-linux: add maskedDirPaths

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -562,6 +562,18 @@ Its value is either slave, private, or shared.
     ]
 ```
 
+## Masked Dir Paths
+
+`maskedDirPaths` is similar to `maskedPaths` but for directories rather than files.
+
+###### Example
+
+```json
+    "maskedPaths": [
+        "/sys/firmware"
+    ]
+```
+
 ## Readonly Paths
 
 `readonlyPaths` will set the provided paths as readonly inside the container.

--- a/config.md
+++ b/config.md
@@ -718,6 +718,9 @@ Here is a full example `config.json` for reference.
             "/proc/timer_stats",
             "/proc/sched_debug"
         ],
+        "maskedDirPaths": [
+            "/sys/firmware",
+        ],
         "readonlyPaths": [
             "/proc/asound",
             "/proc/bus",

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -342,6 +342,10 @@
                 "id": "https://opencontainers.org/schema/bundle/linux/maskedPaths",
                 "$ref": "defs.json#/definitions/ArrayOfStrings"
             },
+            "maskedDirPaths": {
+                "id": "https://opencontainers.org/schema/bundle/linux/maskedDirPaths",
+                "$ref": "defs.json#/definitions/ArrayOfStrings"
+            },
             "readonlyPaths": {
                 "id": "https://opencontainers.org/schema/bundle/linux/readonlyPaths",
                 "$ref": "defs.json#/definitions/ArrayOfStrings"

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -148,6 +148,8 @@ type Linux struct {
 	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
 	// MaskedPaths masks over the provided paths inside the container.
 	MaskedPaths []string `json:"maskedPaths,omitempty"`
+	// MaskedDirPaths masks over the provided directory paths inside the container.
+	MaskedDirPaths []string `json:"maskedDirPaths,omitempty"`
 	// ReadonlyPaths sets the provided paths as RO inside the container.
 	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
 	// MountLabel specifies the selinux context for the mounts in the container.


### PR DESCRIPTION
maskedDirPaths is used to mask directories rather than files.
For example, the /sys/firmware directory should be masked because it can contain some sensitive files (https://github.com/docker/docker/pull/26618):
  - /sys/firmware/acpi/tables/{SLIC,MSDM}: Windows license information:
  - /sys/firmware/ibft/target0/chap-secret: iSCSI CHAP secret


IMO the issue should be fixed but no need to get this PR in v1.0

runc PR: https://github.com/opencontainers/runc/pull/1068

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>