### PR TITLE
config: Drop the redundant config.json filename requirement

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,6 +1,5 @@
 # <a name="containerConfigurationFile" />Container Configuration file
 
-The container's top-level directory MUST contain a configuration file called `config.json`.
 The canonical schema is defined in this document, but there is a JSON Schema in [`schema/config-schema.json`](schema/config-schema.json) and Go bindings in [`specs-go/config.go`](specs-go/config.go).
 [Platform](spec.md#platforms)-specific configuration schema are defined in the [platform-specific documents](#platform-specific-configuration) linked below.
 For properties that are only defined for some [platforms](spec.md#platforms), the Go property has a `platform` tag listing those protocols (e.g. `platform:"linux,solaris"`).


### PR DESCRIPTION
Because:

1. This section defines the configuration format, and doesn't need to be tied to a particular filename.
2. The bundle spec (in `bundle.md`) already has:

    > This REQUIRED file MUST reside in the root of the bundle directory and MUST be named `config.json`.

The config.md line may have been useful when it was added (77d44b10).  But since the bundle.md line landed in 106ec2da (#210), I think it's been redundant.