### PR TITLE
runtime: Add 'exit' to state for collecting the container exit code

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -22,6 +22,7 @@ The value MAY be one of:
 
     Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`** (int, REQUIRED when `status` is `created` or `running`) is the ID of the container process, as seen by the host.
+* **`exit`** (uint, REQUIRED when `status` is `stopped`) is the exit code of the container process.
 * **`bundlePath`** (string, REQUIRED) is the absolute path to the container's bundle directory.
 This is provided so that consumers can find the container's configuration and root filesystem on the host.
 * **`annotations`** (map, OPTIONAL) contains the list of annotations associated with the container.

--- a/schema/state-schema.json
+++ b/schema/state-schema.json
@@ -27,6 +27,11 @@
             "type": "integer",
             "minimum": 0
         },
+        "exit": {
+            "id": "https://opencontainers.org/schema/runtime/state/exit",
+            "type": "integer",
+            "minimum": 0
+        },
         "bundlePath": {
             "id": "https://opencontainers.org/schema/runtime/state/bundlePath",
             "type": "string"

--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -10,6 +10,8 @@ type State struct {
 	Status string `json:"status"`
 	// Pid is the process ID for the container process.
 	Pid int `json:"pid"`
+	// Exit is the exit code the container process.
+	Exit uint `json:"exit,omitempty"`
 	// BundlePath is the path to the container's bundle directory.
 	BundlePath string `json:"bundlePath"`
 	// Annotations are the annotations associated with the container.


### PR DESCRIPTION
This gives us a more portable way to discover the container exit code (vs. [requiring callers to use subreapers][1] or other platform-specific approaches which require knowledge of the runtime implementation).

There would still be no portable way to discover *when* the container had exited (short of polling `state`), but we can handle that separately.

[1]: https://github.com/opencontainers/runc/pull/827#r63598816