### PR TITLE
config.md: add empty limit for key of annotations

### DIFF
--- a/config.md
+++ b/config.md
@@ -388,7 +388,7 @@ The semantics are the same as `Path`, `Args` and `Env` in [golang Cmd](https://g
 This information MAY be structured or unstructured.
 Annotations MUST be a key-value map where both the key and value MUST be strings.
 While the value MUST be present, it MAY be an empty string.
-Keys MUST be unique within this map, and best practice is to namespace the keys.
+Keys MUST be unique and MUST NOT be an empty string within this map, and best practice is to namespace the keys.
 Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
 Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
 If there are no annotations then this property MAY either be absent or an empty map.


### PR DESCRIPTION
empty key does not make any senses, we should limit it.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>