### PR TITLE
config: Clarify mounts[].source relative path anchor

### DIFF
--- a/config.md
+++ b/config.md
@@ -75,6 +75,7 @@ For all platform-specific configuration values, the scope defined below in the [
     * Windows: this field MUST NOT be supplied.
     * Solaris: corresponds to "type" of the fs resource in [zonecfg(1M)][zonecfg.1m].
 * **`source`** (string, OPTIONAL) A device name, but can also be a directory name or a dummy.
+    Path values are either absolute or relative to the bundle.
     * Windows: a local directory on the filesystem of the container host. UNC paths and mapped drives are not supported.
     * Solaris: corresponds to "special" of the fs resource in [zonecfg(1M)][zonecfg.1m].
 * **`options`** (array of strings, OPTIONAL) Mount options of the filesystem to be used.


### PR DESCRIPTION
Borrowing language [from `root.path`][1] for absolute/relative and [from `linux.namespaces[].path`][2] for the runtime mount namespace.

In #509 I'd [floated a generic rule for anchoring relative runtime-namespace paths][3], but there aren't all that many relative runtime-namespace paths, so this PR takes a narrower approach.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/config.md#L33
[2]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/config-linux.md#L38
[3]: https://github.com/opencontainers/runtime-spec/issues/509#issuecomment-228414738