### PR TITLE
specs-go/config: Add omitempty to LinuxSyscall.Args

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -551,7 +551,7 @@ type LinuxSeccompArg struct {
 type LinuxSyscall struct {
 	Names  []string           `json:"names"`
 	Action LinuxSeccompAction `json:"action"`
-	Args   []LinuxSeccompArg  `json:"args"`
+	Args   []LinuxSeccompArg  `json:"args,omitempty"`
 }
 
 // LinuxIntelRdt has container runtime resource constraints


### PR DESCRIPTION
It used to have this, but the `omitempty` [was][1] [dropped][2] in #657.  However, the docs that landed in #706 [list the property as optional][3], and if it is optional, we can leave it unset instead of serializing an empty array.

If it should be required, then we should also require it to have a minimum length of 1 (#762).

Ping @GrantSeltzer, @q384566678.

[1]: https://github.com/opencontainers/runtime-spec/pull/657/files#diff-7f24d60f0cbb9c433e165467e3d34838L534
[2]: https://github.com/opencontainers/runtime-spec/pull/657/files#diff-7f24d60f0cbb9c433e165467e3d34838R534
[3]: https://github.com/opencontainers/runtime-spec/pull/706/files#diff-428eec4013a655816cdefafd5d3505f1R543