### PR TITLE
schema/defs-linux: Fix type for seccomp names

### DIFF
--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -66,9 +66,10 @@
             "type": "object",
             "properties": {
                 "names": {
-                    "type": [
-                        "string"
-                    ]
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "action": {
                     "$ref": "#/definitions/SeccompAction"


### PR DESCRIPTION
The:

    "type": [
      "string"
    ]

syntax added in #657 is not valid:

    $ ./validate ./config-schema.json <../config.json
    The document is not valid. see errors :
    - linux.seccomp.syscalls.0.names: Invalid type. Expected: string, given: array