### PR TITLE
Windows: Clarify r/o root filesystem

### DIFF
--- a/config.md
+++ b/config.md
@@ -32,7 +32,7 @@ For example, if a configuration is compliant with version 1.1 of this specificat
   The path is either an absolute path or a relative path to the bundle.
   On Linux, for example, with a bundle at `/to/bundle` and a root filesystem at `/to/bundle/rootfs`, the `path` value can be either `/to/bundle/rootfs` or `rootfs`.
   A directory MUST exist at the path declared by the field.
-* **`readonly`** (bool, OPTIONAL) If true then the root filesystem MUST be read-only inside the container, defaults to false.
+* **`readonly`** (bool, OPTIONAL) If true then the root filesystem MUST be read-only inside the container, defaults to false. On Windows, this field must be omitted or false.
 
 ### Example
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Clarification that Windows does not support a read-only root filesystem.