### PR TITLE
*: Use inline links for remaining internal references

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -614,7 +614,7 @@ The [Shared Subtrees][sharedsubtree] article in the kernel documentation has mor
 ## <a name="configLinuxMaskedPaths" />Masked Paths
 
 **`maskedPaths`** (array of strings, OPTIONAL) will mask over the provided paths inside the container so that they cannot be read.
-The values MUST be absolute paths in the [container namespace][container-namespace2].
+The values MUST be absolute paths in the [container namespace](glossary.md#container_namespace).
 
 ###### Example
 
@@ -627,7 +627,7 @@ The values MUST be absolute paths in the [container namespace][container-namespa
 ## <a name="configLinuxReadonlyPaths" />Readonly Paths
 
 **`readonlyPaths`** (array of strings, OPTIONAL) will set the provided paths as readonly inside the container.
-The values MUST be absolute paths in the [container namespace][container-namespace2].
+The values MUST be absolute paths in the [container namespace](glossary.md#container-namespace).
 
 ###### Example
 
@@ -647,8 +647,6 @@ The values MUST be absolute paths in the [container namespace][container-namespa
     "mountLabel": "system_u:object_r:svirt_sandbox_file_t:s0:c715,c811"
 ```
 
-
-[container-namespace2]: glossary.md#container_namespace
 
 [cgroup-v1]: https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
 [cgroup-v1-blkio]: https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt

--- a/style.md
+++ b/style.md
@@ -8,12 +8,12 @@ For example, this paragraph will span three lines in the Markdown source.
 
 ## <a name="styleHex" />Traditionally hex settings should use JSON integers, not JSON strings
 
-For example, [`"classID": 1048577`][class-id] instead of `"classID": "0x100001"`.
+For example, [`"classID": 1048577`](config-linux.md#network) instead of `"classID": "0x100001"`.
 The config JSON isn't enough of a UI to be worth jumping through string <-> integer hoops to support an 0x… form ([source][integer-over-hex]).
 
 ## <a name="styleConstantNames" />Constant names should keep redundant prefixes
 
-For example, `CAP_KILL` instead of `KILL` in [**`linux.capabilities`**][capabilities].
+For example, `CAP_KILL` instead of `KILL` in [**`process.capabilities`**](config.md#process).
 The redundancy reduction from removing the namespacing prefix is not useful enough to be worth trimming the upstream identifier ([source][keep-prefix]).
 
 ## <a name="styleOptionalSettings" />Optional settings should not have pointer Go types
@@ -120,8 +120,6 @@ The URL for the Open Containers link above is: https://github.com/opencontainers
 ```
 
 
-[capabilities]: config-linux.md#capabilities
-[class-id]: config-linux.md#network
 [integer-over-hex]: https://github.com/opencontainers/runtime-spec/pull/267#r48360013
 [keep-prefix]: https://github.com/opencontainers/runtime-spec/pull/159#issuecomment-138728337
 [no-pointer-for-boolean]: https://github.com/opencontainers/runtime-spec/pull/290#r50296396


### PR DESCRIPTION
Since #687, the official style is to [only use reference-style links for external links][1].  I expect the remaining three entries just slipped through.  This commit adjusts everything found with:

    $ git grep ']: [a-z]' | grep -v http

It also fixes the underscore → hyphen in the `glossary.md#container-namespace` target and updates the `capabilities` location to catch up with #329.

[1]: https://github.com/opencontainers/runtime-spec/blob/f56fe8ba78f9d70c63fbd301cf1cd680218742fa/style.md#links