### PR TITLE
schema/Makefile: Add .PHONY declarations for phony targets

### DIFF
--- a/schema/Makefile
+++ b/schema/Makefile
@@ -1,6 +1,8 @@
 
+.PHONY: default
 default: validate
 
+.PHONY: help
 help:
 	@echo "Usage: make [target]"
 	@echo
@@ -8,6 +10,7 @@ help:
 	@echo " * 'help' - show this help information"
 	@echo " * 'validate' - build the validation tool"
 
+.PHONY: fmt
 fmt:
 	for i in *.json ; do jq --indent 4 -M . "$${i}" > xx && cat xx > "$${i}" && rm xx ; done
 
@@ -16,6 +19,6 @@ validate: validate.go
 	go get -d ./...
 	go build ./validate.go
 
+.PHONY: clean
 clean:
 	rm -f validate
-


### PR DESCRIPTION
The only non-phony target (where the target name matches the output file) is `validate`, but we need `.PHONY` there because the Go dependencies are not represented in the `Makefile`.  This commit adds the missing `.PHONY` declarations to the other targets, which truly are phony.

Spun off from [this discussion][1] and following the example set by [the `clean` entry in the main `Makefile`][2].

[1]: https://github.com/opencontainers/runtime-spec/pull/774#discussion_r112252004
[2]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc5/Makefile#L97-L98