### PR TITLE
config-linux: Remove redundant MUST for minimum cgroup controllers

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -186,8 +186,7 @@ You can configure a container's cgroups via the `resources` field of the Linux c
 Do not specify `resources` unless limits have to be updated.
 For example, to run a new process in an existing container without updating limits, `resources` need not be specified.
 
-A runtime MUST at least use the minimum set of cgroup controllers required to fulfill the `resources` settings.
-However, a runtime MAY attach the container process to additional cgroup controllers supported by the system.
+Runtimes MAY attach the container process to additional cgroup controllers beyond those necessary to fulfill the `resources` settings.
 
 ###### Example
 


### PR DESCRIPTION
This is my suggested alternative to #729, which is currently removing the lowercase “required” but keeping the redundant MUST.  Any runtime which violated the MUST would necessarily violate some more specific constraint on a `resources` setting, so this PR removes the MUST entirely.