### PR TITLE
Rename `version` to `ociVersion` according to runtime.md

### DIFF
--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -3,7 +3,7 @@ package specs
 // State holds information about the runtime state of the container.
 type State struct {
 	// Version is the version of the specification that is supported.
-	Version string `json:"version"`
+	Version string `json:"ociVersion"`
 	// ID is the container ID
 	ID string `json:"id"`
 	// Status is the runtime state of the container.


### PR DESCRIPTION
<del>
* `Root` is path to the container's rootfs which can be useful information
to hook, and the official sample runtime implementation--runc--has
already added this field as payload to hook, we should add this to the
spec.
    
* `Status` seems like unnecessary field, because `State` is payload to
hook and hook is executed in special time point, e.g.
1.  `Prestart` is a list of hooks to be run before the container process is
executed, indicating a status of `created`.
2. `Poststart` is a list of hooks to be run immediately after the container
process is started, indicating a status of `running`.
3. `Poststop` is a list of hooks to be run after the container process exits,
indicating a status of `stopped`.
So the `Status` field is redundant. 
</del>

According to definition of [state](https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#state), we should rename
`version` field in `state.go` to `ociVersion`

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>