### PR TITLE
Makefile: Require Go >= 1.6 for golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test: .govet .golint .gitvalidation
 
 # `go get github.com/golang/lint/golint`
 .golint:
-ifeq ($(call ALLOWED_GO_VERSION,1.5,$(HOST_GOLANG_VERSION)),true)
+ifeq ($(call ALLOWED_GO_VERSION,1.6,$(HOST_GOLANG_VERSION)),true)
 	@which golint > /dev/null 2>/dev/null || (echo "ERROR: golint not found. Consider 'make install.tools' target" && false)
 	golint ./...
 endif
@@ -92,9 +92,9 @@ endif
 .PHONY: install.tools
 install.tools: .install.golint .install.gitvalidation
 
-# golint does not even build for <go1.5
+# golint does not even build for <go1.6
 .install.golint:
-ifeq ($(call ALLOWED_GO_VERSION,1.5,$(HOST_GOLANG_VERSION)),true)
+ifeq ($(call ALLOWED_GO_VERSION,1.6,$(HOST_GOLANG_VERSION)),true)
 	go get -u github.com/golang/lint/golint
 endif
 


### PR DESCRIPTION
golint [dropped support for Go 1.5][1].  See also opencontainers/runtime-tools#230.

[1]: https://github.com/golang/lint/commit/a428635c58fe96360e83667e2e1a8343fc292bf0