### PR TITLE
config-linux: Require at least one entry in linux.seccomp.sycalls[].names

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -615,6 +615,7 @@ The following parameters can be specified to setup seccomp:
     Each entry has the following structure:
 
     * **`names`** *(array of strings, REQUIRED)* - the names of the syscalls.
+        `names` MUST contain at least one entry.
 
     * **`action`** *(string, REQUIRED)* - the action for seccomp rules.
         A valid list of constants as of libseccomp v2.3.2 is shown below.

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -69,7 +69,8 @@
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "minItems": 1
                 },
                 "action": {
                     "$ref": "#/definitions/SeccompAction"
@@ -80,7 +81,10 @@
                         "$ref": "#/definitions/SyscallArg"
                     }
                 }
-            }
+            },
+            "required": [
+                "names"
+            ]
         },
         "Capability": {
             "description": "Linux process capabilities",


### PR DESCRIPTION
I expect the (undocumented) intention here is to iterate through `names` and call `seccomp_rule_add(3)` or similar for each name.  In that case, an empty `names` makes the whole syscall entry a no-op, and with this commit we can warn users who are validating such configs.

If, on the other hand, we were comfortable with no-op syscall entries, we'd want to make `names` OPTIONAL.

Warning folks who accidentally empty (or don't set) `names` seems more useful to me, and doesn't restrict the useful config space, so that's what I've gone with in this commit.

`minItems` is documented [here][1], and there is an example of its use [here][2]:

```
  "options": {
    "type": "array",
    "minItems": 1,
    "items": { "type": "string" },
    "uniqueItems": true
  },
```

[Part][3] of #762.

[1]: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.11
[2]: http://json-schema.org/example2.html
[3]: https://github.com/opencontainers/runtime-spec/issues/762#issuecomment-292450654