### PR TITLE
Add LayerFolders to Windows platform config

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -3,6 +3,22 @@
 This document describes the schema for the [Windows-specific section](config.md#platform-specific-configuration) of the [container configuration](config.md).
 The Windows container specification uses APIs provided by the Windows Host Compute Service (HCS) to fulfill the spec.
 
+## <a name="configWindowsLayerFolders" />LayerFolders
+
+**`layerFolders`** (array of strings, REQUIRED) specifies a list of layer folders the container image relies on. The list is ordered from topmost layer to base layer.
+  `layerFolders` MUST contain at least one entry.
+
+### Example
+
+```json
+    "windows": {
+        "layerFolders": [
+            "C:\\Layers\\layer1",
+            "C:\\Layers\\layer2"
+        ]
+    }
+```
+
 ## <a name="configWindowsResources" />Resources
 
 You can configure a container's resource limits via the OPTIONAL `resources` field of the Windows configuration.

--- a/config.md
+++ b/config.md
@@ -328,7 +328,7 @@ Runtime implementations MAY support any valid values for platform-specific field
 * **`linux`** (object, OPTIONAL) [Linux-specific configuration](config-linux.md).
   This MAY be set if **`platform.os`** is `linux` and MUST NOT be set otherwise.
 * **`windows`** (object, OPTIONAL) [Windows-specific configuration](config-windows.md).
-  This MAY be set if **`platform.os`** is `windows` and MUST NOT be set otherwise.
+  This MUST be set if **`platform.os`** is `windows` and MUST NOT be set otherwise.
 * **`solaris`** (object, OPTIONAL) [Solaris-specific configuration](config-solaris.md).
   This MAY be set if **`platform.os`** is `solaris` and MUST NOT be set otherwise.
 

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -4,6 +4,14 @@
         "id": "https://opencontainers.org/schema/bundle/windows",
         "type": "object",
         "properties": {
+            "layerFolders": {
+                "id": "https://opencontainers.org/schema/bundle/windows/layerFolders",
+                "type": "array",
+                "items": {
+                    "$ref": "defs.json#/definitions/FilePath"
+                },
+                "minItems": 1
+            },
             "resources": {
                 "id": "https://opencontainers.org/schema/bundle/windows/resources",
                 "type": "object",
@@ -66,6 +74,9 @@
                     }
                 }
             }
-        }
+        },
+        "required": [
+            "layerFolders"
+        ]
     }
 }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -430,6 +430,8 @@ type SolarisAnet struct {
 
 // Windows defines the runtime configuration for Windows based containers, including Hyper-V containers.
 type Windows struct {
+	// LayerFolders contains a list of absolute paths to directories containing image layers.
+	LayerFolders []string `json:"layerFolders"`
 	// Resources contains information for handling resource constraints for the container.
 	Resources *WindowsResources `json:"resources,omitempty"`
 }


### PR DESCRIPTION
LayerFolders is a property that is missing from the runtime spec that is **required** for all useful containers on Windows.

[This issue](https://github.com/opencontainers/runtime-spec/issues/817) mentions extending the runtime spec with "required" platform specific fields.