### PR TITLE
README: Link to MeetBot logs for meeting minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ There is an [iCalendar][rfc5545] format for the meetings [here](meeting.ics).
 
 Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: +1 415 968 0849 (no PIN needed).
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki][runtime-wiki].
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes], with minutes from especially old meetings (September 2015 and earlier) archived [here][runtime-wiki].
 
 ### Mailing List
 
@@ -155,6 +155,7 @@ Read more on [How to Write a Git Commit Message][how-to-git-commit] or the Discu
 [how-to-git-commit]: http://chris.beams.io/posts/git-commit
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
 [iso-week]: https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_of_a_given_date
+[minutes]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/
 [oci]: https://www.opencontainers.org
 [rfc5545]: https://tools.ietf.org/html/rfc5545
 [runtime-wiki]: https://github.com/opencontainers/runtime-spec/wiki


### PR DESCRIPTION
@RobDolinMS had been keeping the wiki up to date with links to the MeetBot logs, but linking directly to the MeetBot logs gives us one less thing to maintain.  The meetings which are only in the wiki are 2015-07-22, 2015-08-05, 2015-08-12, 2015-08-26, 2015-09-02, 2015-09-09, 2015-09-16, 2015-09-24, 2015-09-30.  The last is in MeetBot, but it was our first MeetBot meeting, so the MeetBot logs are not great.