### PR TITLE
schema/config-linux: add length limit for idmappings

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -14,6 +14,8 @@
             "uidMappings": {
                 "id": "https://opencontainers.org/schema/bundle/linux/uidMappings",
                 "type": "array",
+                "minItems": 0,
+                "maxItems": 5,
                 "items": {
                     "$ref": "defs.json#/definitions/IDMapping"
                 }
@@ -21,6 +23,8 @@
             "gidMappings": {
                 "id": "https://opencontainers.org/schema/bundle/linux/gidMappings",
                 "type": "array",
+                "minItems": 0,
+                "maxItems": 5,
                 "items": {
                     "$ref": "defs.json#/definitions/IDMapping"
                 }


### PR DESCRIPTION
According to spec, there is a limit of 5 mappings which is the Linux kernel hard limit.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>