### PR TITLE
Windows: Add IgnoreFlushesDuringBoot

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -106,17 +106,27 @@ For more information about tooling to generate a gMSA, see [Deployment Overview]
 [gMSAOverview]: https://aka.ms/windowscontainers/manage-serviceaccounts
 [gMSATooling]: https://aka.ms/windowscontainers/credentialspec-tools
 
-
 ## <a name="configWindowsServicing" />Servicing
 
 When a container terminates, the Host Compute Service indicates if a Windows update servicing operation is pending.
 You can indicate that a container should be started in a mode to apply pending servicing operations via the OPTIONAL `servicing` field of the Windows configuration.
-
 
 ### Example
 
 ```json
     "windows": {
         "servicing": true
+    }
+```
+
+## <a name="configWindowsIgnoreFlushesDuringBoot" />IgnoreFlushesDuringBoot
+
+You can indicate that a container should be started in an a mode where disk flushes are not performed during container boot via the OPTIONAL `ignoreflushesduringboot` field of the Windows configuration.
+
+### Example
+
+```json
+    "windows": {
+        "ignoreflushesduringboot": true
     }
 ```

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -73,6 +73,10 @@
             "servicing": {
                 "id": "https://opencontainers.org/schema/bundle/windows/servicing",
                 "type": "boolean"
+            },
+            "ignoreflushesduringboot": {
+                "id": "https://opencontainers.org/schema/bundle/windows/ignoreflushesduringboot",
+                "type": "boolean"
             }
         }
     }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -436,6 +436,8 @@ type Windows struct {
 	CredentialSpec interface{} `json:"credentialspec,omitempty"`
 	// Servicing indicates if the container is being started in a mode to apply a Windows Update servicing operation.
 	Servicing bool `json:"servicing,omitempty"`
+	// IgnoreFlushesDuringBoot indicates if the container is being started in a mode where disk writes are not flushed during its boot process.
+	IgnoreFlushesDuringBoot bool `json:"ignoreflushesduringboot,omitempty"`
 }
 
 // WindowsResources has container runtime resource constraints for containers running on Windows.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Similar to #814, the Windows implementation of the docker daemon still passes a number of fields out of band from the OCI runtime spec. This PR addresses the IgnoreFlushesDuringBoot field by adding it to the runtime spec. https://github.com/moby/moby/blob/master/libcontainerd/client_windows.go#L156-L159