### PR TITLE
Use IO instead of io

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -337,7 +337,7 @@ The following parameters can be specified to setup the controller:
 
 #### Block IO Controller
 
-**`blockIO`** (object, OPTIONAL) represents the cgroup subsystem `blkio` which implements the block io controller.
+**`blockIO`** (object, OPTIONAL) represents the cgroup subsystem `blkio` which implements the block IO controller.
 For more information, see [the kernel cgroups documentation about blkio][cgroup-v1-blkio].
 
 The following parameters can be specified to setup the controller:

--- a/runtime-linux.md
+++ b/runtime-linux.md
@@ -8,7 +8,7 @@ Some of the file descriptors MAY be redirected to `/dev/null` even though they a
 
 ## Dev symbolic links
 
-After the container has `/proc` mounted, the following standard symlinks MUST be setup within `/dev/` for the io.
+After the container has `/proc` mounted, the following standard symlinks MUST be setup within `/dev/` for the IO.
 
 |    Source       | Destination |
 | --------------- | ----------- |


### PR DESCRIPTION
For consistency, while all other places use IO.

$ grep -rnIw IO * | wc -l
10

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>