### PR TITLE
config: Make default Linux filesystems an example

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -3,20 +3,6 @@
 This document describes the schema for the [Linux-specific section](config.md#platform-specific-configuration) of the [container configuration](config.md).
 The Linux container specification uses various kernel features like namespaces, cgroups, capabilities, LSM, and filesystem jails to fulfill the spec.
 
-## Default Filesystems
-
-The Linux ABI includes both syscalls and several special file paths.
-Applications expecting a Linux environment will very likely expect these file paths to be setup correctly.
-
-The following filesystems SHOULD be made available in each container's filesystem:
-
-|   Path   |  Type  |
-| -------- | ------ |
-| /proc    | [procfs](https://www.kernel.org/doc/Documentation/filesystems/proc.txt)   |
-| /sys     | [sysfs](https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt)   |
-| /dev/pts | [devpts](https://www.kernel.org/doc/Documentation/filesystems/devpts.txt) |
-| /dev/shm | [tmpfs](https://www.kernel.org/doc/Documentation/filesystems/tmpfs.txt)   |
-
 ## Namespaces
 
 A namespace wraps a global system resource in an abstraction that makes it appear to the processes within the namespace that they have their own isolated instance of the global resource.

--- a/config.md
+++ b/config.md
@@ -63,19 +63,48 @@ For Solaris, the mounts corresponds to fs resource in zonecfg(8).
 
 ### Example (Linux)
 
+## Common Linux Filesystems
+
+The Linux ABI includes both syscalls and several special file paths.
+Applications expecting a Linux environment will very likely expect these file paths to be setup correctly.
+Configuration authors interested in providing common filesystems can consider entries like:
+
 ```json
 "mounts": [
     {
-        "destination": "/tmp",
-        "type": "tmpfs",
-        "source": "tmpfs",
-        "options": ["nosuid","strictatime","mode=755","size=65536k"]
+        "destination": "/proc",
+        "type": "proc",
+        "source": "proc"
     },
     {
-        "destination": "/data",
-        "type": "bind",
-        "source": "/volumes/testing",
-        "options": ["rbind","rw"]
+        "destination": "/dev",
+        "type": "tmpfs",
+        "source": "tmpfs",
+        "options": ["nosuid", "strictatime", "mode=755", "size=65536k"]
+    },
+    {
+        "destination": "/dev/pts",
+        "type": "devpts",
+        "source": "devpts",
+        "options": ["nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"]
+    },
+    {
+        "destination": "/dev/shm",
+        "type": "tmpfs",
+        "source": "shm",
+        "options": ["nosuid", "noexec", "nodev", "mode=1777", "size=65536k"]
+    },
+    {
+        "destination": "/dev/mqueue",
+        "type": "mqueue",
+        "source": "mqueue",
+        "options": ["nosuid", "noexec", "nodev"]
+    },
+    {
+        "destination": "/sys",
+        "type": "sysfs",
+        "source": "sysfs",
+        "options": ["nosuid", "noexec", "nodev", "ro"]
     }
 ]
 ```


### PR DESCRIPTION
The MUST default-filesystem wording altered in #666 had read (to me, anyway) as:

> The runtime MUST supply these even if the config doesn't call for them in mounts.

with #666 weaking it to:

> The runtime SHOULD supply these even if the config doesn't call for them in mounts.

But that's not very useful (callers that *need* a given mount will still have to configure it explicitly).  However, one interpretation of the #666 wording seems to be [something like][1]:

> Config authors probably want to include mounts entries for these.

That's fine, and this commit tries to make that interpretation more obvious by shifting the config recommendation over to the Linux `mounts` example.

This is one of the possible approaches I'd [floated][2] in #666.  Another approach is just dropping the section (#678), so this PR is a parallel alternative to #678.

[1]: https://github.com/opencontainers/runtime-spec/pull/666#issuecomment-277067251
[2]: https://github.com/opencontainers/runtime-spec/pull/666#issuecomment-277086447