### PR TITLE
schema: allow Device.fileMode set to null.

### DIFF
--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -117,7 +117,14 @@
                     "$ref": "defs.json#/definitions/FilePath"
                 },
                 "fileMode": {
-                    "$ref": "#/definitions/FileMode"
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/FileMode"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "major": {
                     "$ref": "#/definitions/Major"


### PR DESCRIPTION
The `fileMode` is marked optional in the [description](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#devices)
In [spec-go](https://github.com/opencontainers/runtime-spec/blob/master/specs-go/config.go#L347), fileMode can be set to null.
However, in the schema, a null type is not allowed for fileMode.

This patch allows fileMode set to null, and consistent with other optional fields.
