### PR TITLE
schema: remove major,minor from device required items

### DIFF
--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -105,9 +105,7 @@
             "type": "object",
             "required": [
                 "type",
-                "path",
-                "major",
-                "minor"
+                "path"
             ],
             "properties": {
                 "type": {


### PR DESCRIPTION
When type is p, major and minor is not required.
So, we should not leave them in required.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>