### PR TITLE
config: Lead off with the purpose of the config

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,11 +1,11 @@
 # <a name="containerConfigurationFile" />Container Configuration file
 
+This configuration file contains metadata necessary to implement standard operations against the container.
+This includes the process to run, environment variables to inject, sandboxing features to use, etc.
+
 The canonical schema is defined in this document, but there is a JSON Schema in [`schema/config-schema.json`](schema/config-schema.json) and Go bindings in [`specs-go/config.go`](specs-go/config.go).
 [Platform](spec.md#platforms)-specific configuration schema are defined in the [platform-specific documents](#platform-specific-configuration) linked below.
 For properties that are only defined for some [platforms](spec.md#platforms), the Go property has a `platform` tag listing those protocols (e.g. `platform:"linux,solaris"`).
-
-The configuration file contains metadata necessary to implement standard operations against the container.
-This includes the process to run, environment variables to inject, sandboxing features to use, etc.
 
 Below is a detailed description of each field defined in the configuration format and valid values are specified.
 Platform-specific fields are identified as such.


### PR DESCRIPTION
Instead of leading off with links to a bunch of other places, notes on the Go tags, etc., make things more inviting by leading off with a big-picture summary of what the configuration is about.

Also drop the `config.json` existence MUST because:

1. This section defines the configuration format, and doesn't need to be tied to a particular filename.
2. The bundle spec (in `bundle.md`) already [has][1]:

    > This REQUIRED file MUST reside in the root of the bundle directory and MUST be named `config.json`.

The `config.md` line may have been useful when it was added (77d44b10).  But since the `bundle.md` line landed in #210, I think it's been redundant.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/bundle.md#L14