### PR TITLE
config-solaris: Restore 'zonecfg.1m_2' link targets

### DIFF
--- a/config-solaris.md
+++ b/config-solaris.md
@@ -1,6 +1,6 @@
 # <a name="solarisApplicationContainerConfiguration" />Solaris Application Container Configuration
 
-Solaris application containers can be configured using the following properties, all of the below properties have mappings to properties specified under [zonecfg(1M)][zonecfg.1m] man page, except milestone.
+Solaris application containers can be configured using the following properties, all of the below properties have mappings to properties specified under [zonecfg(1M)][zonecfg.1m_2] man page, except milestone.
 
 ## <a name="configSolarisMilestone" />milestone
 The SMF(Service Management Facility) FMRI which should go to "online" state before we start the desired process within the container.
@@ -26,7 +26,7 @@ The property should consist of a comma-separated privilege set specification as 
 ## <a name="configSolarisMaxShmMemory" />maxShmMemory
 The maximum amount of shared memory allowed for this application container.
 A scale (K, M, G, T) can be applied to the value for each of these numbers (for example, 1M is one megabyte).
-Mapped to `max-shm-memory` in [zonecfg(1M)][zonecfg.1m] man page.
+Mapped to `max-shm-memory` in [zonecfg(1M)][zonecfg.1m_2] man page.
 
 **`maxShmMemory`** *(string, OPTIONAL)*
 
@@ -40,7 +40,7 @@ Sets a limit on the amount of CPU time that can be used by a container.
 The unit used translates to the percentage of a single CPU that can be used by all user threads in a container, expressed as a fraction (for example, .75) or a mixed number (whole number and fraction, for example, 1.25).
 An ncpu value of 1 means 100% of a CPU, a value of 1.25 means 125%, .75 mean 75%, and so forth.
 When projects within a capped container have their own caps, the minimum value takes precedence.
-cappedCPU is mapped to `capped-cpu` in [zonecfg(1M)][zonecfg.1m] man page.
+cappedCPU is mapped to `capped-cpu` in [zonecfg(1M)][zonecfg.1m_2] man page.
 
 * **`ncpus`** *(string, OPTIONAL)*
 
@@ -54,7 +54,7 @@ cappedCPU is mapped to `capped-cpu` in [zonecfg(1M)][zonecfg.1m] man page.
 ## <a name="configSolarisCappedMemory" />cappedMemory
 The physical and swap caps on the memory that can be used by this application container.
 A scale (K, M, G, T) can be applied to the value for each of these numbers (for example, 1M is one megabyte).
-cappedMemory is mapped to `capped-memory` in [zonecfg(1M)][zonecfg.1m] man page.
+cappedMemory is mapped to `capped-memory` in [zonecfg(1M)][zonecfg.1m_2] man page.
 
 * **`physical`** *(string, OPTIONAL)*
 * **`swap`** *(string, OPTIONAL)*
@@ -78,26 +78,26 @@ For more information on the daemon see the [zoneadmd(1M)][zoneadmd.1m] man page.
 When such a container is started, a temporary VNIC(Virtual NIC) is automatically created for the container.
 The VNIC is deleted when the container is torn down.
 The following properties can be used to setup automatic networks.
-For additional information on properties, check the [zonecfg(1M)][zonecfg.1m] man page for the respective release of Solaris.
+For additional information on properties, check the [zonecfg(1M)][zonecfg.1m_2] man page for the respective release of Solaris.
 
 * **`linkname`** *(string, OPTIONAL)* Specify a name for the automatically created VNIC datalink.
 * **`lowerLink`** *(string, OPTIONAL)* Specify the link over which the VNIC will be created.
-Mapped to `lower-link` in the [zonecfg(1M)][zonecfg.1m] man page.
+Mapped to `lower-link` in the [zonecfg(1M)][zonecfg.1m_2] man page.
 * **`allowedAddress`** *(string, OPTIONAL)* The set of IP addresses that the container can use might be constrained by specifying the allowedAddress property.
 If allowedAddress has not been specified, then they can use any IP address on the associated physical interface for the network resource.
 Otherwise, when allowedAddress is specified, the container cannot use IP addresses that are not in the allowedAddress list for the physical address.
-Mapped to `allowed-address` in the [zonecfg(1M)][zonecfg.1m] man page.
+Mapped to `allowed-address` in the [zonecfg(1M)][zonecfg.1m_2] man page.
 * **`configureAllowedAddress`** *(string, OPTIONAL)* If configureAllowedAddress is set to true, the addresses specified by allowedAddress are automatically configured on the interface each time the container starts.
 When it is set to false, the allowedAddress will not be configured on container start.
-Mapped to `configure-allowed-address` in the [zonecfg(1M)][zonecfg.1m] man page.
+Mapped to `configure-allowed-address` in the [zonecfg(1M)][zonecfg.1m_2] man page.
 * **`defrouter`** *(string, OPTIONAL)* The value for the OPTIONAL default router.
 * **`macAddress`** *(string, OPTIONAL)* Set the VNIC's MAC addresses based on the specified value or keyword.
 If not a keyword, it is interpreted as a unicast MAC address.
-For a list of the supported keywords please refer to the [zonecfg(1M)][zonecfg.1m] man page of the respective Solaris release.
-Mapped to `mac-address` in the [zonecfg(1M)][zonecfg.1m] man page.
+For a list of the supported keywords please refer to the [zonecfg(1M)][zonecfg.1m_2] man page of the respective Solaris release.
+Mapped to `mac-address` in the [zonecfg(1M)][zonecfg.1m_2] man page.
 * **`linkProtection`** *(string, OPTIONAL)* Enables one or more types of link protection using comma-separated values.
 See the protection property in dladm(8) for supported values in respective release of Solaris.
-Mapped to `link-protection` in the [zonecfg(1M)][zonecfg.1m] man page.
+Mapped to `link-protection` in the [zonecfg(1M)][zonecfg.1m_2] man page.
 
 #### Example
 ```json
@@ -117,4 +117,4 @@ Mapped to `link-protection` in the [zonecfg(1M)][zonecfg.1m] man page.
 
 [priv-str-to-set.3c]: http://docs.oracle.com/cd/E53394_01/html/E54766/priv-str-to-set-3c.html
 [zoneadmd.1m]: http://docs.oracle.com/cd/E53394_01/html/E54764/zoneadmd-1m.html
-[zonecfg.1m]: https://docs.oracle.com/cd/E36784_01/html/E36871/zonecfg-1m.html
+[zonecfg.1m_2]: https://docs.oracle.com/cd/E36784_01/html/E36871/zonecfg-1m.html


### PR DESCRIPTION
These were added in #687 to follow the new [`_N` name-dedup policy][1] (vs. [the `config.md` target][2]).  They were just removed in #786 ([overlooking that policy][3]?).  This commit brings them back.

[1]: https://github.com/opencontainers/runtime-spec/blame/101e6f9d5c32579c245d8f45f4bdcd87f9a40cf9/style.md#L35
[2]: https://github.com/opencontainers/runtime-spec/blame/101e6f9d5c32579c245d8f45f4bdcd87f9a40cf9/config.md#L838
[3]: https://github.com/opencontainers/runtime-spec/pull/786#discussion_r115532596