### PR TITLE
config: Bump Hyper-V condition from root.path to root itself

### DIFF
--- a/config.md
+++ b/config.md
@@ -36,7 +36,7 @@ For all platform-specific configuration values, the scope defined below in the [
 
     * On Windows, `path` MUST be a [volume GUID path][naming-a-volume].
 
-    * On Linux and Solaris, `path` is either an absolute path or a relative path to the bundle.
+    * On POSIX platforms, `path` is either an absolute path or a relative path to the bundle.
         For example, with a bundle at `/to/bundle` and a root filesystem at `/to/bundle/rootfs`, the `path` value can be either `/to/bundle/rootfs` or `rootfs`.
         The value SHOULD be the conventional `rootfs`.
 
@@ -45,7 +45,7 @@ For all platform-specific configuration values, the scope defined below in the [
 * **`readonly`** (bool, OPTIONAL) If true then the root filesystem MUST be read-only inside the container, defaults to false.
     * On Windows, this field MUST be omitted or false.
 
-### Example (POSIX)
+### Example (POSIX platforms)
 
 ```json
 "root": {
@@ -94,9 +94,9 @@ For all platform-specific configuration values, the scope defined below in the [
 ]
 ```
 
-### <a name="configLinuxAndSolarisMounts" />Linux and Solaris Mounts
+### <a name="configPOSIXMounts" />POSIX-platform Mounts
 
-For Linux and Solaris based systems the mounts structure has the following fields:
+For POSIX platforms the `mounts` structure has the following fields:
 
 * **`type`** (string, OPTIONAL) The type of the filesystem to be mounted.
   * Linux: filesystem types supported by the kernel as listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660").
@@ -195,9 +195,9 @@ For Linux-based systems the process structure supports the following process-spe
 
 The user for the process is a platform-specific structure that allows specific control over which user the process runs as.
 
-#### <a name="configLinuxAndSolarisUser" />Linux and Solaris User
+#### <a name="configPOSIXUser" />POSIX-platform User
 
-For Linux and Solaris based systems the user structure has the following fields:
+For POSIX platforms the `user` structure has the following fields:
 
 * **`uid`** (int, REQUIRED) specifies the user ID in the [container namespace](glossary.md#container-namespace).
 * **`gid`** (int, REQUIRED) specifies the group ID in the [container namespace](glossary.md#container-namespace).
@@ -348,9 +348,9 @@ For Windows based systems the user structure has the following fields:
 }
 ```
 
-## <a name="configHooks" />Linux and Solaris Hooks
+## <a name="configHooks" />POSIX-platform Hooks
 
-For Linux- and Solaris-based systems, the configuration structure supports `hooks` for configuring custom actions related to the [lifecycle](runtime.md#lifecycle) of the container.
+For POSIX platforms, the configuration structure supports `hooks` for configuring custom actions related to the [lifecycle](runtime.md#lifecycle) of the container.
 
 * **`hooks`** (object, OPTIONAL) MAY contain any of the following properties:
     * **`prestart`** (array of objects, OPTIONAL) is an array of [pre-start hooks](#prestart).

--- a/config.md
+++ b/config.md
@@ -26,18 +26,22 @@ For all platform-specific configuration values, the scope defined below in the [
 
 ## <a name="configRoot" />Root
 
-**`root`** (object, REQUIRED) specifies the container's root filesystem.
+**`root`** (object, OPTIONAL) specifies the container's root filesystem.
+    On Windows, for Windows Server Containers, this field is REQUIRED.
+    For [Hyper-V Containers](config-windows.md#hyperv), this field MUST NOT be set.
 
-* **`path`** (string, OPTIONAL) Specifies the path to the root filesystem for the container.
-    The path is either an absolute path or a relative path to the bundle.
+    On all other platforms, this field is REQUIRED.
 
-    * On Windows, for Windows Server Containers, this field is REQUIRED and MUST be specified as a [volume GUID path][naming-a-volume].
-      For Hyper-V Containers, this field MUST be omitted.
-    * On all other platforms, this field is REQUIRED.
+* **`path`** (string, REQUIRED) Specifies the path to the root filesystem for the container.
+
+    * On Windows, `path` MUST be a [volume GUID path][naming-a-volume].
+
+    * On Linux and Solaris, `path` is either an absolute path or a relative path to the bundle.
+        For example, with a bundle at `/to/bundle` and a root filesystem at `/to/bundle/rootfs`, the `path` value can be either `/to/bundle/rootfs` or `rootfs`.
         The value SHOULD be the conventional `rootfs`.
-    * On Linux, for example, with a bundle at `/to/bundle` and a root filesystem at `/to/bundle/rootfs`, the `path` value can be either `/to/bundle/rootfs` or `rootfs`.
 
-    If defined, a directory MUST exist at the path declared by the field.
+    A directory MUST exist at the path declared by the field.
+
 * **`readonly`** (bool, OPTIONAL) If true then the root filesystem MUST be read-only inside the container, defaults to false.
     * On Windows, this field MUST be omitted or false.
 

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -41,6 +41,9 @@
             "description": "Configures the container's root filesystem.",
             "id": "https://opencontainers.org/schema/bundle/root",
             "type": "object",
+            "required": [
+                "path"
+            ],
             "properties": {
                 "path": {
                     "id": "https://opencontainers.org/schema/bundle/root/path",
@@ -214,7 +217,6 @@
         }
     },
     "required": [
-        "ociVersion",
-        "root"
+        "ociVersion"
     ]
 }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -9,7 +9,7 @@ type Spec struct {
 	// Process configures the container process.
 	Process *Process `json:"process,omitempty"`
 	// Root configures the container's root filesystem.
-	Root Root `json:"root"`
+	Root *Root `json:"root,omitempty"`
 	// Hostname configures the container's hostname.
 	Hostname string `json:"hostname,omitempty"`
 	// Mounts configures additional mounts (on top of Root).
@@ -94,7 +94,7 @@ type User struct {
 // Root contains information about the container's root filesystem on the host.
 type Root struct {
 	// Path is the absolute path to the container's root filesystem.
-	Path string `json:"path,omitempty"`
+	Path string `json:"path"`
 	// Readonly makes the root filesystem for the container readonly before the process is executed.
 	Readonly bool `json:"readonly,omitempty"`
 }


### PR DESCRIPTION
Don't require users targetting Hyper-V to set an empty object (`"root": {}`).  This also avoids confusion about whether you can set `root.readonly` without setting `root.path` (you can't).

Following #820.