### PR TITLE
config: Make 'process.args' optional

### DIFF
--- a/config.md
+++ b/config.md
@@ -126,8 +126,9 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
 * **`cwd`** (string, REQUIRED) is the working directory that will be set for the executable.
   This value MUST be an absolute path.
 * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2001's `environ`][ieee-1003.1-2001-xbd-c8.1].
-* **`args`** (array of strings, REQUIRED) with similar semantics to [IEEE Std 1003.1-2001 `execvp`'s *argv*][ieee-1003.1-2001-xsh-exec].
+* **`args`** (array of strings, OPTIONAL) with similar semantics to [IEEE Std 1003.1-2001 `execvp`'s *argv*][ieee-1003.1-2001-xsh-exec].
   This specification extends the IEEE standard in that at least one entry is REQUIRED, and that entry is used with the same semantics as `execvp`'s *file*.
+  This property is REQUIRED when [`start`](runtime.md#start) is called.
 
 For Linux-based systems the process structure supports the following process specific fields:
 

--- a/runtime.md
+++ b/runtime.md
@@ -103,6 +103,7 @@ This operation MUST generate an error if it is not provided the container ID.
 Attempting to start a container that does not exist MUST generate an error.
 Attempting to start an already started container MUST have no effect on the container and MUST generate an error.
 This operation MUST run the user-specified program as specified by [`process`](config.md#process).
+This operation MUST generate an error if `process.args` was not set.
 
 Upon successful completion of this operation the `status` property of this container MUST be `running`.
 

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -74,8 +74,7 @@
             "id": "https://opencontainers.org/schema/bundle/process",
             "type": "object",
             "required": [
-                "cwd",
-                "args"
+                "cwd"
             ],
             "properties": {
                 "args": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -38,7 +38,7 @@ type Process struct {
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
-	Args []string `json:"args"`
+	Args []string `json:"args,omitempty"`
 	// Env populates the process environment for the process.
 	Env []string `json:"env,omitempty"`
 	// Cwd is the current working directory for the process and must be


### PR DESCRIPTION
Since #384, it's possible for a container process to never execute user-specified code (e.g. you can call `create`, `kill`, `delete` without calling `start`).  For folks who expect to do that, there`s no reason to define `process.args`.

The main point of #489 without the surrounding cleanup, since most of the cleanup has since landed via:

* The one-sentence-per-line fixes in #443.
* The line calling out `process` as required from #525.

There was some [negative][2] [review][3] of this change in #489, although @mrunalp acknowledged [support for the “never calling `start`” workflow][3].  If there is a maintainer consensus around that workflow being supported, requiring `process.args` in all cases [seems like needless hoop-jumping][4].  I'm fine with *validation tooling* warning users “you might have forgotten to put something meaningful in `process.args`, so `start` calls will fail”.  But I'd rather not have *this spec* require dummy `process.args` from folks who will never call `start`.

[1]: https://github.com/opencontainers/runtime-spec/pull/489#issuecomment-259856833
[2]: https://github.com/opencontainers/runtime-spec/pull/489#issuecomment-258564522
[3]: https://github.com/opencontainers/runtime-spec/pull/489#issuecomment-259783257
[4]: https://github.com/opencontainers/runtime-spec/pull/489#issuecomment-259787865