### PR TITLE
Remove Memory reservation on Windows

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -15,16 +15,13 @@ The following parameters can be specified:
 
 * **`limit`** *(uint64, OPTIONAL)* - sets limit of memory usage in bytes.
 
-* **`reservation`** *(uint64, OPTIONAL)* - sets the guaranteed minimum amount of memory for a container in bytes.
-
 #### Example
 
 ```json
     "windows": {
         "resources": {
             "memory": {
-                "limit": 2097152,
-                "reservation": 524288
+                "limit": 2097152
             }
         }
     }

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -15,10 +15,6 @@
                             "limit": {
                                 "id": "https://opencontainers.org/schema/bundle/windows/resources/memory/limit",
                                 "$ref": "defs.json#/definitions/uint64"
-                            },
-                            "reservation": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/memory/reservation",
-                                "$ref": "defs.json#/definitions/uint64"
                             }
                         }
                     },

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -450,8 +450,6 @@ type WindowsResources struct {
 type WindowsMemoryResources struct {
 	// Memory limit in bytes.
 	Limit *uint64 `json:"limit,omitempty"`
-	// Memory reservation in bytes.
-	Reservation *uint64 `json:"reservation,omitempty"`
 }
 
 // WindowsCPUResources contains CPU resource management settings.


### PR DESCRIPTION
Windows does not have a memory reservation in the platform. This removes the field from the runtime spec.

Signed-off-by: Darren Stahl <darst@microsoft.com>