### PR TITLE
*: Replace "array" type with "array of objects"

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -356,14 +356,14 @@ The following parameters can be specified to setup the controller:
 
 * **`blkioLeafWeight`** *(uint16, OPTIONAL)* - equivalents of `blkioWeight` for the purpose of deciding how much weight tasks in the given cgroup has while competing with the cgroup's child cgroups. The range is from 10 to 1000.
 
-* **`blkioWeightDevice`** *(array, OPTIONAL)* - specifies the list of devices which will be bandwidth rate limited. The following parameters can be specified per-device:
+* **`blkioWeightDevice`** *(array of objects, OPTIONAL)* - specifies the list of devices which will be bandwidth rate limited. The following parameters can be specified per-device:
     * **`major, minor`** *(int64, REQUIRED)* - major, minor numbers for device. More info in `man mknod`.
     * **`weight`** *(uint16, OPTIONAL)* - bandwidth rate for the device, range is from 10 to 1000
     * **`leafWeight`** *(uint16, OPTIONAL)* - bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
 
     You must specify at least one of `weight` or `leafWeight` in a given entry, and can specify both.
 
-* **`blkioThrottleReadBpsDevice`**, **`blkioThrottleWriteBpsDevice`**, **`blkioThrottleReadIOPSDevice`**, **`blkioThrottleWriteIOPSDevice`** *(array, OPTIONAL)* - specify the list of devices which will be IO rate limited.
+* **`blkioThrottleReadBpsDevice`**, **`blkioThrottleWriteBpsDevice`**, **`blkioThrottleReadIOPSDevice`**, **`blkioThrottleWriteIOPSDevice`** *(array of objects, OPTIONAL)* - specify the list of devices which will be IO rate limited.
   The following parameters can be specified per-device:
     * **`major, minor`** *(int64, REQUIRED)* - major, minor numbers for device. More info in `man mknod`.
     * **`rate`** *(uint64, REQUIRED)* - IO rate limit for the device
@@ -436,7 +436,7 @@ The following parameters can be specified to setup the controller:
 
 * **`classID`** *(uint32, OPTIONAL)* - is the network class identifier the cgroup's network packets will be tagged with
 
-* **`priorities`** *(array, OPTIONAL)* - specifies a list of objects of the priorities assigned to traffic originating from processes in the group and egressing the system on various interfaces.
+* **`priorities`** *(array of objects, OPTIONAL)* - specifies a list of objects of the priorities assigned to traffic originating from processes in the group and egressing the system on various interfaces.
   The following parameters can be specified per-priority:
     * **`name`** *(string, REQUIRED)* - interface name
     * **`priority`** *(uint32, REQUIRED)* - priority applied to the interface

--- a/config.md
+++ b/config.md
@@ -46,7 +46,7 @@ For example, if a configuration is compliant with version 1.1 of this specificat
 
 ## <a name="configMounts" />Mounts
 
-**`mounts`** (array, OPTIONAL) specifies additional mounts beyond [`root`](#root).
+**`mounts`** (array of objects, OPTIONAL) specifies additional mounts beyond [`root`](#root).
 The runtime MUST mount entries in the listed order.
 For Linux, the parameters are as documented in [mount(2)][mount.2] system call man page.
 For Solaris, the mount entry corresponds to the 'fs' resource in the [zonecfg(1M)][zonecfg.1m] man page.
@@ -350,16 +350,16 @@ Implementations MUST error out when invalid values are encountered and MUST gene
 Hooks allow for the configuration of custom actions related to the [lifecycle](runtime.md#lifecycle) of the container.
 
 * **`hooks`** (object, OPTIONAL) MAY contain any of the following properties:
-  * **`prestart`** (array, OPTIONAL) is an array of [pre-start hooks](#prestart).
+  * **`prestart`** (array of objects, OPTIONAL) is an array of [pre-start hooks](#prestart).
     Entries in the array contain the following properties:
     * **`path`** (string, REQUIRED) with similar semantics to [IEEE Std 1003.1-2001 `execv`'s *path*][ieee-1003.1-2001-xsh-exec].
       This specification extends the IEEE standard in that **`path`** MUST be absolute.
     * **`args`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2001 `execv`'s *argv*][ieee-1003.1-2001-xsh-exec].
     * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2001's `environ`][ieee-1003.1-2001-xbd-c8.1].
     * **`timeout`** (int, OPTIONAL) is the number of seconds before aborting the hook.
-  * **`poststart`** (array, OPTIONAL) is an array of [post-start hooks](#poststart).
+  * **`poststart`** (array of objects, OPTIONAL) is an array of [post-start hooks](#poststart).
     Entries in the array have the same schema as pre-start entries.
-  * **`poststop`** (array, OPTIONAL) is an array of [post-stop hooks](#poststop).
+  * **`poststop`** (array of objects, OPTIONAL) is an array of [post-stop hooks](#poststop).
     Entries in the array have the same schema as pre-start entries.
 
 Hooks allow users to specify programs to run before or after various lifecycle events.


### PR DESCRIPTION
We have a few different element types in our arrays, so it's useful to clarify the element type for the property being specified.  Before this commit:

    $ sed -n 's|.*\*\*`\([^`]*\)`\*\*[^(]*(\([^,]*\),.*|\2|p' *.md | sort | uniq -c | grep array
          7 array
          1 array of ints
          8 array of objects
         13 array of strings

All of the bare `array` instances turned out to be arrays of objects.