### PR TITLE
Use rt instead of realtime

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -315,19 +315,19 @@ For more information, see [the cpusets cgroup man page][cgroup-v1-cpusets].
 
 The following parameters can be specified to setup the controller:
 
-* **`shares`** *(uint64, OPTIONAL)* - specifies a relative share of CPU time available to the tasks in a cgroup
+* **`shares`** *(uint64, OPTIONAL)* - specifies a relative share of CPU time available to the tasks in a cgroup.
 
-* **`quota`** *(uint64, OPTIONAL)* - specifies the total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by **`period`** below)
+* **`quota`** *(uint64, OPTIONAL)* - specifies the total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by **`period`** below).
 
-* **`period`** *(uint64, OPTIONAL)* - specifies a period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated (CFS scheduler only)
+* **`period`** *(uint64, OPTIONAL)* - specifies a period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated (CFS scheduler only).
 
-* **`realtimeRuntime`** *(uint64, OPTIONAL)* - specifies a period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources
+* **`rtRuntime`** *(uint64, OPTIONAL)* - specifies a period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources, it applies to realtime (RT) scheduler only).
 
-* **`realtimePeriod`** *(uint64, OPTIONAL)* - same as **`period`** but applies to realtime scheduler only
+* **`rtPeriod`** *(uint64, OPTIONAL)* - same as **`period`** but applies to realtime (RT) scheduler only.
 
-* **`cpus`** *(string, OPTIONAL)* - list of CPUs the container will run in
+* **`cpus`** *(string, OPTIONAL)* - list of CPUs the container will run in.
 
-* **`mems`** *(string, OPTIONAL)* - list of Memory Nodes the container will run in
+* **`mems`** *(string, OPTIONAL)* - list of Memory Nodes the container will run in.
 
 ###### Example
 
@@ -336,8 +336,8 @@ The following parameters can be specified to setup the controller:
         "shares": 1024,
         "quota": 1000000,
         "period": 500000,
-        "realtimeRuntime": 950000,
-        "realtimePeriod": 1000000,
+        "rtRuntime": 950000,
+        "rtPeriod": 1000000,
         "cpus": "2-3",
         "mems": "0-7"
     }

--- a/config.md
+++ b/config.md
@@ -620,8 +620,8 @@ Here is a full example `config.json` for reference.
                 "shares": 1024,
                 "quota": 1000000,
                 "period": 500000,
-                "realtimeRuntime": 950000,
-                "realtimePeriod": 1000000,
+                "rtRuntime": 950000,
+                "rtPeriod": 1000000,
                 "cpus": "2-3",
                 "mems": "0-7"
             },

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -190,12 +190,12 @@
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/quota",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
-                            "realtimePeriod": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimePeriod",
+                            "rtPeriod": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/rtPeriod",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
-                            "realtimeRuntime": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimeRuntime",
+                            "rtRuntime": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/rtRuntime",
                                 "$ref": "defs.json#/definitions/uint64Pointer"
                             },
                             "shares": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -288,9 +288,9 @@ type LinuxCPU struct {
 	// CPU period to be used for hardcapping (in usecs).
 	Period *uint64 `json:"period,omitempty"`
 	// How much time realtime scheduling may use (in usecs).
-	RealtimeRuntime *uint64 `json:"realtimeRuntime,omitempty"`
+	RtRuntime *uint64 `json:"rtRuntime,omitempty"`
 	// CPU period to be used for realtime scheduling (in usecs).
-	RealtimePeriod *uint64 `json:"realtimePeriod,omitempty"`
+	RtPeriod *uint64 `json:"rtPeriod,omitempty"`
 	// CPUs to use within the cpuset. Default is to use any CPU available.
 	Cpus *string `json:"cpus,omitempty"`
 	// List of memory nodes in the cpuset. Default is to use any available memory node.


### PR DESCRIPTION
I don't have strong opinion on this, `rt` is widely used
as present of `realtime`, it makes the name shorter and
cleaner. And this is also the naming method which Linux
kernel use.

We can consider this before 1.0 when we still have chance.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>