### PR TITLE
specs-go/config: Add a 'linux' tag to OOMScoreAdj

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -53,7 +53,7 @@ type Process struct {
 	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// Specify an oom_score_adj for the container.
-	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
+	OOMScoreAdj *int `json:"oomScoreAdj,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }


### PR DESCRIPTION
This should have happened in #789 as part of moving the property from a Linux-specific type to a cross-platform type.