### PR TITLE
Update to Windows network options

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -75,22 +75,31 @@ The following parameters can be specified:
     }
 ```
 
-### <a name="configWindowsNetwork" />Network
+## <a name="configWindowsNetwork" />Network
 
-`network` is an OPTIONAL configuration for the container's network usage.
+You can configure a container's networking options via the OPTIONAL `network` field of the Windows configuration.
 
 The following parameters can be specified:
 
-* **`egressBandwidth`** *(uint64, OPTIONAL)* - specified the maximum egress bandwidth in bytes per second for the container.
+* **`endpointList`** *(array of strings, OPTIONAL)* - list of HNS (Host Network Service) endpoints that the container should connect to.
+* **`allowUnqualifiedDNSQuery`** *(bool, OPTIONAL)* - specifies if unqualified DNS name resolution is allowed.
+* **`DNSSearchList`** *(array of strings, OPTIONAL)* - comma seperated list of DNS suffixes to use for name resolution.
+* **`networkSharedContainerName`** *(string, OPTIONAL)* - name (ID) of the container that we will share with the network stack.
 
 #### Example
 
 ```json
     "windows": {
-        "resources": {
-            "network": {
-                "egressBandwidth": 1048577
-            }
+        "network": {
+            "endpointList": [
+                "7a010682-17e0-4455-a838-02e5d9655fe6"
+            ],
+            "allowUnqualifiedDNSQuery": true,
+            "DNSSearchList": [
+                "a.com",
+                "b.com"
+            ],
+            "networkSharedContainerName": "containerName"
         }
    }
 ```

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -53,16 +53,28 @@
                                 "$ref": "defs.json#/definitions/uint64"
                             }
                         }
+                    }
+                }
+            },
+            "network": {
+                "id": "https://opencontainers.org/schema/bundle/windows/network",
+                "type": "object",
+                "properties": {
+                    "endpointList": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/network/endpointList",
+                        "$ref": "defs.json#/definitions/ArrayOfStrings"
                     },
-                    "network": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/resources/network",
-                        "type": "object",
-                        "properties": {
-                            "egressBandwidth": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/network/egressBandwidth",
-                                "$ref": "defs.json#/definitions/uint64"
-                            }
-                        }
+                    "allowUnqualifiedDNSQuery": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/network/allowUnqualifiedDNSQuery",
+                        "type": "boolean"
+                    },
+                    "DNSSearchList": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/network/DNSSearchList",
+                        "$ref": "defs.json#/definitions/ArrayOfStrings"
+                    },
+                    "networkSharedContainerName": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/network/networkSharedContainerName",
+                        "type": "string"
                     }
                 }
             },

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -440,6 +440,8 @@ type Windows struct {
 	IgnoreFlushesDuringBoot bool `json:"ignoreflushesduringboot,omitempty"`
 	// HyperV contains information for running a container with Hyper-V isolation.
 	HyperV *WindowsHyperV `json:"hyperv,omitempty"`
+	// Network restriction configuration.
+	Network *WindowsNetwork `json:"network,omitempty"`
 }
 
 // WindowsResources has container runtime resource constraints for containers running on Windows.
@@ -450,8 +452,6 @@ type WindowsResources struct {
 	CPU *WindowsCPUResources `json:"cpu,omitempty"`
 	// Storage restriction configuration.
 	Storage *WindowsStorageResources `json:"storage,omitempty"`
-	// Network restriction configuration.
-	Network *WindowsNetworkResources `json:"network,omitempty"`
 }
 
 // WindowsMemoryResources contains memory resource management settings.
@@ -480,10 +480,16 @@ type WindowsStorageResources struct {
 	SandboxSize *uint64 `json:"sandboxSize,omitempty"`
 }
 
-// WindowsNetworkResources contains network resource management settings.
-type WindowsNetworkResources struct {
-	// EgressBandwidth is the maximum egress bandwidth in bytes per second.
-	EgressBandwidth *uint64 `json:"egressBandwidth,omitempty"`
+// WindowsNetwork contains network settings for Windows containers.
+type WindowsNetwork struct {
+	// List of HNS endpoints that the container should connect to.
+	EndpointList []string `json:"endpointList,omitempty"`
+	// Specifies if unqualified DNS name resolution is allowed.
+	AllowUnqualifiedDNSQuery bool `json:"allowUnqualifiedDNSQuery,omitempty"`
+	// Comma seperated list of DNS suffixes to use for name resolution.
+	DNSSearchList []string `json:"DNSSearchList,omitempty"`
+	// Name (ID) of the container that we will share with the network stack.
+	NetworkSharedContainerName string `json:"networkSharedContainerName,omitempty"`
 }
 
 // WindowsHyperV contains information for configuring a container to run with Hyper-V isolation.


### PR DESCRIPTION
This moves the Windows network runtime options into the spec. 

NetworkResourceSettings was never used in the runtime spec, and implemented in HNS and libnetwork instead of at runtime on Windows.

/cc @RobDolinMS 

Signed-off-by: Darren Stahl <darst@microsoft.com>