### PR TITLE
spec: Add "NOT RECOMMENDED" to RFC 2119 keywords

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -33,7 +33,7 @@ Platforms defined by this specification are:
 
 # <a name="ociRuntimeSpecNotationalConventions" />Notational Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119][rfc2119].
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119][rfc2119].
 
 The key words "unspecified", "undefined", and "implementation-defined" are to be interpreted as described in the [rationale for the C99 standard][c99-unspecified].
 


### PR DESCRIPTION
Catching up with [erratum 499][1].

[1]: https://www.rfc-editor.org/errata_search.php?rfc=2119&eid=499