### PR TITLE
Change Windows CPU Percent to Maximum

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -40,7 +40,7 @@ The following parameters can be specified:
 
 * **`shares`** *(uint16, OPTIONAL)* - specifies the relative weight to other containers with CPU shares.
 
-* **`percent`** *(uint, OPTIONAL)* - specifies the percentage of available CPUs usable by the container.
+* **`maximum`** *(uint, OPTIONAL)* - specifies the portion of processor cycles that this container can use as a percentage times 100.
 
 #### Example
 
@@ -48,7 +48,7 @@ The following parameters can be specified:
     "windows": {
         "resources": {
             "cpu": {
-                "percent": 50
+                "maximum": 5000
             }
         }
     }

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -34,9 +34,9 @@
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/shares",
                                 "$ref": "defs-windows.json#/definitions/cpuShares"
                             },
-                            "percent": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/percent",
-                                "$ref": "defs.json#/definitions/percent"
+                            "maximum": {
+                                "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/maximum",
+                                "$ref": "defs.json#/definitions/uint16"
                             }
                         }
                     },

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -460,8 +460,8 @@ type WindowsCPUResources struct {
 	Count *uint64 `json:"count,omitempty"`
 	// CPU shares (relative weight to other containers with cpu shares). Range is from 1 to 10000.
 	Shares *uint16 `json:"shares,omitempty"`
-	// Percent of available CPUs usable by the container.
-	Percent *uint8 `json:"percent,omitempty"`
+	// Specifies the portion of processor cycles that this container can use as a percentage times 100.
+	Maximum *uint16 `json:"maximum,omitempty"`
 }
 
 // WindowsStorageResources contains storage resource management settings.


### PR DESCRIPTION
In order to increase the granularity of CPU resource control, change the CPU Percent (0-100) resource setting to CPU Maximum (0-10000)

The HCS API accepts a ProcessorMaximum, which is a percentage multiplied by 100. This PR allows finer control over the CPU resources of Windows containers by extending the ProcessorMaximum into the OCI spec, rather than truncating to a 0-100 percent.

The discussion context is https://github.com/moby/moby/issues/32014 and https://github.com/moby/moby/pull/32608. The implementation of NanoCPUs in Moby should be able to scale to precision smaller than a single percent of total CPU resources.

/cc @jhowardmsft 

Signed-off-by: Darren Stahl <darst@microsoft.com>