### PR TITLE
bundle: DRYer root.path entry

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -14,13 +14,7 @@ This includes the following artifacts:
     This REQUIRED file MUST reside in the root of the bundle directory and MUST be named `config.json`.
     See [`config.json`](config.md) for more details.
 
-2. <a name="containerFormat02" />A directory representing the root filesystem of the container.
-    On Windows, for Windows Server containers, this directory is REQUIRED.
-    For Hyper-V containers, it MUST be omitted.
-
-    On all other platforms, this field is REQUIRED.
-
-    If set, this directory MUST be referenced by [`root`](config.md#root) within the `config.json` file.
+2. <a name="containerFormat02" />container's root filesystem: the directory referenced by [`root.path`](config.md#root), if that property is set in `config.json`.
 
 When supplied, while these artifacts MUST all be present in a single directory on the local filesystem, that directory itself is not part of the bundle.
 In other words, a tar archive of a *bundle* will have these artifacts at the root of the archive, not nested within a top-level directory.


### PR DESCRIPTION
Instead of repeating the config.md conditions, just make the linkage more clear.  Now the chain is:

1. Bundles REQUIRE a `config.json` which is a bundle artifact.
2. If that `config.json` has a `root.path` entry (as specified in `config.md`), then add the referenced directory to the set of bundle artifacts.  The `config.md` requirements include “If defined, a directory MUST exist at the path declared by the field”.
3. Apply the “MUST all be present in a single directory” condition to all bundle artifacts.  I [don't like that direct-child restriction][1], but I'm not touching it in this commit.

So these are the same requirements as before this commit, but with less redundancy and fewer words.

[1]: https://github.com/opencontainers/runtime-spec/pull/469