### PR TITLE
defs.json: add misssing int64Pointer

### DIFF
--- a/schema/defs.json
+++ b/schema/defs.json
@@ -56,6 +56,16 @@
                 }
             ]
         },
+        "int64Pointer": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/int64"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "uint16Pointer": {
             "oneOf": [
                 {


### PR DESCRIPTION
int64Pointer is used in config-linux.json, but hasn't been defined.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>