### PR TITLE
Rename bundlePath to bundle

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -22,7 +22,7 @@ The value MAY be one of:
 
     Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`** (int, REQUIRED when `status` is `created` or `running`) is the ID of the container process, as seen by the host.
-* **`bundlePath`** (string, REQUIRED) is the absolute path to the container's bundle directory.
+* **`bundle`** (string, REQUIRED) is the absolute path to the container's bundle directory.
 This is provided so that consumers can find the container's configuration and root filesystem on the host.
 * **`annotations`** (map, OPTIONAL) contains the list of annotations associated with the container.
 If no annotations were provided then this property MAY either be absent or an empty map.
@@ -37,7 +37,7 @@ When serialized in JSON, the format MUST adhere to the following pattern:
     "id": "oci-container1",
     "status": "running",
     "pid": 4422,
-    "bundlePath": "/containers/redis",
+    "bundle": "/containers/redis",
     "annotations": {
         "myKey": "myValue"
     }

--- a/schema/state-schema.json
+++ b/schema/state-schema.json
@@ -27,8 +27,8 @@
             "type": "integer",
             "minimum": 0
         },
-        "bundlePath": {
-            "id": "https://opencontainers.org/schema/runtime/state/bundlePath",
+        "bundle": {
+            "id": "https://opencontainers.org/schema/runtime/state/bundle",
             "type": "string"
         },
         "annotations": {
@@ -40,6 +40,6 @@
         "id",
         "status",
         "pid",
-        "bundlePath"
+        "bundle"
     ]
 }

--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -6,12 +6,12 @@ type State struct {
 	Version string `json:"ociVersion"`
 	// ID is the container ID
 	ID string `json:"id"`
-	// Status is the runtime state of the container.
+	// Status is the runtime status of the container.
 	Status string `json:"status"`
 	// Pid is the process ID for the container process.
 	Pid int `json:"pid"`
-	// BundlePath is the path to the container's bundle directory.
-	BundlePath string `json:"bundlePath"`
-	// Annotations are the annotations associated with the container.
+	// Bundle is the path to the container's bundle directory.
+	Bundle string `json:"bundle"`
+	// Annotations are key values associated with the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }


### PR DESCRIPTION
The path part is just redundant and runc is already providing `bundle` to consumers. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>