### PR TITLE
Windows: Add Hyper-V isolation fields

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -130,3 +130,24 @@ You can indicate that a container should be started in an a mode where disk flus
         "ignoreflushesduringboot": true
     }
 ```
+
+## <a name="configWindowsHyperV" />HyperV
+
+`hyperv` is an OPTIONAL field of the Windows configuration. If present, the container MUST be run with Hyper-V isolation. If omitted, the container MUST be run as a Windows Server container.
+
+The following parameters can be specified:
+
+* **`utilityvmpath`** *(string, OPTIONAL)* - specifies the path to the image used for the utility VM. This would be specified if using a base image which does not contain a utility VM image. If not supplied, the runtime will search the container filesystem layers from the bottom-most layer upwards, until it locates "UtilityVM", and default to that path.
+
+* **`sandboxpath`** *(string, REQUIRED)* - specifies the root of the path to the sandbox to be used for the container.
+
+### Example
+
+```json
+    "windows": {
+        "hyperv": {
+            "utilityvmpath": "C:\\\\path\\\\to\\utilityvm",
+            "sandboxpath": "C:\\\\programdata\\\\docker\\\\windowsfilter
+        }
+    }
+```

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -77,6 +77,20 @@
             "ignoreflushesduringboot": {
                 "id": "https://opencontainers.org/schema/bundle/windows/ignoreflushesduringboot",
                 "type": "boolean"
+            },
+            "hyperv": {
+                "id": "https://opencontainers.org/schema/bundle/windows/hyperv",
+                "type": "object",
+                "properties": {
+                    "utilityvmpath": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/hyperv/utilityvmpath",
+                        "type": "string"
+                    },
+                    "sandboxpath": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/hyperv/sandboxpath",
+                        "type": "string"
+                    }
+                }
             }
         }
     }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -438,6 +438,8 @@ type Windows struct {
 	Servicing bool `json:"servicing,omitempty"`
 	// IgnoreFlushesDuringBoot indicates if the container is being started in a mode where disk writes are not flushed during its boot process.
 	IgnoreFlushesDuringBoot bool `json:"ignoreflushesduringboot,omitempty"`
+	// HyperV contains information for running a container with Hyper-V isolation.
+	HyperV *WindowsHyperV `json:"hyperv,omitempty"`
 }
 
 // WindowsResources has container runtime resource constraints for containers running on Windows.
@@ -482,6 +484,14 @@ type WindowsStorageResources struct {
 type WindowsNetworkResources struct {
 	// EgressBandwidth is the maximum egress bandwidth in bytes per second.
 	EgressBandwidth *uint64 `json:"egressBandwidth,omitempty"`
+}
+
+// WindowsHyperV contains information for configuring a container to run with Hyper-V isolation.
+type WindowsHyperV struct {
+	// SandboxPath is a required host-path to the sandbox to be used by the container.
+	SandboxPath string `json:"sandboxpath"`
+	// UtilityVMPath is an optional path to the image used for the Utility VM.
+	UtilityVMPath string `json:"utilityvmpath,omitempty"`
 }
 
 // LinuxSeccomp represents syscall restrictions


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Similar to #814, the Windows implementation of the docker daemon still passes a number of fields out of band from the OCI runtime spec. This PR addresses the fields required to support Hyper-V containers by adding them to the runtime spec. 