### PR TITLE
runtime-linux: Condition /proc/self/fd symlinks on source existence

### DIFF
--- a/runtime-linux.md
+++ b/runtime-linux.md
@@ -8,7 +8,7 @@ Some of the file descriptors MAY be redirected to `/dev/null` even though they a
 
 ## <a name="runtimeLinuxDevSymbolicLinks" /> Dev symbolic links
 
-After the container has `/proc` mounted, the following standard symlinks MUST be setup within `/dev/` for the IO.
+While creating the container (step 2 in the [lifecycle](runtime.md#lifecycle)), runtimes MUST create the following symlinks if the source file exists after processing [`mounts`](config.md#mounts):
 
 |    Source       | Destination |
 | --------------- | ----------- |


### PR DESCRIPTION
Since #666 it's no longer guaranteed that `/proc` will exist.  And there doesn't seem to be much point in requiring symlinks which will be known broken.

This commit also tightens the timing.  Before it was just “after the container has `/proc` mounted”, which could have happened during the `delete` operation (if the container authors wanted to be especially ornery).  With this commit, I've put the creation in [step 2 of the lifecycle][1].  And within step 2, it happens after `mounts` has been processed.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/runtime.md#L54-L57