### PR TITLE
schema: Drop pointers and nulls

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -72,11 +72,11 @@
                         "properties": {
                             "blkioWeight": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioWeight",
-                                "$ref": "defs-linux.json#/definitions/blkioWeightPointer"
+                                "$ref": "defs-linux.json#/definitions/blkioWeight"
                             },
                             "blkioLeafWeight": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioLeafWeight",
-                                "$ref": "defs-linux.json#/definitions/blkioWeightPointer"
+                                "$ref": "defs-linux.json#/definitions/blkioWeight"
                             },
                             "blkioThrottleReadBpsDevice": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleReadBpsDevice",
@@ -129,23 +129,23 @@
                             },
                             "period": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/period",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             },
                             "quota": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/quota",
-                                "$ref": "defs.json#/definitions/int64Pointer"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "realtimePeriod": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimePeriod",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             },
                             "realtimeRuntime": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimeRuntime",
-                                "$ref": "defs.json#/definitions/int64Pointer"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "shares": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/shares",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             }
                         }
                     },
@@ -178,27 +178,27 @@
                         "properties": {
                             "kernel": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/kernel",
-                                "$ref": "defs.json#/definitions/int64Pointer"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "kernelTCP": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/kernelTCP",
-                                "$ref": "defs.json#/definitions/int64Pointer"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "limit": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/limit",
-                                "$ref": "defs.json#/definitions/int64Pointer"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "reservation": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/reservation",
-                                "$ref": "defs.json#/definitions/int64Pointer"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "swap": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swap",
-                                "$ref": "defs.json#/definitions/int64Pointer"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "swappiness": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swappiness",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             }
                         }
                     },
@@ -255,14 +255,7 @@
             },
             "sysctl": {
                 "id": "https://opencontainers.org/schema/bundle/linux/sysctl",
-                "oneOf": [
-                    {
-                        "$ref": "defs.json#/definitions/mapStringString"
-                    },
-                    {
-                        "type": "null"
-                    }
-                ]
+                "$ref": "defs.json#/definitions/mapStringString"
             },
             "maskedPaths": {
                 "id": "https://opencontainers.org/schema/bundle/linux/maskedPaths",

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -14,11 +14,11 @@
                         "properties": {
                             "limit": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/memory/limit",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             },
                             "reservation": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/memory/reservation",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             }
                         }
                     },
@@ -28,15 +28,15 @@
                         "properties": {
                             "count": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/count",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             },
                             "shares": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/shares",
-                                "$ref": "defs-windows.json#/definitions/cpuSharesPointer"
+                                "$ref": "defs-windows.json#/definitions/cpuShares"
                             },
                             "percent": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/percent",
-                                "$ref": "defs.json#/definitions/percentPointer"
+                                "$ref": "defs.json#/definitions/percent"
                             }
                         }
                     },
@@ -46,15 +46,15 @@
                         "properties": {
                             "iops": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/iops",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             },
                             "bps": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/bps",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             },
                             "sandboxSize": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/sandboxSize",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             }
                         }
                     },
@@ -64,7 +64,7 @@
                         "properties": {
                             "egressBandwidth": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/network/egressBandwidth",
-                                "$ref": "defs.json#/definitions/uint64Pointer"
+                                "$ref": "defs.json#/definitions/uint64"
                             }
                         }
                     }

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -126,24 +126,10 @@
                     "$ref": "#/definitions/Minor"
                 },
                 "uid": {
-                    "oneOf": [
-                        {
-                            "$ref": "defs.json#/definitions/UID"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                    "$ref": "defs.json#/definitions/UID"
                 },
                 "gid": {
-                    "oneOf": [
-                        {
-                            "$ref": "defs.json#/definitions/GID"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                    "$ref": "defs.json#/definitions/GID"
                 }
             }
         },
@@ -151,16 +137,6 @@
             "type": "integer",
             "minimum": 10,
             "maximum": 1000
-        },
-        "blkioWeightPointer": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/blkioWeight"
-                },
-                {
-                    "type": "null"
-                }
-            ]
         },
         "blockIODevice": {
             "type": "object",
@@ -187,10 +163,10 @@
                     "type": "object",
                     "properties": {
                         "weight": {
-                            "$ref": "#/definitions/blkioWeightPointer"
+                            "$ref": "#/definitions/blkioWeight"
                         },
                         "leafWeight": {
-                            "$ref": "#/definitions/blkioWeightPointer"
+                            "$ref": "#/definitions/blkioWeight"
                         }
                     }
                 }
@@ -221,24 +197,10 @@
                     "$ref": "string"
                 },
                 "major": {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/Major"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                    "$ref": "#/definitions/Major"
                 },
                 "minor": {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/Minor"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                    "$ref": "#/definitions/Minor"
                 },
                 "access": {
                     "$ref": "string"

--- a/schema/defs-windows.json
+++ b/schema/defs-windows.json
@@ -5,16 +5,6 @@
             "type": "integer",
             "minimum": 1,
             "maximum": 10000
-        },
-        "cpuSharesPointer": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/cpuShares"
-                },
-                {
-                    "type": "null"
-                }
-            ]
         }
     }
 }

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -46,56 +46,6 @@
             "minimum": 0,
             "maximum": 100
         },
-        "intPointer": {
-            "oneOf": [
-                {
-                    "type": "integer"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "int64Pointer": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/int64"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "uint16Pointer": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/uint16"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "uint64Pointer": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/uint64"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "percentPointer": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/percent"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
         "mapStringString": {
             "type": "object",
             "patternProperties": {
@@ -141,9 +91,13 @@
                     "$ref": "#/definitions/Env"
                 },
                 "timeout": {
-                    "$ref": "#/definitions/intPointer"
+                    "$ref": "#/definitions/int"
                 }
-            }
+            },
+            "required": [
+                "args",
+                "path"
+            ]
         },
         "ArrayOfHooks": {
             "type": "array",
@@ -197,14 +151,7 @@
             "type": "string"
         },
         "annotations": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/mapStringString"
-                },
-                {
-                    "type": "null"
-                }
-            ]
+            "$ref": "#/definitions/mapStringString"
         }
     }
 }


### PR DESCRIPTION
Maintainers feel (and I agree) that there's [no point in explicitly allowing a null value when callers can simply leave the property unset][1].  This commit removes all references to “pointer” and “null” from the JSON Schema to support that decision.  While optional properties [may sometimes be represented as pointer types in Go][2], optional properties should be represented in JSON Schema by not including the properties in the `required` array.

Spun off from [this comment][3] as [requested][4] by @RobDolinMS.

[1]: https://github.com/opencontainers/runtime-spec/pull/555#issuecomment-272020515
[2]: https://github.com/opencontainers/runtime-spec/blob/c368be6a74d7383f9b6c9a4b7a3e73d65537b08a/style.md#optional-settings-should-not-have-pointer-go-types
[3]: https://github.com/opencontainers/runtime-spec/pull/655#discussion_r96018318
[4]: https://github.com/opencontainers/runtime-spec/pull/655#issuecomment-273622407