### PR TITLE
config-linux: Remove explicit 'null' from device cgroup values

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -218,9 +218,9 @@ Each entry has the following structure:
 
 * **`allow`** *(boolean, REQUIRED)* - whether the entry is allowed or denied.
 * **`type`** *(string, OPTIONAL)* - type of device: `a` (all), `c` (char), or `b` (block).
-  `null` or unset values mean "all", mapping to `a`.
+  Unset values mean "all", mapping to `a`.
 * **`major, minor`** *(int64, OPTIONAL)* - [major, minor numbers][devices] for the device.
-  `null` or unset values mean "all", mapping to [`*` in the filesystem API][cgroup-v1-devices].
+  Unset values mean "all", mapping to [`*` in the filesystem API][cgroup-v1-devices].
 * **`access`** *(string, OPTIONAL)* - cgroup permissions for device.
   A composition of `r` (read), `w` (write), and `m` (mknod).
 


### PR DESCRIPTION
Catch the Markdown spec up with the JSON Schema change in #662.  The Markdown is canonical, so we could restore the explicit-null handling to the JSON Schema instead, but the [maintainers feel][1] (and I agree) that there's no point in explicitly allowing a null value when callers can simply leave the property unset.

[1]: https://github.com/opencontainers/runtime-spec/pull/555#issuecomment-272020515