### PR TITLE
meeting: Include README link in DESCRIPTION body

### DIFF
--- a/meeting.ics
+++ b/meeting.ics
@@ -21,13 +21,14 @@ END:DAYLIGHT
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:tdc-meeting-1@opencontainers.org
-DTSTAMP:20170405T180000Z
+DTSTAMP:20170405T220000Z
 DTSTART;TZID=America/Los_Angeles:20170329T080000
 RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
 DURATION:PT1H
 SUMMARY:OCI TDC Meeting
 DESCRIPTION;ALTREP="https://github.com/opencontainers/runtime-spec#
  weekly-call":Open Containers Initiative Developer Meeting\n
+ https://github.com/opencontainers/runtime-spec#weekly-call\n
  Web: https://www.uberconference.com/opencontainers\n
  Audio-only: +1 415 968 0849 (no PIN needed)
 LOCATION:https://www.uberconference.com/opencontainers
@@ -35,13 +36,14 @@ URL:https://github.com/opencontainers/runtime-spec/blob/master/meeting.ics
 END:VEVENT
 BEGIN:VEVENT
 UID:tdc-meeting-2@opencontainers.org
-DTSTAMP:20170405T180000Z
+DTSTAMP:20170405T220000Z
 DTSTART;TZID=America/Los_Angeles:20170405T170000
 RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
 DURATION:PT1H
 SUMMARY:OCI TDC Meeting
 DESCRIPTION;ALTREP="https://github.com/opencontainers/runtime-spec#
  weekly-call":Open Containers Initiative Developer Meeting\n
+ https://github.com/opencontainers/runtime-spec#weekly-call\n
  Web: https://www.uberconference.com/opencontainers\n
  Audio-only: +1 415 968 0849 (no PIN needed)
 LOCATION:https://www.uberconference.com/opencontainers


### PR DESCRIPTION
And bump `DTSTAMP` for the touched `VEVENTS`.

com.android.calendar version 7.1.1 only displays the `DESCRIPTION` body, and does not provide a link to `ALTREP` (in fact, I don't see any instances of `ALTREP` in [the source][1]).  Including the README link in the `DESCRIPTION` body gives folks using that calendar application an easy way to get to the README section.

The ICS was validated [here][2].

This will conflict with #757.  There's already one LGTM there, so I suggest landing that one first.  However, I'm happy to rebase whichever PR lands second.

[1]: https://android.googlesource.com/platform/packages/apps/Calendar/+/android-7.1.1_r38
[2]: https://icalendar.org/validator.html