### PR TITLE
config: Improve seccomp format to be more expressive

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -538,12 +538,17 @@ Operator Constants:
    "seccomp": {
        "defaultAction": "SCMP_ACT_ALLOW",
        "architectures": [
-           "SCMP_ARCH_X86"
+           "SCMP_ARCH_X86",
+           "SCMP_ARCH_X32"
        ],
        "syscalls": [
            {
-               "name": "getcwd",
-               "action": "SCMP_ACT_ERRNO"
+               "names": [
+                   "getcwd",
+                   "chmod"
+               ],
+               "action": "SCMP_ACT_ERRNO",
+               "comment": "stop exploit x"
            }
        ]
    }

--- a/config.md
+++ b/config.md
@@ -710,12 +710,17 @@ Here is a full example `config.json` for reference.
         "seccomp": {
             "defaultAction": "SCMP_ACT_ALLOW",
             "architectures": [
-                "SCMP_ARCH_X86"
+                "SCMP_ARCH_X86",
+                "SCMP_ARCH_X32"
             ],
             "syscalls": [
                 {
-                    "name": "getcwd",
-                    "action": "SCMP_ACT_ERRNO"
+                    "names": [
+                        "getcwd",
+                        "chmod"
+                    ],
+                    "action": "SCMP_ACT_ERRNO",
+                    "comment": "stop exploit x"
                 }
             ]
         },

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -63,8 +63,10 @@
         "Syscall": {
             "type": "object",
             "properties": {
-                "name": {
-                    "type": "string"
+                "names": {
+                    "type": [
+                        "string"
+                    ]
                 },
                 "action": {
                     "$ref": "#/definitions/SeccompAction"

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -365,13 +365,6 @@ type LinuxDeviceCgroup struct {
 	Access string `json:"access,omitempty"`
 }
 
-// LinuxSeccomp represents syscall restrictions
-type LinuxSeccomp struct {
-	DefaultAction LinuxSeccompAction `json:"defaultAction"`
-	Architectures []Arch             `json:"architectures"`
-	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
-}
-
 // Solaris contains platform specific configuration for Solaris application containers.
 type Solaris struct {
 	// SMF FMRI which should go "online" before we start the container process.
@@ -469,6 +462,13 @@ type WindowsNetworkResources struct {
 	EgressBandwidth *uint64 `json:"egressBandwidth,omitempty"`
 }
 
+// LinuxSeccomp represents syscall restrictions
+type LinuxSeccomp struct {
+	DefaultAction LinuxSeccompAction `json:"defaultAction"`
+	Architectures []Arch             `json:"architectures,omitempty"`
+	Syscalls      []LinuxSyscall     `json:"syscalls"`
+}
+
 // Arch used for additional architectures
 type Arch string
 
@@ -529,7 +529,8 @@ type LinuxSeccompArg struct {
 
 // LinuxSyscall is used to match a syscall in Seccomp
 type LinuxSyscall struct {
-	Name   string             `json:"name"`
-	Action LinuxSeccompAction `json:"action"`
-	Args   []LinuxSeccompArg  `json:"args,omitempty"`
+	Names   []string           `json:"names"`
+	Action  LinuxSeccompAction `json:"action"`
+	Args    []LinuxSeccompArg  `json:"args"`
+	Comment string             `json:"comment"`
 }


### PR DESCRIPTION
I'm opening this to continue [this discussion](https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/BkTgy0bZrXQ) about improving the seccomp specification. @mrunalp @runcom @justincormack

While of course runtime-spec shouldn't make changes with specific projects in mind, it's worth noting that this format is currently being used in [cri-o]() and [docker]().

The change proposes that Syscalls be grouped together in the case that their listings be exactly the same. Conditionals can be expressed on architectures and capabilities also. Comments are a nice feature for dev-ops teams as well.

There's inconsistencies ([example](https://github.com/opencontainers/runc/issues/1273)) in the use of seccomp specifications across oci projects, I think heading in the direction of this improvement can help standardize adoption of the spec. 


See the following example of this format: 
```
{
    "archMap": [{
        "architecture": "SCMP_ARCH_X86_64",
        "subArchitectures": [
            "SCMP_ARCH_X86",
            "SCMP_ARCH_X32"
        ]
    }],
    "syscalls": [{
        "names": [
            "accept",
            "accept4",
            "access",
            "alarm",
            "alarm",
            "bind",
            "brk",
            "capget",
            "capset",
            "chdir",
            "chmod"
        ],
        "action": "SCMP_ACT_ALLOW",
        "args": [],
        "comment": "this is a comment!",
        "includes": {},
        "excludes": {}
    }, {
        "names": [
            "iopl",
            "ioperm"
        ],
        "action": "SCMP_ACT_ALLOW",
        "args": [],
        "comment": "",
        "includes": {
            "caps": [
                "CAP_SYS_RAWIO"
            ]
        },
        "excludes": {}
    }, {
        "names": [
            "clone"
        ],
        "action": "SCMP_ACT_ALLOW",
        "args": [{
            "index": 1,
            "value": 2080505856,
            "valueTwo": 0,
            "op": "SCMP_CMP_MASKED_EQ"
        }],
        "comment": "",
        "includes": {
            "arches": [
                "s390",
                "s390x"
            ]
        },
        "excludes": {
            "caps": [
                "CAP_SYS_ADMIN"
            ]
        }
    }]
}
```



Signed-off-by: grantseltzer <grantseltzer@gmail.com>