### PR TITLE
config-linux: Forbid the empty string for mountLabel

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -642,6 +642,7 @@ The values MUST be absolute paths in the [container namespace](glossary.md#conta
 ## <a name="configLinuxMountLabel" />Mount Label
 
 **`mountLabel`** (string, OPTIONAL) will set the Selinux context for the mounts in the container.
+    The value MUST NOT be an empty string.
 
 ### Example
 

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -264,7 +264,8 @@
             },
             "mountLabel": {
                 "id": "https://opencontainers.org/schema/bundle/linux/mountLabel",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         }
     }


### PR DESCRIPTION
`minLength` is documented [here][1].

The spec is currently not clear about how values for this property should be used, and after this commit it is still not clear.  But the `Linux.MountLabel` property is not a `*string`, so distinguishing between “unset” and “set to the empty string” would be awkward in Go.  I'm not familiar enough with the backing kernel API to be able to put RFC 2119 teeth into how the value should be used (#746), but I'm pretty sure we either want this commit (forbidding the empty string) or a `*string` in the Go type.

Related to opencontainers/runtime-tools#386, which is attempting to validate this property and using “[is the Go property different from the empty string][2]?” to mean “does the config set this property?”.  Without this commit, those statements are not interchangeable.

[1]: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.7
[2]: https://github.com/opencontainers/runtime-tools/pull/386/commits/b92ab4284b90ab07c529ac69a0f647c15a706f50#diff-8351286f57eb81e245c9c99c07f3b34fR523