### PR TITLE
config: Replace '$GOOS' with 'GOOS', etc.

### DIFF
--- a/config.md
+++ b/config.md
@@ -298,12 +298,12 @@ For Windows based systems the user structure has the following fields:
 
 * **`os`** (string, REQUIRED) specifies the operating system family of the container configuration's specified [`root`](#root) file system bundle.
   The runtime MUST generate an error if it does not support the specified **`os`**.
-  Bundles SHOULD use, and runtimes SHOULD understand, **`os`** entries listed in the Go Language document for [`$GOOS`][go-environment].
-  If an operating system is not included in the `$GOOS` documentation, it SHOULD be submitted to this specification for standardization.
+  Bundles SHOULD use, and runtimes SHOULD understand, **`os`** entries listed in the Go Language document for [`GOOS`][go-environment].
+  If an operating system is not included in the `GOOS` documentation, it SHOULD be submitted to this specification for standardization.
 * **`arch`** (string, REQUIRED) specifies the instruction set for which the binaries in the specified [`root`](#root) file system bundle have been compiled.
   The runtime MUST generate an error if it does not support the specified **`arch`**.
-  Values for **`arch`** SHOULD use, and runtimes SHOULD understand, **`arch`** entries listed in the Go Language document for [`$GOARCH`][go-environment].
-  If an architecture is not included in the `$GOARCH` documentation, it SHOULD be submitted to this specification for standardization.
+  Values for **`arch`** SHOULD use, and runtimes SHOULD understand, **`arch`** entries listed in the Go Language document for [`GOARCH`][go-environment].
+  If an architecture is not included in the `GOARCH` documentation, it SHOULD be submitted to this specification for standardization.
 
 ### Example
 


### PR DESCRIPTION
Windows' [`cmd.exe` prefers wrapping in `%`][1] (e.g. `%GOOS%`), and @RobDolinMS has asked for the POSIX `$` to be removed (#477).  In this case, I think the context is sufficient that we can just use the variable name instead of Rob's recommended “for the environment variable FOO”.

Fixes #477.

[1]: https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/ntcmds_shelloverview.mspx?mfr=true