### PR TITLE
Expand platform to be more sophisticated

### DIFF
--- a/config.md
+++ b/config.md
@@ -310,13 +310,18 @@ For Windows based systems the user structure has the following fields:
   The runtime MUST generate an error if it does not support the specified **`arch`**.
   Values for **`arch`** SHOULD use, and runtimes SHOULD understand, **`arch`** entries listed in the Go Language document for [`GOARCH`][go-environment].
   If an architecture is not included in the `GOARCH` documentation, it SHOULD be submitted to this specification for standardization.
+* **`os.version`** (string, OPTIONAL) specifies the operating system version, for example `10.0.10586`.
+* **`os.features`** (array of strings, OPTIONAL) specifies an array of strings, each specifying a mandatory OS feature, for example `win32k`.
+* **`variant`** (string, OPTIONAL) specifies the variant of the CPU, for example `v8` to specify a perticular CPU variant of the ARM CPU.
+* **`features`** (array of strings, OPTIONAL) this property is RESERVED for future versions of the specification.
 
 ### Example
 
 ```json
 "platform": {
     "os": "linux",
-    "arch": "amd64"
+    "arch": "amd64",
+    "variant": "v8"
 }
 ```
 
@@ -338,7 +343,8 @@ Runtime implementations MAY support any valid values for platform-specific field
 {
     "platform": {
         "os": "linux",
-        "arch": "amd64"
+        "arch": "amd64",
+        "variant": "v8"
     },
     "linux": {
         "namespaces": [

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -52,7 +52,22 @@
                 "os": {
                     "id": "https://opencontainers.org/schema/bundle/platform/os",
                     "type": "string"
-                }
+                },
+                "os.version": {
+                    "id": "https://opencontainers.org/schema/bundle/platform/os.version",
+                    "type": "string"
+                },
+                "os.features": {
+                    "id": "https://opencontainers.org/schema/bundle/platform/os.features",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "variant": {
+                    "id": "https://opencontainers.org/schema/bundle/platform/variant",
+                    "type": "string"
+		}
             }
         },
         "root": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -108,6 +108,14 @@ type Platform struct {
 	OS string `json:"os"`
 	// Arch is the architecture
 	Arch string `json:"arch"`
+	// OSVersion specifies the operating system version, for example `10.0.10586`.
+	OSVersion string `json:"os.version,omitempry"`
+	// OSFeatures specifies an array of strings, each specifying a mandatory
+	// OS feature, for example `win32k`.
+	OSFeatures []string `json:"os.features,omitempry"`
+	// Variant specifies the variant of the CPU, for example `v8` to specify
+	// a perticular CPU variant of the ARM CPU.
+	Variant string `json:"variant,omitempry"`
 }
 
 // Mount specifies a mount for a container.


### PR DESCRIPTION
Currently support is not sufficient for many platforms,
such as ARM, we need more information to identify a
specific platform.

Image-spec already had these entries, so I just picked
them up and applied to runtime-spec.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>