### PR TITLE
config-windows: Fix header level for network example

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -86,7 +86,7 @@ The following parameters can be specified:
 * **`DNSSearchList`** *(array of strings, OPTIONAL)* - comma seperated list of DNS suffixes to use for name resolution.
 * **`networkSharedContainerName`** *(string, OPTIONAL)* - name (ID) of the container that we will share with the network stack.
 
-#### Example
+### Example
 
 ```json
     "windows": {


### PR DESCRIPTION
Catching #801 up with the [anchoring policy][1].

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc5/style.md#anchoring