### PR TITLE
README: E.123 number for meeting call

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The contributors and maintainers of all OCI projects have a weekly meeting on We
 
 There is an [iCalendar][rfc5545] format for the meetings [here](meeting.ics).
 
-Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: 415-968-0849 (no PIN needed.)
+Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: +1 415 968 0849 (no PIN needed).
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
 Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki][runtime-wiki].
 


### PR DESCRIPTION
And fix a period/paren swap.  The period/paren swap and contry-code addition both bring the local version more in line with [the image-spec version][1] and seem like good changes.

I've diverged from the image-spec version by using space separation in the phone number instead of hyphens.  From [E.123][3]:

> 9.1  Grouping of digits in a telephone number⁵ should be accomplished by means or spaces⁶ unless an agreed upon explicit symbol (e.g. hyphen) is necessary for procedural purposes. Only spaces should be used in an international number.

[1]: https://github.com/opencontainers/image-spec/blob/v1.0.0-rc5/README.md#weekly-call
[3]: https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-E.123-200102-I!!PDF-E&type=items