### PR TITLE
config: Shift oomScoreAdj from linux.resources to process

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -263,21 +263,6 @@ For more information, see [the memory cgroup man page][cgroup-v1-memory].
     "disableOOMKiller": false
 ```
 
-#### <a name="configLinuxSetOomScoreAdj" />Set oom_score_adj
-
-* **`oomScoreAdj`** *(int, OPTIONAL)* adjusts the oom-killer score in `[pid]/oom_score_adj` for the container process's `[pid]` in a [proc pseudo-filesystem][procfs].
-    If `oomScoreAdj` is set, the runtime MUST set `oom_score_adj` to the given value.
-    If `oomScoreAdj` is not set, the runtime MUST NOT change the value of `oom_score_adj`.
-
-This is a kernel/system level setting, where as `disableOOMKiller` is scoped for a memory cgroup.
-For more information on how these two settings work together, see [the memory cgroup documentation section 10. OOM Contol][cgroup-v1-memory].
-
-###### Example
-
-```json
-    "oomScoreAdj": 100
-```
-
 #### <a name="configLinuxMemory" />Memory
 
 **`memory`** (object, OPTIONAL) represents the cgroup subsystem `memory` and it's used to set limits on the container's memory usage.

--- a/config.md
+++ b/config.md
@@ -154,6 +154,12 @@ For Linux-based systems the process structure supports the following process spe
 
 * **`apparmorProfile`** (string, OPTIONAL) specifies the name of the AppArmor profile to be applied to processes in the container.
   For more information about AppArmor, see [AppArmor documentation][apparmor].
+* **`oomScoreAdj`** *(int, OPTIONAL)* adjusts the oom-killer score in `[pid]/oom_score_adj` for the container process's `[pid]` in a [proc pseudo-filesystem][procfs].
+    If `oomScoreAdj` is set, the runtime MUST set `oom_score_adj` to the given value.
+    If `oomScoreAdj` is not set, the runtime MUST NOT change the value of `oom_score_adj`.
+
+    This is a per-process setting, where as [`disableOOMKiller`](config-linux.md#disable-out-of-memory-killer) is scoped for a memory cgroup.
+    For more information on how these two settings work together, see [the memory cgroup documentation section 10. OOM Contol][cgroup-v1-memory_2].
 * **`selinuxLabel`** (string, OPTIONAL) specifies the SELinux label to be applied to the processes in the container.
   For more information about SELinux, see  [SELinux documentation][selinux].
 
@@ -503,6 +509,7 @@ Here is a full example `config.json` for reference.
             }
         ],
         "apparmorProfile": "acme_secure_profile",
+        "oomScoreAdj": 100,
         "selinuxLabel": "system_u:system_r:svirt_lxc_net_t:s0:c124,c675",
         "noNewPrivileges": true
     },
@@ -682,7 +689,6 @@ Here is a full example `config.json` for reference.
                     "limit": 9223372036854772000
                 }
             ],
-            "oomScoreAdj": 100,
             "memory": {
                 "limit": 536870912,
                 "reservation": 536870912,
@@ -818,8 +824,10 @@ Here is a full example `config.json` for reference.
 
 
 [apparmor]: https://wiki.ubuntu.com/AppArmor
+[cgroup-v1-memory_2]: https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
 [selinux]:http://selinuxproject.org/page/Main_Page
 [no-new-privs]: https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt
+[procfs_2]: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 [semver-v2.0.0]: http://semver.org/spec/v2.0.0.html
 [go-environment]: https://golang.org/doc/install/source#environment
 [ieee-1003.1-2001-xbd-c8.1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html#tag_08_01

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -47,10 +47,6 @@
                             "$ref": "defs-linux.json#/definitions/DeviceCgroup"
                         }
                     },
-                    "oomScoreAdj": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/oomScoreAdj",
-                        "type": "integer"
-                    },
                     "pids": {
                         "id": "https://opencontainers.org/schema/bundle/linux/resources/pids",
                         "type": "object",

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -178,6 +178,10 @@
                     "id": "https://opencontainers.org/schema/bundle/process/linux/apparmorProfile",
                     "type": "string"
                 },
+                "oomScoreAdj": {
+                    "id": "https://opencontainers.org/schema/bundle/process/linux/oomScoreAdj",
+                    "type": "integer"
+                },
                 "selinuxLabel": {
                     "id": "https://opencontainers.org/schema/bundle/process/linux/selinuxLabel",
                     "type": "string"

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -52,6 +52,8 @@ type Process struct {
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
 	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
+	// Specify an oom_score_adj for the container.
+	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
@@ -335,8 +337,6 @@ type LinuxResources struct {
 	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
-	// Specify an oom_score_adj for the container.
-	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
 	// Memory restriction configuration
 	Memory *LinuxMemory `json:"memory,omitempty"`
 	// CPU resource restriction configuration


### PR DESCRIPTION
The only discussion related to this is in #236 and #292, where the relationship between `oomScoreAdj` and `disableOOMKiller` is raised.  But since #137 resources has been tied to cgroups, and `oomScoreAdj` is not about cgroups. We [currently have][1]:

> You can configure a container's cgroups via the resources field of the Linux configuration.

In #782, I suggested we move the property from `linux.resources.oomScoreAdj` to `linux.oomScoreAdj` so config authors and runtimes don't have to worry about what `cgroupsPath` means if the only entry in `resources` is `oomScoreAdj`.  @crosbymichael [responded with][2]:

> If anything it should probably go on the process

So that's what this commit does.

Fixes #782.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0-rc5/config-linux.md#L185
[2]: https://github.com/opencontainers/runtime-spec/issues/782#issuecomment-299990075