### PR TITLE
config: Require strictly-positive timeout values

### DIFF
--- a/config.md
+++ b/config.md
@@ -357,6 +357,7 @@ Hooks allow for the configuration of custom actions related to the [lifecycle](r
     * **`args`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2001 `execv`'s *argv*][ieee-1003.1-2001-xsh-exec].
     * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2001's `environ`][ieee-1003.1-2001-xbd-c8.1].
     * **`timeout`** (int, OPTIONAL) is the number of seconds before aborting the hook.
+      If set, `timeout` MUST be greater than zero.
   * **`poststart`** (array of objects, OPTIONAL) is an array of [post-start hooks](#poststart).
     Entries in the array have the same schema as pre-start entries.
   * **`poststop`** (array of objects, OPTIONAL) is an array of [post-stop hooks](#poststop).

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -91,7 +91,8 @@
                     "$ref": "#/definitions/Env"
                 },
                 "timeout": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 }
             },
             "required": [


### PR DESCRIPTION
If the timeout value was zero, the hook would always error, and there doesn't seem to be much point to that.  And I'm not sure what negative timeouts would mean.  By adding this restriction, we do not limit useful hook entries, and we give the validation code grounds to warn users attempting to validate configs which are poorly defined or have useless hook entries.

Removing the pointer is not strictly required, but keeps up with our [anti-pointer zero-value style][1] now that Go's zero-value is clearly invalid.

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc5/style.md#optional-settings-should-not-have-pointer-go-types