### PR TITLE
meeting.ics: Bump even-week meeting from 5pm to 2pm Pacific

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When in doubt, start on the [mailing-list](#mailing-list).
 The contributors and maintainers of all OCI projects have a weekly meeting on Wednesdays at:
 
 * 8:00 AM (USA Pacific), during [odd weeks][iso-week].
-* 5:00 PM (USA Pacific), during [even weeks][iso-week].
+* 2:00 PM (USA Pacific), during [even weeks][iso-week].
 
 There is an [iCalendar][rfc5545] format for the meetings [here](meeting.ics).
 

--- a/meeting.ics
+++ b/meeting.ics
@@ -36,8 +36,8 @@ URL:https://github.com/opencontainers/runtime-spec/blob/master/meeting.ics
 END:VEVENT
 BEGIN:VEVENT
 UID:tdc-meeting-2@opencontainers.org
-DTSTAMP:20170405T220000Z
-DTSTART;TZID=America/Los_Angeles:20170405T170000
+DTSTAMP:20170517T143500Z
+DTSTART;TZID=America/Los_Angeles:20170517T140000
 RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
 DURATION:PT1H
 SUMMARY:OCI TDC Meeting


### PR DESCRIPTION
Catch up with [this][1], effective this afternoon.  There was earlier discussion [here][2].

[1]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/AuNglHFyrkA
[2]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/nZ0lS4fDBbQ