### PR TITLE
config-linux: Convert linux.namespaces from an array to an object

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -23,10 +23,9 @@ A namespace wraps a global system resource in an abstraction that makes it appea
 Changes to the global resource are visible to other processes that are members of the namespace, but are invisible to other processes.
 For more information, see [the man page](http://man7.org/linux/man-pages/man7/namespaces.7.html).
 
-Namespaces are specified as an array of entries inside the `namespaces` root field.
-The following parameters can be specified to setup namespaces:
+* **`namespaces`** (object, OPTIONAL) specifies the container namespaces.
+    Valid keys are:
 
-* **`type`** *(string, REQUIRED)* - namespace type. The following namespaces types are supported:
     * **`pid`** processes inside the container will only be able to see other processes inside the same container.
     * **`network`** the container will have its own network stack.
     * **`mount`** the container will have an isolated mount table.
@@ -35,39 +34,29 @@ The following parameters can be specified to setup namespaces:
     * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container.
     * **`cgroup`** the container will have an isolated view of the cgroup hierarchy.
 
-* **`path`** *(string, OPTIONAL)* - path to namespace file in the [runtime mount namespace](glossary.md#runtime-namespace)
+    Values have the following properties:
+
+    * **`path`** *(string, OPTIONAL)* - path to namespace file in the [runtime mount namespace](glossary.md#runtime-namespace)
 
 If a path is specified, that particular file is used to join that type of namespace.
-If a namespace type is not specified in the `namespaces` array, the container MUST inherit the [runtime namespace](glossary.md#runtime-namespace) of that type.
+If a namespace type is not specified in the `namespaces` object, the container MUST inherit the [runtime namespace](glossary.md#runtime-namespace) of that type.
 If a new namespace is not created (because the namespace type is not listed, or because it is listed with a `path`), runtimes MUST assume that the setup for that namespace has already been done and error out if the config specifies anything else related to that namespace.
 
 ###### Example
 
 ```json
-    "namespaces": [
-        {
-            "type": "pid",
+    "namespaces": {
+        "pid": {
             "path": "/proc/1234/ns/pid"
         },
-        {
-            "type": "network",
+        "network": {
             "path": "/var/run/netns/neta"
         },
-        {
-            "type": "mount"
-        },
-        {
-            "type": "ipc"
-        },
-        {
-            "type": "uts"
-        },
-        {
-            "type": "user"
-        },
-        {
-            "type": "cgroup"
-        }
+        "mount": {},
+        "ipc": {},
+        "uts": {},
+        "user": {},
+        "cgroup": {}
     ]
 ```
 

--- a/config.md
+++ b/config.md
@@ -279,11 +279,9 @@ For Windows based systems the user structure has the following fields:
         "arch": "amd64"
     },
     "linux": {
-        "namespaces": [
-          {
-            "type": "pid"
-          }
-        ]
+        "namespaces": {
+            "pid": {}
+        }
     }
 }
 ```
@@ -691,28 +689,14 @@ Here is a full example `config.json` for reference.
                 }
             ]
         },
-        "namespaces": [
-            {
-                "type": "pid"
-            },
-            {
-                "type": "network"
-            },
-            {
-                "type": "ipc"
-            },
-            {
-                "type": "uts"
-            },
-            {
-                "type": "mount"
-            },
-            {
-                "type": "user"
-            },
-            {
-                "type": "cgroup"
-            }
+        "namespaces": {
+            "pid": {},
+            "network": {},
+            "ipc": {},
+            "uts": {},
+            "mount": {},
+            "user": {},
+            "cgroup": {}
         ],
         "maskedPaths": [
             "/proc/kcore",

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -48,13 +48,29 @@
             },
             "namespaces": {
                 "id": "https://opencontainers.org/schema/bundle/linux/namespaces",
-                "type": "array",
-                "items": {
-                    "anyOf": [
-                        {
-                            "$ref": "defs-linux.json#/definitions/NamespaceReference"
-                        }
-                    ]
+                "type": "object",
+                "properties": {
+                    "cgroup": {
+                        "$ref": "defs-linux.json#/definitions/Namespace"
+                    },
+                    "ipc": {
+                        "$ref": "defs-linux.json#/definitions/Namespace"
+                    },
+                    "mount": {
+                        "$ref": "defs-linux.json#/definitions/Namespace"
+                    },
+                    "network": {
+                        "$ref": "defs-linux.json#/definitions/Namespace"
+                    },
+                    "pid": {
+                        "$ref": "defs-linux.json#/definitions/Namespace"
+                    },
+                    "user": {
+                        "$ref": "defs-linux.json#/definitions/Namespace"
+                    },
+                    "uts": {
+                        "$ref": "defs-linux.json#/definitions/Namespace"
+                    }
                 }
             },
             "resources": {

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -262,24 +262,9 @@
                 }
             }
         },
-        "NamespaceType": {
-            "type": "string",
-            "enum": [
-                "mount",
-                "pid",
-                "network",
-                "uts",
-                "ipc",
-                "user",
-                "cgroup"
-            ]
-        },
-        "NamespaceReference": {
+        "Namespace": {
             "type": "object",
             "properties": {
-                "type": {
-                    "$ref": "#/definitions/NamespaceType"
-                },
                 "path": {
                     "$ref": "defs.json#/definitions/FilePath"
                 }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -141,7 +141,7 @@ type Linux struct {
 	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
 	CgroupsPath *string `json:"cgroupsPath,omitempty"`
 	// Namespaces contains the namespaces that are created and/or joined by the container
-	Namespaces []LinuxNamespace `json:"namespaces,omitempty"`
+	Namespaces map[LinuxNamespaceType]LinuxNamespace `json:"namespaces,omitempty"`
 	// Devices are a list of device nodes that are created for the container
 	Devices []LinuxDevice `json:"devices,omitempty"`
 	// Seccomp specifies the seccomp security settings for the container.
@@ -158,8 +158,6 @@ type Linux struct {
 
 // LinuxNamespace is the configuration for a Linux namespace
 type LinuxNamespace struct {
-	// Type is the type of Linux namespace
-	Type LinuxNamespaceType `json:"type"`
 	// Path is a path to an existing namespace persisted on disk that can be joined
 	// and is of the same type
 	Path string `json:"path,omitempty"`


### PR DESCRIPTION
Namespaces do not need repeated entries and the ordering is handled by the runtime regardless of the spec ordering (e.g. in opencontainers/runC#977).  Using an object leans on the new wording from #584 to make both of those points explicit.

An alternative to #597.

I feel like we've talked this idea over before, but the only reference I could dig up was my passing mention of “probably convert the array to an object keyed by name” [here](https://github.com/opencontainers/runtime-spec/pull/275#r48071357).
