### PR TITLE
config-linux: RFC 2119 tightening for namespaces

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -35,11 +35,14 @@ The following parameters can be specified to setup namespaces:
     * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container.
     * **`cgroup`** the container will have an isolated view of the cgroup hierarchy.
 
-* **`path`** *(string, OPTIONAL)* - an absolute path to namespace file in the [runtime mount namespace](glossary.md#runtime-namespace)
+* **`path`** *(string, OPTIONAL)* - an absolute path to namespace file in the [runtime mount namespace](glossary.md#runtime-namespace).
+    The runtime MUST place the container process in the namespace associated with that `path`.
+    The runtime MUST [generate an error](runtime.md#errors) if `path` is not associated with a namespace of type `type`.
 
-If a path is specified, that particular file is used to join that type of namespace.
+    If `path` is not specified, the runtime MUST create a new [container namespace](glossary.md#container-namespace) of type `type`.
+
 If a namespace type is not specified in the `namespaces` array, the container MUST inherit the [runtime namespace](glossary.md#runtime-namespace) of that type.
-If a `namespaces` field contains duplicated namespaces with same `type`, the runtime MUST error out.
+If a `namespaces` field contains duplicated namespaces with same `type`, the runtime MUST [generate an error](runtime.md#errors).
 
 ###### Example
 


### PR DESCRIPTION
Previously we had no MUST-level runtime requirements for namespace entries in valid configs.  This commit attempts to pin those down.  For more background on hierarchical namespaces, see [here][1].  For more background on the owning user namespace idea, see [here][2], [here][3], and [here][4].

The “`path` not associated with a namespace of type `type`” condition ensures that runtimes don't blindly call `setns(2)` on the path without setting `nstype` nonzero.

Part of #746.

Ping @cyphar, especially on the owning-user-namespace condition.

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a7306ed8d94af729ecef8b6e37506a1c6fc14788
[2]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6786741dbf99e44fb0c0ed85a37582b8a26f1c3b
[3]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e5ff5ce6e20ee22511398bb31fb912466cf82a36
[4]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d95fa3c76a66b6d76b1e109ea505c55e66360f3c