### PR TITLE
config: Change “Process configuration” → “Process” header

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To provide context for users the following section gives example use cases for e
 #### Application Bundle Builders
 
 Application bundle builders can create a [bundle](bundle.md) directory that includes all of the files required for launching an application as a container.
-The bundle contains an OCI [configuration file](config.md) where the builder can specify host-independent details such as [which executable to launch](config.md#process-configuration) and host-specific settings such as [mount](config.md#mounts) locations, [hook](config.md#hooks) paths, Linux [namespaces](config-linux.md#namespaces) and [cgroups](config-linux.md#control-groups).
+The bundle contains an OCI [configuration file](config.md) where the builder can specify host-independent details such as [which executable to launch](config.md#process) and host-specific settings such as [mount](config.md#mounts) locations, [hook](config.md#hooks) paths, Linux [namespaces](config-linux.md#namespaces) and [cgroups](config-linux.md#control-groups).
 Because the configuration includes host-specific settings, application bundle directories copied between two hosts may require configuration adjustments.
 
 #### Hook Developers

--- a/config.md
+++ b/config.md
@@ -114,7 +114,7 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
 ```
 
 
-## Process configuration
+## Process
 
 **`process`** (object, REQUIRED) configures the container process.
 

--- a/glossary.md
+++ b/glossary.md
@@ -15,7 +15,7 @@ For example, namespaces, resource limits, and mounts are all part of the contain
 
 ## Container namespace
 
-On Linux, a leaf in the [namespace][namespaces.7] hierarchy in which the [configured process](config.md#process-configuration) executes.
+On Linux, a leaf in the [namespace][namespaces.7] hierarchy in which the [configured process](config.md#process) executes.
 
 ## JSON
 

--- a/runtime.md
+++ b/runtime.md
@@ -49,12 +49,12 @@ The lifecycle describes the timeline of events that happen from when a container
 1. OCI compliant runtime's [`create`](runtime.md#create) command is invoked with a reference to the location of the bundle and a unique identifier.
 2. The container's runtime environment MUST be created according to the configuration in [`config.json`](config.md).
    If the runtime is unable to create the environment specified in the [`config.json`](config.md), it MUST generate an error.
-   While the resources requested in the [`config.json`](config.md) MUST be created, the user-specified code (from [`process`](config.md#process-configuration)) MUST NOT be run at this time.
+   While the resources requested in the [`config.json`](config.md) MUST be created, the user-specified code (from [`process`](config.md#process)) MUST NOT be run at this time.
    Any updates to [`config.json`](config.md) after this step MUST NOT affect the container.
 3. Once the container is created additional actions MAY be performed based on the features the runtime chooses to support.
    However, some actions might only be available based on the current state of the container (e.g. only available while it is started).
 4. Runtime's [`start`](runtime.md#start) command is invoked with the unique identifier of the container.
-   The runtime MUST run the user-specified code, as specified by [`process`](config.md#process-configuration).
+   The runtime MUST run the user-specified code, as specified by [`process`](config.md#process).
 5. The container's process is stopped.
    This MAY happen due to them erroring out, exiting, crashing or the runtime's [`kill`](runtime.md#kill) operation being invoked.
 6. Runtime's [`delete`](runtime.md#delete) command is invoked with the unique identifier of the container.
@@ -102,7 +102,7 @@ Any changes made to the [`config.json`](config.md) file after this operation wil
 This operation MUST generate an error if it is not provided the container ID.
 Attempting to start a container that does not exist MUST generate an error.
 Attempting to start an already started container MUST have no effect on the container and MUST generate an error.
-This operation MUST run the user-specified code as specified by [`process`](config.md#process-configuration).
+This operation MUST run the user-specified code as specified by [`process`](config.md#process).
 
 Upon successful completion of this operation the `status` property of this container MUST be `running`.
 


### PR DESCRIPTION
All of these sections are about configuration, and we don't usually use “{Whatever} configuration” in the headers.

Micro-pivot spun off from #489.