### PR TITLE
config: Drop Solaris UID/GID note

### DIFF
--- a/config.md
+++ b/config.md
@@ -160,8 +160,6 @@ For Linux and Solaris based systems the user structure has the following fields:
 
 _Note: symbolic name for uid and gid, such as uname and gname respectively, are left to upper levels to derive (i.e. `/etc/passwd` parsing, NSS, etc)_
 
-_Note: For Solaris, uid and gid specify the uid and gid of the process inside the container and need not be same as in the host._
-
 ### Example (Linux)
 
 ```json


### PR DESCRIPTION
The note is from #411, but as I [pointed out there][1], this is also true for Linux.  #412 landed in parallel with more explicit namepacing for these fields, so we no longer need the overly-specific Solaris note.

[1]: https://github.com/opencontainers/runtime-spec/pull/411#r61620322