### PR TITLE
README: remove extraneous apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The specification and code is licensed under the Apache 2.0 license found in the
 
 ## Code of Conduct
 
-Participation in the OpenContainers community is governed by [OpenContainer's Code of Conduct](https://github.com/opencontainers/tob/blob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md).
+Participation in the OCI community is governed by the [OCI Code of Conduct](https://github.com/opencontainers/tob/blob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md).
 
 ## Discuss your design
 


### PR DESCRIPTION
Also s/OpenContainers/OCI/ as used in the image-spec README.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>