### PR TITLE
schema/validate: get correct canonical of schemaPath

### DIFF
--- a/schema/validate.go
+++ b/schema/validate.go
@@ -19,12 +19,12 @@ func main() {
 
 	schemaPath := os.Args[1]
 	if !strings.Contains(schemaPath, "://") {
-		schemaPath, err := filepath.Abs(schemaPath)
+		absPath, err := filepath.Abs(schemaPath)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		schemaPath = "file://" + schemaPath
+		schemaPath = "file://" + absPath
 	}
 	schemaLoader := gojsonschema.NewReferenceLoader(schemaPath)
 


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

Before this fix, we can't get correct schemaPath, because it's overridden.