### PR TITLE
State when the runtime should and must not apply Linux ambient capabities

### DIFF
--- a/config.md
+++ b/config.md
@@ -133,6 +133,9 @@ For Linux-based systems the process structure supports the following process spe
 
 * **`capabilities`** (array of strings, OPTIONAL) capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
   Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html).
+
+    If the `noNewPrivileges` flag is set the runtime SHOULD try to apply Linux ambient capabilities. If this flag is not set it MUST NOT apply ambient capabilities.
+
 * **`rlimits`** (array of objects, OPTIONAL) allows setting resource limits for a process inside the container.
   Each entry has the following structure:
 


### PR DESCRIPTION
Ambient capabilities are a feature, since Linux 4.3, that enables capabilities
to be set on non root proesses directly. They are the only way to set these,
so are desirable in the case of "no new privileges" where suid binaries or
filesystem capabilities cannot be used as tis flag denies these operations,
and therefore there is no other way to apply capabilities to non root processes.

Without "no new privileges" users generally expect suid binaries or
filesystem capabilities to be the way to grant capabilities to non
root processes.

See https://github.com/opencontainers/runc/pull/1286 for the `runc` pull
and detailed explanation of the security issues in offering a choice here.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>