### PR TITLE
Windows: Add servicing

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -105,3 +105,18 @@ For more information about tooling to generate a gMSA, see [Deployment Overview]
 
 [gMSAOverview]: https://aka.ms/windowscontainers/manage-serviceaccounts
 [gMSATooling]: https://aka.ms/windowscontainers/credentialspec-tools
+
+
+## <a name="configWindowsServicing" />Servicing
+
+When a container terminates, the Host Compute Service indicates if a Windows update servicing operation is pending.
+You can indicate that a container should be started in a mode to apply pending servicing operations via the OPTIONAL `servicing` field of the Windows configuration.
+
+
+### Example
+
+```json
+    "windows": {
+        "servicing": true
+    }
+```

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -69,6 +69,10 @@
             "credentialspec": {
                 "id": "https://opencontainers.org/schema/bundle/windows/credentialspec",
                 "type": "object"
+            },
+            "servicing": {
+                "id": "https://opencontainers.org/schema/bundle/windows/servicing",
+                "type": "boolean"
             }
         }
     }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -434,6 +434,8 @@ type Windows struct {
 	Resources *WindowsResources `json:"resources,omitempty"`
 	// CredentialSpec contains a JSON object describing a group Managed Service Account (gMSA) specification.
 	CredentialSpec interface{} `json:"credentialspec,omitempty"`
+	// Servicing indicates if the container is being started in a mode to apply a Windows Update servicing operation.
+	Servicing bool `json:"servicing,omitempty"`
 }
 
 // WindowsResources has container runtime resource constraints for containers running on Windows.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Similar to https://github.com/opencontainers/runtime-spec/pull/814, the Windows implementation of the docker daemon still passes a number of fields out of band from the OCI runtime spec. This PR addresses the Servicing field by adding it to the runtime spec. https://github.com/moby/moby/blob/master/libcontainerd/client_windows.go#L152-L154