### PR TITLE
config: Replace "SHOULD consider" for 'rootfs' path value

### DIFF
--- a/config.md
+++ b/config.md
@@ -30,11 +30,11 @@ For all platform-specific configuration values, the scope defined below in the [
 
 * **`path`** (string, OPTIONAL) Specifies the path to the root filesystem for the container.
     The path is either an absolute path or a relative path to the bundle.
-    Users SHOULD consider using a conventional name, such as `rootfs`.
 
     * On Windows, for Windows Server Containers, this field is REQUIRED and MUST be specified as a [volume GUID path][naming-a-volume].
       For Hyper-V Containers, this field MUST be omitted.
     * On all other platforms, this field is REQUIRED.
+        The value SHOULD be the conventional `rootfs`.
     * On Linux, for example, with a bundle at `/to/bundle` and a root filesystem at `/to/bundle/rootfs`, the `path` value can be either `/to/bundle/rootfs` or `rootfs`.
 
     If defined, a directory MUST exist at the path declared by the field.


### PR DESCRIPTION
SHOULD [means][1]:

> … there may exist valid reasons in particular circumstances to ignore a particular item, but the full implications must be understood and carefully weighed before choosing a different course.

So consideration is already baked into the definition, and we can just say “SHOULD be” and warn folks whenever they use a value other than `rootfs`.

Also break this into its own paragraph, because the value recommendation is orthogonal to and less important than the value semantics covered in the preceding sentences.

[1]: https://tools.ietf.org/html/rfc2119#section-3