### PR TITLE
Makefile: Remove unnecessary .PHONY entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ DOC_FILES := \
 
 default: docs
 
-.PHONY: docs
 docs: $(OUTPUT_DIRNAME)/$(DOC_FILENAME).pdf $(OUTPUT_DIRNAME)/$(DOC_FILENAME).html
 
 ifeq "$(strip $(PANDOC))" ''
@@ -55,8 +54,6 @@ version.md: ./specs-go/version.go
 HOST_GOLANG_VERSION	= $(shell go version | cut -d ' ' -f3 | cut -c 3-)
 # this variable is used like a function. First arg is the minimum version, Second arg is the version to be checked.
 ALLOWED_GO_VERSION	= $(shell test '$(shell /bin/echo -e "$(1)\n$(2)" | sort -V | head -n1)' = '$(1)' && echo 'true')
-
-.PHONY: test .govet .golint .gitvalidation
 
 test: .govet .golint .gitvalidation
 
@@ -80,8 +77,6 @@ else
 	git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
 endif
 
-
-.PHONY: install.tools
 install.tools: .install.golint .install.gitvalidation
 
 # golint does not even build for <go1.6
@@ -93,8 +88,6 @@ endif
 .install.gitvalidation:
 	go get -u github.com/vbatts/git-validation
 
-
-.PHONY: clean
 clean:
 	rm -rf $(OUTPUT_DIRNAME) *~
 	rm -f version.md

--- a/schema/Makefile
+++ b/schema/Makefile
@@ -1,10 +1,8 @@
 GOOD_TESTS = $(wildcard test/good/*.json)
 BAD_TESTS = $(wildcard test/bad/*.json)
 
-.PHONY: default
 default: validate
 
-.PHONY: help
 help:
 	@echo "Usage: make [target]"
 	@echo
@@ -12,7 +10,6 @@ help:
 	@echo " * 'help' - show this help information"
 	@echo " * 'validate' - build the validation tool"
 
-.PHONY: fmt
 fmt:
 	find . -name '*.json' -exec bash -c 'jq --indent 4 -M . {} > xx && mv xx {} || echo "skipping invalid {}"' \;
 
@@ -21,7 +18,6 @@ validate: validate.go
 	go get -d ./...
 	go build ./validate.go
 
-.PHONY: test
 test: validate $(TESTS)
 	for TYPE in $$(ls test); \
 	do \
@@ -50,6 +46,5 @@ test: validate $(TESTS)
 		done; \
 	done
 
-.PHONY: clean
 clean:
 	rm -f validate


### PR DESCRIPTION
The only `.PHONY` entry we *need* is for `schema/validate`, since that's a real file but we haven't told Make about its real dependencies (which involve complicated Go lookups).  I'm personally in favor of using `.PHONY` for all targets that aren't on-disk files, because it hints to readers that the rule is not generating a file at the target.  But there has been resistance to adding .PHONY entries to all such cases (e.g. #791), so this commit brings us around to a internally-consistent “only use `.PHONY` when you always need it” position.

That means that, for example, users who create files named `clean` will turn `clean` the target into a no-op, but runtime-spec maintainers are ok with that.