### PR TITLE
glossary: Make objects explicitly unordered and forbid duplicate names

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -20,6 +20,8 @@ On Linux, a leaf in the [namespace][namespaces.7] hierarchy in which the [config
 ## JSON
 
 All configuration [JSON][] MUST be encoded in [UTF-8][].
+JSON objects MUST NOT include duplicate names.
+The order of entries in JSON objects is not significant.
 
 ## Runtime
 
@@ -31,6 +33,6 @@ It reads the [configuration files](#configuration) from a [bundle](#bundle), use
 On Linux, a leaf in the [namespace][namespaces.7] hierarchy from which the [runtime](#runtime) process is executed.
 New container namespaces will be created as children of the runtime namespaces.
 
-[JSON]: http://json.org/
+[JSON]: https://tools.ietf.org/html/rfc7159
 [UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf
 [namespaces.7]: http://man7.org/linux/man-pages/man7/namespaces.7.html


### PR DESCRIPTION
Pin down our JSON definition to a particular RFC (which we can explicitly bump if neccessary), instead of referencing the floating JSON homepage.

Explicitly make objects unordered and forbid duplicate names to avoid relying on unportable behavior.  RFC 7159 is [a bit more relaxed][1]:

> The names within an object SHOULD be unique.

but [warns][1]:

> An object whose names are all unique is interoperable in the sense
> that all software implementations receiving that object will agree
> on the name-value mappings.  When the names within an object are not
> unique, the behavior of software that receives such an object is
> unpredictable.  Many implementations report the last name/value pair
> only.  Other implementations report an error or fail to parse the
> object, and some implementations report all of the name/value pairs,
> including duplicates.

The RFC also [warns about order portability][1]:

> JSON parsing libraries have been observed to differ as to whether or
> not they make the ordering of object members visible to calling
> software.  Implementations whose behavior does not depend on member
> ordering will be interoperable in the sense that they will not be
> affected by these differences.

And has some (informative?) language about [entries being unordered][2]:

> An object is an unordered collection of zero or more name/value pairs…

[1]: https://tools.ietf.org/html/rfc7159#section-4
[2]: https://tools.ietf.org/html/rfc7159#section-1