### PR TITLE
config: Document 'rbind' and 'bind' mount options extensions

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -112,7 +112,7 @@ type Platform struct {
 type Mount struct {
 	// Destination is the path where the mount will be placed relative to the container's root.  The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
 	Destination string `json:"destination"`
-	// Type specifies the mount kind.
+	// Type specifies the type of filesystem to mount.
 	Type string `json:"type,omitempty"`
 	// Source specifies the source path of the mount.  In the case of bind mounts on
 	// Linux based systems this would be the file on the host.


### PR DESCRIPTION
My last attempt to get (recursive) bind mounts documented was in #530, which was rejected based on “[`MS_REC` makes no sense what-so-ever outside of a bind mount][1]”.  That [doesn't make sense to me][2], with `mount(8)` exposing `MS_REC | MS_SHARED` as `--make-rshared`, `MS_REC | MS_SLAVE` as `--make-rslave`, etc., but here's a reroll that uses `rbind` and `bind` instead, with a goal of specifying the (recursive) bind syntax so runtime-tools can rely on that instead of [blindly assuming runtimes support an unspecified bind syntax][3].

[1]: https://github.com/opencontainers/runtime-spec/pull/530#issuecomment-257028720
[2]: https://github.com/opencontainers/runtime-spec/pull/530#issuecomment-258664079
[3]: https://github.com/opencontainers/runtime-tools/blob/18a122b45a71765b09c6a451008a63687040b74a/generate/generate.go#L799-L817