### PR TITLE
Bump version (rc6 and back to dev)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,67 @@
 OpenContainers Specifications
 
+Changes with v1.0.0-rc6:
+
+	Breaking changes:
+
+	* config: Shift oomScoreAdj to process and add RFC 2119 requirements
+	  for the runtime (#781, #789, #836)
+	* config-windows: Change CPU 'percent' to 'maximum' (#777)
+	* config-windows: Remove memory 'reservation' (#788)
+
+	Additions:
+
+	* config-linux: Add Intel RDT/CAT Linux support (#630, #787)
+	* config-linux: Add Markdown specification for syscalls (#706)
+	* config-linux: Add 'unbindable' rootfsPropagation value (#770, #775)
+	* config-windows: Add 'credentialspec' (#814)
+
+	Removals and increased restrictions:
+
+	* config: Forbid 'root.path' on Hyper-V (#820)
+	* config: Require strictly-postitive 'timeout' values (#764)
+	* config: Strengthen punt to kernel for valid capabilities strings
+	  (#766, #790)
+	* config: Forbid setting 'readonly' true on Windows (#819)
+	* config: Forbid setting mount 'type' entirely on Windows and forbid
+	  UNC paths and mapped drives in 'source' on Windows (#821)
+	* config-linux: Clearly require absolute path for namespace (#720)
+	* config-linux: RFC 2119 tightening for namespaces (#767)
+	* config-linux: Require at least one entry in
+	  linux.seccomp.sycalls[].names (#769)
+	* config-linux: Remove syscall.comment (#714)
+	* config-linux: Use MUST and MAY for weight and leafWeight (#751)
+	* config-linux: Remove explicit 'null' from device cgroup values
+	  (#804)
+	* runtime: Remove "features the runtime chooses to support" (#732)
+	* runtime: Drop "not supported by the base OS" loophole (#733)
+	* runtime-linux: Condition /proc/self/fd symlinks on source
+	  existence (#736)
+
+	Decreased restrictions:
+
+	* config: Make 'process' optional (#701, #805)
+	* config-linux: Make linux.seccomp.syscalls optional (#768)
+	* config-linux: Remove local range restrictions for blkioWeight,
+	  blkioLeafWeight, weight, leafWeight, and shares (#780)
+
+	Minor fixes and documentation:
+
+	* config: Specify height/width units (characters) for consoleSize (#761)
+	* config-linux: Explicit namespace for interface names (#713)
+	* runtime: Explicitly make process.* timing implementation-defined (#700)
+	* specs-go/config: Remove range restrictions from Windows comments (#783)
+	* specs-go/config: Add omitempty to LinuxSyscall.Args (#763)
+	* specs-go/config: Use a pointer for Process.ConsoleSize (#792)
+	* schema/Makefile: Make 'validate' the default target (#750)
+	* schema/Makefile: Add 'clean' target (#774)
+	* schema: Add 'test' target to the Makefile (#785)
+	* *: Remove unnecessary .PHONY entries (#750, #778, #802)
+	* *: Typo fixes and polishing (#681, #708, #702, #703, #709, #711,
+	   #712, #721, #722, #723, #724, #730, #737, #738, #741, #744, #749,
+	   #753, #756, #765, #773, #776, #784, #786, #793, #794, #796, #798,
+	   #799, #800, #803, #812, #824, #826, #832)
+
 Changes with v1.0.0-rc5:
 
 	Breaking changes:

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc5-dev"
+	VersionDev = "-rc6"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc6"
+	VersionDev = "-rc6-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
PRs since v1.0.0-rc5:
#820 jhowardmsft/clarifyrootpath
#814 jhowardmsft/credentialspec
#836 wking/oom-score-adj-go-tag
#832 wking/config-linux-header-levels
#821 jhowardmsft/clarifymountntfs
#824 Mashimiao/add-link-mknod
#826 Mashimiao/config-linux-fix-cgroups-des
#819 jhowardmsft/clarifyreadonlyroot
#803 Mashimiao/config-specify-config
#766 wking/cap-validation
#724 q384566678/fix-configmd
#812 Mashimiao/config-lifecycle-links
#805 wking/schema-test-optional-process
#804 wking/remove-exlicit-null
#798 Mashimiao/bundle-root-reference
#802 wking/minimal-phony
#700 wking/process-config-timing
#732 wking/drop-additional-actions-step
#681 wking/valid-values
#701 wking/optional-process
#702 wking/remove-operation-status-redefinition
#733 wking/remove-base-operating-system-loophole
#736 wking/dev-symlink-conditional
#767 wking/rfc2119-namespaces
#790 tianon/punt-caps-to-kernel-docs
#799 wking/inline-internal-links
#800 wking/remove-redundant-cgroup-must
#713 Mashimiao/config-linux-fix-network-interface
#796 Mashimiao/small-tfix
#703 Mashimiao/schema-fix-user
#793 wking/unique-solaris-zonecfg-link-target
#789 wking/move-oom-adj-to-process
#730 wking/drop-access-control-concerns
#794 wking/consistent-solaris-zonecfg-link-target
#737 wking/config-lead-in
#792 wking/pointer-for-console-size
#756 wking/config-drop-filename
#764 wking/strictly-positive-timeout
#781 wking/oomScoreAdj-rfc-2119
#785 wking/schema-tests
#786 q384566678/fix-solaris
#787 wking/intel-rdt-style
#784 q384566678/schema-fix
#783 q384566678/range-limt
#788 darrenstahlmsft/RemoveReservation
#777 darrenstahlmsft/WindowsCpuMaximum
#775 q384566678/rootfs-enum
#768 wking/optional-syscalls
#769 wking/require-syscall-names
#773 q384566678/device-up
#778 wking/schema-makefile-phony
#780 hqhq/remove_blkio_range
#770 q384566678/rootfsPropagation-test
#776 wking/file-link-fix
#774 q384566678/makefile-clean
#761 wking/box-size-units
#765 wking/not-required
#763 wking/seccomp-args-omitempty
#750 q384566678/schema-test
#758 wking/ics-description-link-readme
#757 wking/ics-uberconf-link
#739 wking/meetbot-minute-archives
#748 wking/meeting-copy-edit
#753 wking/tk/remove-env-var-dollars
#751 hqhq/use_MUST_for_weight
#749 wking/array-of-x
#752 q384566678/fix-typo
#740 wking/alternating-meetings
#744 wking/fix-anchor-for-runtime-implementations
#741 q384566678/fix-info
#706 q384566678/fix-seecomp
#738 wking/broken-mounts-example
#721 Mashimiao/specs-config-format-code
#722 Mashimiao/file-spec-fix
#723 Mashimiao/config-fix-broken-links
#720 Mashimiao/config-linux-fix-namespace-path
#630 xiaochenshen/rdt-cat-resctrl-cgroup-v1
#714 q384566678/seccomp-commits
#712 wking/seccomp-json-schema-names
#718 wking/v1.0.0-rc5-change-log
#710 vbatts/bump-version
#711 wking/example-cap-json-typo
#709 wking/style-link-markup
#708 wking/backtick-cleanup
#717 crosbymichael/remove-alex
