### PR TITLE
config: Make process optional

### DIFF
--- a/config.md
+++ b/config.md
@@ -120,7 +120,8 @@ For Windows, see links for details about [mountvol](http://ss64.com/nt/mountvol.
 
 ## Process
 
-**`process`** (object, REQUIRED) specifies the container process.
+**`process`** (object, OPTIONAL) specifies the container process.
+  This property is REQUIRED when [`start`](runtime.md#start) is called.
 
 * **`terminal`** (bool, OPTIONAL) specifies whether a terminal is attached to that process, defaults to false.
   As an example, if set to true on Linux a pseudoterminal pair is allocated for the container process and the pseudoterminal slave is duplicated on the container process's [standard streams][stdin.3].

--- a/runtime.md
+++ b/runtime.md
@@ -107,6 +107,7 @@ This operation MUST generate an error if it is not provided the container ID.
 Attempting to start a container that does not exist MUST generate an error.
 Attempting to start an already started container MUST have no effect on the container and MUST generate an error.
 This operation MUST run the user-specified program as specified by [`process`](config.md#process).
+This operation MUST generate an error if `process` was not set.
 
 Upon successful completion of this operation the `status` property of this container MUST be `running`.
 

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -229,7 +229,6 @@
     "required": [
         "ociVersion",
         "platform",
-        "process",
         "root"
     ]
 }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -9,7 +9,7 @@ type Spec struct {
 	// Platform specifies the configuration's target platform.
 	Platform Platform `json:"platform"`
 	// Process configures the container process.
-	Process Process `json:"process"`
+	Process *Process `json:"process,omitempty"`
 	// Root configures the container's root filesystem.
 	Root Root `json:"root"`
 	// Hostname configures the container's hostname.


### PR DESCRIPTION
Since #384, it's possible for a container process to never execute user-specified code (e.g. you can call `create`, `kill`, `delete` without calling `start`).  For folks who expect to do that, there's no reason to define `process.args`.

The narrow solution to this would be to make `process.args` optional, but that approach was [rejected in favor of this all-or-nothing approach to `process` handling][1].  What an unset `process` means for the implementation-defined container process between `create` and `start` is unclear, but clarifying how that is handled is a separate issue (#700) independent of whether `process` is optional or not.

[1]: https://github.com/opencontainers/runtime-spec/pull/620#issuecomment-282820279