### PR TITLE
config: Convert process.rlimits from an array to an object

### DIFF
--- a/config.md
+++ b/config.md
@@ -107,13 +107,21 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
   The executable is the first element and MUST be available at the given path inside of the rootfs.
   If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
 
-For Linux-based systems the process structure supports the following process specific fields:
+For Linux and Solaris systems, the process structure supports the following process-specific fields:
+
+* **`rlimits`** (object, OPTIONAL) configures [rlimits][setrlimit.3] for the container process.
+    Valid keys are `RLIMIT_*` resources.
+    POSIX [defines several][setrlimit.3], and [Linux][setrlimit.2-linux] and [Solaris][setrlimit.2-solaris] add additional, platform-specific resources.
+    Values have the following properties:
+
+    * **`soft`** (uint64, OPTIONAL) The current limit on the resource.
+    * **`hard`** (uint64, OPTIONAL) The ceiling for soft limts going forward.
+      Only a process with appropriate privileges can raise a hard limit.
+
+For Linux-based systems, the process structure supports the following process-specific fields:
 
 * **`capabilities`** (array of strings, OPTIONAL) capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
 Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)
-* **`rlimits`** (array of rlimits, OPTIONAL) rlimits is an array of rlimits that allows setting resource limits for a process inside the container.
-The kernel enforces the `soft` limit for a resource while the `hard` limit acts as a ceiling for that value that could be set by an unprivileged process.
-Valid values for the 'type' field are the resources defined in [the man page](http://man7.org/linux/man-pages/man2/setrlimit.2.html).
 * **`apparmorProfile`** (string, OPTIONAL) apparmor profile specifies the name of the apparmor profile that will be used for the container.
 For more information about Apparmor, see [Apparmor documentation](https://wiki.ubuntu.com/AppArmor)
 * **`selinuxLabel`** (string, OPTIONAL) SELinux process label specifies the label with which the processes in a container are run.
@@ -167,9 +175,8 @@ _Note: For Solaris, uid and gid specify the uid and gid of the process inside th
         "CAP_KILL",
         "CAP_NET_BIND_SERVICE"
     ],
-    "rlimits": [
-        {
-            "type": "RLIMIT_NOFILE",
+    "rlimits": {
+        "RLIMIT_NOFILE": {
             "hard": 1024,
             "soft": 1024
         }
@@ -415,18 +422,16 @@ Here is a full example `config.json` for reference.
             "CAP_KILL",
             "CAP_NET_BIND_SERVICE"
         ],
-        "rlimits": [
-            {
-                "type": "RLIMIT_CORE",
+        "rlimits": {
+            "RLIMIT_CORE": {
                 "hard": 1024,
                 "soft": 1024
             },
-            {
-                "type": "RLIMIT_NOFILE",
+            "RLIMIT_NOFILE": {
                 "hard": 1024,
                 "soft": 1024
             }
-        ],
+        },
         "apparmorProfile": "acme_secure_profile",
         "selinuxLabel": "system_u:system_r:svirt_lxc_net_t:s0:c124,c675",
         "noNewPrivileges": true
@@ -738,6 +743,9 @@ Here is a full example `config.json` for reference.
 ```
 
 [container-namespace]: glossary.md#container-namespace
+[setrlimit.2-linux]: http://man7.org/linux/man-pages/man2/setrlimit.2.html
+[setrlimit.2-solaris]: http://docs.oracle.com/cd/E36784_01/html/E36872/setrlimit-2.html
+[setrlimit.3]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/setrlimit.html
 [go-environment]: https://golang.org/doc/install/source#environment
 [runtime-namespace]: glossary.md#runtime-namespace
 [uts-namespace]: http://man7.org/linux/man-pages/man7/namespaces.7.html

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -133,25 +133,9 @@
                 },
                 "rlimits": {
                     "id": "https://opencontainers.org/schema/bundle/linux/rlimits",
-                    "type": "array",
-                    "items": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0",
-                        "type": "object",
-                        "properties": {
-                            "hard": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/hard",
-                                "$ref": "defs.json#/definitions/uint64"
-                            },
-                            "soft": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/soft",
-                                "$ref": "defs.json#/definitions/uint64"
-                            },
-                            "type": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/type",
-                                "type": "string",
-                                "pattern": "^RLIMIT_[A-Z]+$"
-                            }
-                        }
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "defs-linux.json#/definitions/Rlimit"
                     }
                 }
             }

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -77,6 +77,17 @@
                 }
             }
         },
+        "Rlimit": {
+            "type": "object",
+            "properties": {
+                "hard": {
+                    "$ref": "defs.json#/definitions/uint64"
+                },
+                "soft": {
+                    "$ref": "defs.json#/definitions/uint64"
+                }
+            }
+        },
         "Capability": {
             "description": "Linux process permissions",
             "type": "string",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -47,7 +47,7 @@ type Process struct {
 	// Capabilities are Linux capabilities that are kept for the container.
 	Capabilities []string `json:"capabilities,omitempty" platform:"linux"`
 	// Rlimits specifies rlimit options to apply to the process.
-	Rlimits []LinuxRlimit `json:"rlimits,omitempty" platform:"linux"`
+	Rlimits map[string]LinuxRlimit `json:"rlimits,omitempty" platform:"linux,solaris"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
 	// ApparmorProfile specifies the apparmor profile for the container.
@@ -195,10 +195,8 @@ type LinuxIDMapping struct {
 	Size uint32 `json:"size"`
 }
 
-// LinuxRlimit type and restrictions
+// LinuxRlimit resource limitations
 type LinuxRlimit struct {
-	// Type of the rlimit to set
-	Type string `json:"type"`
 	// Hard is the hard limit for the specified type
 	Hard uint64 `json:"hard"`
 	// Soft is the soft limit for the specified type


### PR DESCRIPTION
Rlimits do not need either ordering or repeat entries for a single type.  While come JSON libraries preserve object key order or allow repeats, there are many JSON libraries which do not (e.g. Python and JavaScript both parse JSON objects into hash tables).  Using objects here reinforces the unimportance of ordering or repeated entries.

Also add Solaris support.  I'm not entirely clear on this, because while Solaris is POSIX-certified system and there is a Solaris man page for setrlimit, @anuthan [claims no Solaris support for rlimits](https://github.com/opencontainers/runtime-spec/pull/564#discussion_r79016149).

The `additionalProperties` object bit comes from [here](https://spacetelescope.github.io/understanding-json-schema/reference/object.html#properties), although it is not documented in [draft 4 of the JSON Schema RFC](https://tools.ietf.org/html/draft-zyp-json-schema-04).
