### PR TITLE
runtime: Drop "Barring access control concerns"

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -2,7 +2,7 @@
 
 ## <a name="runtimeScopeContainer" />Scope of a Container
 
-Barring access control concerns, the entity using a runtime to create a container MUST be able to use the operations defined in this specification against that same container.
+The entity using a runtime to create a container MUST be able to use the operations defined in this specification against that same container.
 Whether other entities using the same, or other, instance of the runtime can see that container is out of scope of this specification.
 
 ## <a name="runtimeState" />State


### PR DESCRIPTION
This wording landed without comment as part of #225.  However, I'm not entirely clear on the exception it's making.  It may be trying to say something like:

> Just because you were authorized to manage that container when you created it doesn't mean you're still authorized to perform operation X on it now.  Maybe you've lost privileges in the meantime.

But as far as compliance testing is concerned, the same test harness will be calling `create` and the subsequent operations.  That harness will be reporting MUST violations if the runtime refuses a subsequent operation, and removing the access-control loophole makes it more obvious that the runtime's refusal is non-compliant.