### PR TITLE
linux: relax filesystem requirements for container

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -8,7 +8,7 @@ The Linux container specification uses various kernel features like namespaces, 
 The Linux ABI includes both syscalls and several special file paths.
 Applications expecting a Linux environment will very likely expect these file paths to be setup correctly.
 
-The following filesystems MUST be made available in each container's filesystem:
+The following filesystems SHOULD be made available in each container's filesystem:
 
 |   Path   |  Type  |
 | -------- | ------ |


### PR DESCRIPTION
change MUST to SHOULD so containers are not required to have all these filesystems mounted.

Related to discussions in https://github.com/opencontainers/runc/pull/1176

cc @cyphar @crosbymichael @philips @justincormack