### PR TITLE
schema/defs-linux: Drop 'Capability' type

### DIFF
--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -141,35 +141,35 @@
                             "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/bounding",
                             "type": "array",
                             "items": {
-                                "$ref": "defs-linux.json#/definitions/Capability"
+                                "type": "string"
                             }
                         },
                         "permitted": {
                             "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/permitted",
                             "type": "array",
                             "items": {
-                                "$ref": "defs-linux.json#/definitions/Capability"
+                                "type": "string"
                             }
                         },
                         "effective": {
                             "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/effective",
                             "type": "array",
                             "items": {
-                                "$ref": "defs-linux.json#/definitions/Capability"
+                                "type": "string"
                             }
                         },
                         "inheritable": {
                             "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/inheritable",
                             "type": "array",
                             "items": {
-                                "$ref": "defs-linux.json#/definitions/Capability"
+                                "type": "string"
                             }
                         },
                         "ambient": {
                             "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/ambient",
                             "type": "array",
                             "items": {
-                                "$ref": "defs-linux.json#/definitions/Capability"
+                                "type": "string"
                             }
                         }
                     }

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -82,11 +82,6 @@
                 }
             }
         },
-        "Capability": {
-            "description": "Linux process capabilities",
-            "type": "string",
-            "pattern": "^CAP_([A-Z]|_)+$"
-        },
         "Major": {
             "description": "major device number",
             "$ref": "defs.json#/definitions/int64"


### PR DESCRIPTION
The current “[For example, valid values for Linux…][1]” wording in config.md does not seem strong enough to support this condition, especially since the spec makes no claims about what valid capabilities are for non-Linux OSes.  And `process.capabilities` has been nominally legal for non-Linux OSes since #673.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/config.md#L135-L136