### PR TITLE
specs-go/config: Use a pointer for Process.ConsoleSize

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -34,7 +34,7 @@ type Process struct {
 	// Terminal creates an interactive terminal for the container.
 	Terminal bool `json:"terminal,omitempty"`
 	// ConsoleSize specifies the size of the console.
-	ConsoleSize Box `json:"consoleSize,omitempty"`
+	ConsoleSize *Box `json:"consoleSize,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.


### PR DESCRIPTION
Avoid injecting `"consoleSize":{"height":0,"width":0}` when serializing with Go's stock JSON serializer.  Using a pointer for this optional struct property works around golang/go#11939.

Spun off from #759.