### PR TITLE
Exclude hook state definition explicitly

### DIFF
--- a/config.md
+++ b/config.md
@@ -324,6 +324,7 @@ Presently there are `Prestart`, `Poststart` and `Poststop`.
 Hooks allow one to run programs before/after various lifecycle events of the container.
 Hooks MUST be called in the listed order.
 The state of the container is passed to the hooks over stdin, so the hooks could get the information they need to do their work.
+The container state data format is defined by various runtime implementations, and is not included in this specification.
 
 Hook paths are absolute and are executed from the host's filesystem in the [runtime namespace][runtime-namespace].
 


### PR DESCRIPTION
Hook State data is passed from runtime to hook, the data structure isn't
defined in spec, and we should clearly clarify this in case reader keeps
trying to find the definition from here.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>