### PR TITLE
config-linux: Use the implicit link name shortcut

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -12,10 +12,10 @@ The following filesystems SHOULD be made available in each container's filesyste
 
 | Path     | Type   |
 | -------- | ------ |
-| /proc    | [procfs][procfs]   |
-| /sys     | [sysfs][sysfs]     |
-| /dev/pts | [devpts][devpts]   |
-| /dev/shm | [tmpfs][tmpfs]     |
+| /proc    | [procfs][] |
+| /sys     | [sysfs][]  |
+| /dev/pts | [devpts][] |
+| /dev/shm | [tmpfs][]  |
 
 ## <a name="configLinuxNamespaces" />Namespaces
 
@@ -510,7 +510,7 @@ For more information, see the [sysctl(8)][sysctl.8] man page.
 Seccomp provides application sandboxing mechanism in the Linux kernel.
 Seccomp configuration allows one to configure actions to take for matched syscalls and furthermore also allows matching on values passed as arguments to syscalls.
 For more information about Seccomp, see [Seccomp][seccomp] kernel documentation.
-The actions, architectures, and operators are strings that match the definitions in seccomp.h from [libseccomp][libseccomp] and are translated to corresponding values.
+The actions, architectures, and operators are strings that match the definitions in seccomp.h from [libseccomp][] and are translated to corresponding values.
 
 **`seccomp`** (object, OPTIONAL)
 


### PR DESCRIPTION
#826 added a redundant link name for libseccomp.  This commit restores the old [implicit link name shortcut][1] there and updates the other entries (all of which were for the filesystems table in config-linux) that could also use that shortcut.  This is obviously not a major change, but I think it makes the source easier to read by minimizing the markup so you can focus on the text.

[1]: https://daringfireball.net/projects/markdown/syntax#link