### PR TITLE
README: Document the alternate-week meeting times

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ When in doubt, start on the [mailing-list](#mailing-list).
 
 ### Weekly Call
 
-The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 2:00 PM (USA Pacific).
+The contributors and maintainers of all OCI projects have a weekly meeting on Wednesdays at:
+
+* 9:00 AM (USA Pacific), during [even weeks][iso-week].
+* 2:00 PM (USA Pacific), during [odd weeks][iso-week].
+
 Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: 415-968-0849 (no PIN needed.)
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
 Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki][runtime-wiki].
@@ -148,6 +152,7 @@ Read more on [How to Write a Git Commit Message][how-to-git-commit] or the Discu
 [dev-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
 [how-to-git-commit]: http://chris.beams.io/posts/git-commit
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[iso-week]: https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_of_a_given_date
 [oci]: https://www.opencontainers.org
 [runtime-wiki]: https://github.com/opencontainers/runtime-spec/wiki
 [uberconference]: https://www.uberconference.com/opencontainers


### PR DESCRIPTION
On Thu, Mar 09, 2017 at 08:37:55AM -0700, Chris Aniszczyk [wrote][1]:
> summarizing the discussion, how about we just alternative the time like Jonathan discussed?
>
> I believe that's the only fair thing to do and it's reassuring to hear from people like Phil who would be able to make the time along with others.
>
> I'm fine with the current time (1000AEST/1500PST/0000CET) and then 0400AEST/0900PST/1800CET

Folks with a [POSIX `date` command][2] can find the week number with:

    $ date +%V
    10

That means that next week will be an odd week with the 2pm PDT meeting (because the US goes into daylight savings time this weekend), which is 2016-03-15 21:00 UTC.

There may be some doubling up around the end of the year, but we're usually canceling meetings around then anyway.

I'd be happier with meeting times anchored to UTC to make life easier for folks outside of the US, but one change at a time ;).  And I think UTC-anchored times have been rejected before, but I haven't dug up a reference for that.

[1]: https://groups.google.com/a/opencontainers.org/d/msg/dev/p0mTOspVgd0/mh7FYse2BAAJ
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/date.html