### PR TITLE
runtime: Drop "not supported by the base OS" loophole

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -82,7 +82,7 @@ Unless otherwise stated, logging a warning does not change the flow of the opera
 
 ## <a name="runtimeOperations" />Operations
 
-OCI compliant runtimes MUST support the following operations, unless the operation is not supported by the base operating system.
+Unless otherwise stated, runtimes MUST support the following operations.
 
 Note: these operations are not specifying any command-line APIs, and the parameters are inputs for general operations.
 


### PR DESCRIPTION
All of these operations should be supported on all of our compliance-tested platforms.  If there are cases where a given OS cannot support one of these operations, it should be discussed in that operation's section, and the "Unless otherwise stated" qualifier makes space for that.  But leaving the reader to decide on whether a host OS supports a given operation seems too unstable for a specification.

I've also dropped the "OCI compliant" qualifier, because the (not) compliant language in `spec.md` already ties OCI compliance to the RFC 2119 language.  There's no point in mentioning "OCI compliant" outside of that section, because the "MUST" already brings in all of the compliance associations we need.