### PR TITLE
config-linux: Make linux.seccomp.syscalls OPTIONAL

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -610,7 +610,10 @@ The following parameters can be specified to setup seccomp:
     * `SCMP_ARCH_PARISC`
     * `SCMP_ARCH_PARISC64`
 
-* **`syscalls`** *(array of objects, REQUIRED)* - match a syscall in seccomp.
+* **`syscalls`** *(array of objects, OPTIONAL)* - match a syscall in seccomp.
+
+    While this property is OPTIONAL, some values of `defaultAction` are not useful without `syscalls` entries.
+    For example, if `defaultAction` is `SCMP_ACT_KILL` and `syscalls` is empty or unset, the kernel will kill the container process on its first syscall.
 
     Each entry has the following structure:
 

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -251,7 +251,10 @@
                             "$ref": "defs-linux.json#/definitions/Syscall"
                         }
                     }
-                }
+                },
+                "required": [
+                    "defaultAction"
+                ]
             },
             "sysctl": {
                 "id": "https://opencontainers.org/schema/bundle/linux/sysctl",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -484,7 +484,7 @@ type WindowsNetworkResources struct {
 type LinuxSeccomp struct {
 	DefaultAction LinuxSeccompAction `json:"defaultAction"`
 	Architectures []Arch             `json:"architectures,omitempty"`
-	Syscalls      []LinuxSyscall     `json:"syscalls"`
+	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
 }
 
 // Arch used for additional architectures


### PR DESCRIPTION
Fixes #762, since the issue there has been quiet, and [1.0 may be almost upon us][1], so I'm nervous about leaving the issue to cook for too long ;).

This commit has gone with OPTIONAL, because a seccomp config which only sets `defaultAction` seems potentially valid.  But I'd be ok with the “REQUIRED with length > 0” approach to fixing #762 too.

[1]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2017/opencontainers.2017-04-12-14.59.log.html#l-13