### PR TITLE
bundle: Move 'rootfs' recommendation to config.md

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -15,8 +15,6 @@ This REQUIRED file MUST reside in the root of the bundle directory and MUST be n
 See [`config.json`](config.md) for more details.
 
 2. <a name="containerFormat02" />A directory representing the root filesystem of the container.
-    While the name of this directory may be arbitrary, users should consider using a conventional name, such as `rootfs`.
-
     On Windows, for Windows Server containers, this directory is REQUIRED. For Hyper-V containers, it MUST be omitted.
 
     On all other platforms, this field is REQUIRED.

--- a/config.md
+++ b/config.md
@@ -29,6 +29,7 @@ For example, if a configuration is compliant with version 1.1 of this specificat
 **`root`** (object, REQUIRED) specifies the container's root filesystem.
 
 * **`path`** (string, OPTIONAL) Specifies the path to the root filesystem for the container. The path is either an absolute path or a relative path to the bundle.
+    Users SHOULD consider using a conventional name, such as `rootfs`.
 
     On Windows, for Windows Server Containers, this field is REQUIRED. For Hyper-V Containers, this field MUST be omitted.
 


### PR DESCRIPTION
Anyone setting 'rootfs.path' should be aware of this advice, regardless of whether they're the ones composing the bundle or not.

Use the RFC 2119 “SHOULD” (vs. the old lowercase “should”) for this recommendation.  The SHOULD semantics make sense and using SHOULD avoids confusing readers (“did they mean to SHOULD this?”).

Also drop the “While the name of this directory may be arbitrary” caveat, because SHOULD already implies “but you can pick another directory name if you want”.

Note that the “MUST be present in a single directory” line which is still in `bundle.md` forbids you from picking `foo/bar`, `../foo`, or other paths that do not point at a direct child of the bundle directory.  I [don't like that direct-child restriction][1], but I'm not touching it in this commit.

[1]: https://github.com/opencontainers/runtime-spec/pull/469