### PR TITLE
config: Bring "unique... within this map" back together

### DIFF
--- a/config.md
+++ b/config.md
@@ -393,7 +393,8 @@ If a hook returns a non-zero exit code, then an error is logged and the remainin
 This information MAY be structured or unstructured.
 Annotations MUST be a key-value map where both the key and value MUST be strings.
 While the value MUST be present, it MAY be an empty string.
-Keys MUST be unique and MUST NOT be an empty string within this map, and best practice is to namespace the keys.
+Keys MUST be unique within this map.
+Keys MUST NOT be an empty string.
 Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
 Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
 If there are no annotations then this property MAY either be absent or an empty map.

--- a/config.md
+++ b/config.md
@@ -391,14 +391,18 @@ If a hook returns a non-zero exit code, then an error is logged and the remainin
 
 **`annotations`** (object, OPTIONAL) contains arbitrary metadata for the container.
 This information MAY be structured or unstructured.
-Annotations MUST be a key-value map where both the key and value MUST be strings.
-While the value MUST be present, it MAY be an empty string.
+Annotations MUST be a key-value map.
+If there are no annotations then this property MAY either be absent or an empty map.
+
+Keys MUST be strings.
 Keys MUST be unique within this map.
 Keys MUST NOT be an empty string.
 Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
 Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
-If there are no annotations then this property MAY either be absent or an empty map.
 Implementations that are reading/processing this configuration file MUST NOT generate an error if they encounter an unknown annotation key.
+
+Values MUST be strings.
+Values MAY be an empty string.
 
 ```json
 "annotations": {


### PR DESCRIPTION
This PR is [my suggestion][1] from #645, which @dqminh thumbs-upped, but which didn't make it in before #645 landed.

Pull the empty-key restriction out into its own sentence (instead of leaving it in the middle of the uniqueness restriction).

Drop the “best practice” portion, because the following line is “Keys SHOULD be named using a reverse domain notation…”, which covers that idea more explicitly.

[1]: https://github.com/opencontainers/runtime-spec/pull/645/files#r94497998