### PR TITLE
config: Require absolute mount destinations

### DIFF
--- a/config.md
+++ b/config.md
@@ -46,6 +46,7 @@ The runtime MUST mount entries in the listed order.
 The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
 
 * **`destination`** (string, REQUIRED) Destination of mount point: path inside container.
+  This value MUST be an absolute path.
   For the Windows operating system, one mount destination MUST NOT be nested within another mount (e.g., c:\\foo and c:\\foo\\bar).
 * **`type`** (string, REQUIRED) The filesystem type of the filesystem to be mounted.
   Linux: *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660").


### PR DESCRIPTION
`destination` has been the path inside the container since #136.  My personal preference is to [have an explicit pivot root and allow paths relative to the current working directory][1], but that would be a big shift from the current OCI spec.  The only way the current spec lets you turn off the root pivot is by not setting a mount namespace at all (and even then, it's not clear if that turns off the pivot).  And the config's `root` entry is required (despite my [attempts to have it made optional][2]), so it's not really clear how containers that don't set a mount namespace are supposed to work (if they're supported at all).

You might be able to get away with something like:

> When a mount namespace is not set, `destination` paths are relative to the runtime's initial working directory (or relative to the `config.json`, or whatever).  When a mount namespace is set, `destination` paths are relative to the mount namespace's root.

but with mount-namespace-less containers already so unclear, it seems better to just require absolute `destination`s.  If/when we get clearer support for explicit pivot-root calls or containers that inherit the host mount namespace (without re-joining it and losing their old working directory), we can consider lifting the absolute-path restriction.

[1]: https://github.com/wking/ccon/tree/v0.4.0#mount-namespace
[2]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/6ZKMNWujDhU