### PR TITLE
config-linux: Drop the default-filesystem section

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -3,20 +3,6 @@
 This document describes the schema for the [Linux-specific section](config.md#platform-specific-configuration) of the [container configuration](config.md).
 The Linux container specification uses various kernel features like namespaces, cgroups, capabilities, LSM, and filesystem jails to fulfill the spec.
 
-## Default Filesystems
-
-The Linux ABI includes both syscalls and several special file paths.
-Applications expecting a Linux environment will very likely expect these file paths to be setup correctly.
-
-The following filesystems SHOULD be made available in each container's filesystem:
-
-|   Path   |  Type  |
-| -------- | ------ |
-| /proc    | [procfs](https://www.kernel.org/doc/Documentation/filesystems/proc.txt)   |
-| /sys     | [sysfs](https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt)   |
-| /dev/pts | [devpts](https://www.kernel.org/doc/Documentation/filesystems/devpts.txt) |
-| /dev/shm | [tmpfs](https://www.kernel.org/doc/Documentation/filesystems/tmpfs.txt)   |
-
 ## Namespaces
 
 A namespace wraps a global system resource in an abstraction that makes it appear to the processes within the namespace that they have their own isolated instance of the global resource.


### PR DESCRIPTION
Users who need these mounts would have to explicitly set them up in their configuration (as runtime-tools [continues to do][1]) if they wanted to guarantee their presence.  Users who don't need them can omit them from their configuration.  I don't see how keeping a SHOULD-strength runtime requirement helps either of those workflows.

This is one of the possible approaches I'd [floated][2] in #666.

[1]: https://github.com/opencontainers/runtime-tools/pull/24
[2]: https://github.com/opencontainers/runtime-spec/pull/666#issuecomment-274550344