### PR TITLE
config-linux: Lift no-tweaking namespace restriction

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,14 +18,6 @@ Could be solved by lifecycle/ops and create/start split discussions
 
 *Owner:* vishh & duglin
 
-### Live Container Updates
-
-Should we allow dynamic container updates to runtime options?
-
-Proposal: make it an optional feature
-
-*Owner:* hqhq (was vishh) robdolinms, bcorrie
-
 ### Version Schema
 
 Decide on a robust versioning schema for the spec as it evolves.

--- a/config-linux.md
+++ b/config-linux.md
@@ -39,7 +39,6 @@ The following parameters can be specified to setup namespaces:
 
 If a path is specified, that particular file is used to join that type of namespace.
 If a namespace type is not specified in the `namespaces` array, the container MUST inherit the [runtime namespace](glossary.md#runtime-namespace) of that type.
-If a new namespace is not created (because the namespace type is not listed, or because it is listed with a `path`), runtimes MUST assume that the setup for that namespace has already been done and error out if the config specifies anything else related to that namespace.
 If a `namespaces` field contains duplicated namespaces with same `type`, the runtime MUST error out.
 
 ###### Example

--- a/config.md
+++ b/config.md
@@ -256,7 +256,8 @@ For Windows based systems the user structure has the following fields:
 ## Hostname
 
 * **`hostname`** (string, OPTIONAL) configures the container's hostname as seen by processes running inside the container.
-  On Linux, you can only set this if your bundle creates a new [UTS namespace][uts-namespace].
+  On Linux, this will change the hostname in the [container][container-namespace] [UTS namespace][uts-namespace].
+  Depending on your [namespace configuration](config-linux.md#namespaces), the container UTS namespace may be the [runtime UTS namespace][runtime-namespace].
 
 ### Example
 


### PR DESCRIPTION
This restriction originally landed via #158.  The hostname case landed via #214, citing the namespace restriction.  The restriciton extended to runtime namespaces in #538.  There was also a proposal in-flight to get config-wide consistency around the no-tweaking concept (#540).

In today's meeting, the maintainer consensus was to [strike the no-tweaking restriction][2], which is what I've done here.  I've removed the ROADMAP entry because this gives folks a way to adjust existing containers (launch a new container which joins and tweaks the original).

The hostname entry still mentions the UTS namespace to provide a guard against accidental foot-gunning.  There was no no-tweaking language for properties related to other namespaces (e.g. 'mounts').  Maybe the other namespaces have more obvious names.

Fixes #17.
Fixes #305.

[2]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2017/opencontainers.2017-01-11-22.04.log.html#l-117