### PR TITLE
config: process.user.username is implementation-defined on Windows

### DIFF
--- a/config.md
+++ b/config.md
@@ -260,6 +260,8 @@ _Note: symbolic name for uid and gid, such as uname and gname respectively, are 
 For Windows based systems the user structure has the following fields:
 
 * **`username`** (string, OPTIONAL) specifies the user name for the process.
+    The value MUST NOT be an empty string.
+    The default `username` is implementation-defined.
 
 ### Example (Windows)
 

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -130,6 +130,11 @@
                         "additionalGids": {
                             "id": "https://opencontainers.org/schema/bundle/process/user/additionalGids",
                             "$ref": "defs.json#/definitions/ArrayOfGIDs"
+                        },
+                        "username": {
+                            "id": "https://opencontainers.org/schema/bundle/process/user/username",
+                            "type": "string",
+                            "minLength": 1
                         }
                     }
                 },


### PR DESCRIPTION
On POSIX (currently Linux and Solaris), [`uid` and `gid` are required][1]. My preferred approach here is to [make those optional][2] and [use platform defaults][3]:

    If unset, the runtime will not attempt to manipulate the user ID (e.g. not calling setuid(2) or similar).

But the maintainer consensus is that they want those to be [explicitly][4] [required][5] [properties][6].

The Windows `username`, on the other hand, [*is* optional][7], although the default behavior is unclear.  I see no discussion in #565 to suggest whether this was intentionally approved or not.  And in #618 (where I asked about the inconsistency), @crosbymichael [said][8]:

> No, both should be made explicit unless there is something on windows that prohibits this.

So this commit is making that happen.

Pinging some Windows folks for review of the “unless there is something on windows that prohibits this” condition: @jhowardmsft, @RobDolinMS, @jstarks.

Note that there is also a JSON Schema PR for `username` in flight with #703, but that is orthogonal to this change (the JSON Schema cannot require `username` even if the field is REQUIRED on Windows, because it is not required, or even specified, on other OSes).

Fixes #618.

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config.md#linux-and-solaris-user
[2]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/DWdystx5X3A
[3]: https://github.com/opencontainers/runtime-spec/pull/417#issuecomment-216076069
[4]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2016/opencontainers.2016-05-04-17.00.log.html#l-44
[5]: https://github.com/opencontainers/runtime-spec/pull/417#issuecomment-216937010
[6]: https://github.com/opencontainers/runtime-spec/pull/417#issuecomment-216937090
[7]: https://github.com/opencontainers/runtime-spec/blob/cc983bb6f4ca85194dc6d64ee300cca00e495070/config.md#windows-user
[8]: https://github.com/opencontainers/runtime-spec/issues/618#issuecomment-277105273