### PR TITLE
runtime: Container-scope-wide uniqueness for container IDs

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -11,8 +11,6 @@ The state of a container includes the following properties:
 
 * **`ociVersion`** (string, REQUIRED) is the OCI specification version used when creating the container.
 * **`id`** (string, REQUIRED) is the container's ID.
-This MUST be unique across all containers on this host.
-There is no requirement that it be unique across hosts.
 * **`status`** (string, REQUIRED) is the runtime state of the container.
 The value MAY be one of:
 
@@ -99,7 +97,7 @@ This operation MUST return the state of a container as specified in the [State](
 `create <container-id> <path-to-bundle>`
 
 This operation MUST [generate an error](#errors) if it is not provided a path to the bundle and the container ID to associate with the container.
-If the ID provided is not unique across all containers within the scope of the runtime, or is not valid in any other way, the implementation MUST [generate an error](#errors) and a new container MUST NOT be created.
+If the ID provided is not unique across all containers within the [scope of the container](#scope-of-a-container), or is not valid in any other way, the implementation MUST [generate an error](#errors) and a new container MUST NOT be created.
 Using the data in [`config.json`](config.md), this operation MUST create a new container.
 This means that all of the resources associated with the container MUST be created, however, the user-specified program MUST NOT be run at this time.
 If the runtime cannot create the container as specified in [`config.json`](config.md), it MUST [generate an error](#errors) and a new container MUST NOT be created.


### PR DESCRIPTION
As written:

>  MUST be unique across all containers on this host.

seems unenforceable.  How will runC know what IDs are in use with other runtimes on that host?  And how will a runtime in one namespace know which IDs are used in another namespace?

The create-time language is much closer to being enforcable, by invoking the container-scope idea.  To firm this up, I've adjusted the wording to aligh with the name of the scope section, and I've linked to that scope section.

With the create-time check in place, I don't think there's any purpose to documenting the scope again in the state JSON section, so I've dropped those two lines.