### PR TITLE
Windows: Add CredentialSpec

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -94,3 +94,14 @@ The following parameters can be specified:
         }
    }
 ```
+
+## <a name="configWindowsCredentialSpec" />Credential Spec
+
+You can configure a container's group Managed Service Account (gMSA) via the OPTIONAL `credentialspec` field of the Windows configuration.
+The `credentialspec` is a JSON object whose properties are implementation-defined.
+For more information about gMSAs, see [Active Directory Service Accounts for Windows Containers][gMSAOverview].
+For more information about tooling to generate a gMSA, see [Deployment Overview][gMSATooling].
+
+
+[gMSAOverview]: https://aka.ms/windowscontainers/manage-serviceaccounts
+[gMSATooling]: https://aka.ms/windowscontainers/credentialspec-tools

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -65,6 +65,10 @@
                         }
                     }
                 }
+            },
+            "credentialspec": {
+                "id": "https://opencontainers.org/schema/bundle/windows/credentialspec",
+                "type": "object"
             }
         }
     }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -432,6 +432,8 @@ type SolarisAnet struct {
 type Windows struct {
 	// Resources contains information for handling resource constraints for the container.
 	Resources *WindowsResources `json:"resources,omitempty"`
+	// CredentialSpec contains a JSON object describing a group Managed Service Account (gMSA) specification.
+	CredentialSpec interface{} `json:"credentialspec,omitempty"`
 }
 
 // WindowsResources has container runtime resource constraints for containers running on Windows.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

The Windows implementation of the docker daemon still passes a number of fields out of band from the OCI runtime spec. This PR addresses the `CredentialSpec` field by adding it to the runtime spec. (https://github.com/moby/moby/blob/master/libcontainerd/client_windows.go#L177-L178)