### PR TITLE
[Config Linux] Replace "required" (lower case)

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -186,7 +186,7 @@ You can configure a container's cgroups via the `resources` field of the Linux c
 Do not specify `resources` unless limits have to be updated.
 For example, to run a new process in an existing container without updating limits, `resources` need not be specified.
 
-A runtime MUST at least use the minimum set of cgroup controllers required to fulfill the `resources` settings.
+A runtime MUST at least use the minimum set of cgroup controllers necessary to fulfill the `resources` settings.
 However, a runtime MAY attach the container process to additional cgroup controllers supported by the system.
 
 ###### Example


### PR DESCRIPTION
Replaces "required" (lower case) with "necessary" since this instance does not seem to be intended as "REQUIRED"

Signed-off-by: Rob Dolin <robdolin@microsoft.com>