### PR TITLE
config-linux: Specify relationships for new namespaces

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -40,6 +40,9 @@ The following parameters can be specified to setup namespaces:
     The runtime MUST [generate an error](runtime.md#errors) if `path` is not associated with a namespace of type `type`.
 
     If `path` is not specified, the runtime MUST create a new [container namespace](glossary.md#container-namespace) of type `type`.
+    For hierarchical namespaces (e.g. `pid`, `user`), the new container namespace MUST be a child of the [runtime namespace](glossary.md#runtime-namespace) of that type.
+    For seeded namespaces (e.g. `mount`, `uts`), the new container namespace MUST be seeded by the runtime namespace of that type.
+    When `type` is not `user`, new namespaces MUST be owned by the container `user` namespace.
 
 If a namespace type is not specified in the `namespaces` array, the container MUST inherit the [runtime namespace](glossary.md#runtime-namespace) of that type.
 If a `namespaces` field contains duplicated namespaces with same `type`, the runtime MUST [generate an error](runtime.md#errors).

--- a/glossary.md
+++ b/glossary.md
@@ -15,7 +15,7 @@ For example, namespaces, resource limits, and mounts are all part of the contain
 
 ## <a name="glossaryContainerNamespace" />Container namespace
 
-On Linux, a leaf in the [namespace][namespaces.7] hierarchy in which the [configured process](config.md#process) executes.
+On Linux, the [namespaces][namespaces.7] in which the [configured process](config.md#process) executes.
 
 ## <a name="glossaryJson" />JSON
 
@@ -30,9 +30,7 @@ It reads the [configuration files](#configuration) from a [bundle](#bundle), use
 
 ## <a name="glossaryRuntimeNamespace" />Runtime namespace
 
-On Linux, a leaf in the [namespace][namespaces.7] hierarchy from which the [runtime](#runtime) process is executed.
-New container namespaces will be created as children of the runtime namespaces.
-
+On Linux, the namespaces from which new [container namespaces](config-linux.md#namespaces) are created.
 
 [JSON]: https://tools.ietf.org/html/rfc7159
 [UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf


### PR DESCRIPTION
Spun off from #767, since these [are][1] [contentious][2].  I still think we want to say something about these relationships.

We already have some of “runtime namespace” conditions (e.g. when a type is not listed in `linux.namespaces[]`), so runtimes should already have implementation-specific wording around what the runtime namespaces are (we don't explicitly make them implementation-defined, although we probably should).  Anyhow, that's not a new concept added by this commit.

### Seeded namespaces

For example, if you ask for a new `uts` namespace but do not set the optional [`hostname`][3], having the seed defined means that the hostname in the container UTS namespace is well-defined (it will be whatever the hostname was in the runtime UTS namespace).

This is less of an issue for the mount namespace, because with [`root.path` REQUIRED][4], there's no way to avoid clobbering whatever mounts you got from your seed (which makes not asking for a new mount namespace exciting ;).

### Hierarchical namespaces

I think “I want this container to run in a new user/pid namespace that is a child of the runtime user/pid namespace” should be something that has a portable config expression.  Otherwise it becomes very unclear what to put in the `hostID` field for `(u|g)idMappings`, because you don't know what namespace will be used to interpret the hostIDs.

### Namespace ownership

This is another case where I think specified clarity is essential.  A new network namespace will not be very useful if you don't know who owns it.

[1]: https://github.com/opencontainers/runtime-spec/pull/767#discussion_r115591844
[2]: https://github.com/opencontainers/runtime-spec/pull/767#discussion_r115592437
[3]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc5/config.md#hostname
[4]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc5/config.md#root