### PR TITLE
meeting: Add UberConference information

### DIFF
--- a/meeting.ics
+++ b/meeting.ics
@@ -21,24 +21,30 @@ END:DAYLIGHT
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:tdc-meeting-1@opencontainers.org
-DTSTAMP:20170322T223000Z
+DTSTAMP:20170405T180000Z
 DTSTART;TZID=America/Los_Angeles:20170329T080000
 RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
 DURATION:PT1H
 SUMMARY:OCI TDC Meeting
 DESCRIPTION;ALTREP="https://github.com/opencontainers/runtime-spec#
- weekly-call":Open Containers Initiative Developer Meeting
+ weekly-call":Open Containers Initiative Developer Meeting\n
+ Web: https://www.uberconference.com/opencontainers\n
+ Audio-only: +1 415 968 0849 (no PIN needed)
+LOCATION:https://www.uberconference.com/opencontainers
 URL:https://github.com/opencontainers/runtime-spec/blob/master/meeting.ics
 END:VEVENT
 BEGIN:VEVENT
 UID:tdc-meeting-2@opencontainers.org
-DTSTAMP:20170322T223000Z
+DTSTAMP:20170405T180000Z
 DTSTART;TZID=America/Los_Angeles:20170405T170000
 RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
 DURATION:PT1H
 SUMMARY:OCI TDC Meeting
 DESCRIPTION;ALTREP="https://github.com/opencontainers/runtime-spec#
- weekly-call":Open Containers Initiative Developer Meeting
+ weekly-call":Open Containers Initiative Developer Meeting\n
+ Web: https://www.uberconference.com/opencontainers\n
+ Audio-only: +1 415 968 0849 (no PIN needed)
+LOCATION:https://www.uberconference.com/opencontainers
 URL:https://github.com/opencontainers/runtime-spec/blob/master/meeting.ics
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
And bump `DTSTAMP` for the touched `VEVENTS`.

This is less DRY, but makes life easier for folks pulling up the calendar a minute before the meeting, since they don't have to click through to the README section.  Also [requested][1] by @vbatts ;).

The [`LOCATION`][2] entry seems like a reasonable location for the conference-call page, so I've used that.  Note that the URI there is a text value; `LOCATION` [supports URIs in `ALTREP`][2], but the UberConference page isn't an “[alternate text representation for the property value][3]”.  The URI in `DESCRIPTION` is a fallback for clients that don't support/display `LOCATION` (I'm not sure if any exist, but it's easy to play it safe).  I couldn't find a more structured location for the phone number, unless we also wanted to put that in `LOCATION`.

The ICS was validated [here][4].

[1]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-04-05.log.html#t2017-04-05T17:55:25
[2]: https://tools.ietf.org/html/rfc5545#section-3.8.1.7
[3]: https://tools.ietf.org/html/rfc5545#section-3.2.1
[4]: https://icalendar.org/validator.html