### PR TITLE
config: Specify height/width units (characters) for consoleSize

### DIFF
--- a/config.md
+++ b/config.md
@@ -124,7 +124,7 @@ For Windows, see [mountvol][mountvol] and [SetVolumeMountPoint][set-volume-mount
 
 * **`terminal`** (bool, OPTIONAL) specifies whether a terminal is attached to that process, defaults to false.
   As an example, if set to true on Linux a pseudoterminal pair is allocated for the container process and the pseudoterminal slave is duplicated on the container process's [standard streams][stdin.3].
-* **`consoleSize`** (object, OPTIONAL) specifies the console size of the terminal if attached, containing the following properties:
+* **`consoleSize`** (object, OPTIONAL) specifies the console size in characters of the terminal if attached, containing the following properties:
   * **`height`** (uint, REQUIRED)
   * **`width`** (uint, REQUIRED)
 * **`cwd`** (string, REQUIRED) is the working directory that will be set for the executable.


### PR DESCRIPTION
This is pretty clear from the examples like [this][1]:

    "consoleSize": {
      "height": 25,
      "width": 80
    }

But examples are not normative, so this commit makes the character units normative.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/config.md#L180