### PR TITLE
Windows: Remove Sandbox, additional tweaks

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -148,15 +148,12 @@ The following parameters can be specified:
 
 * **`utilityvmpath`** *(string, OPTIONAL)* - specifies the path to the image used for the utility VM. This would be specified if using a base image which does not contain a utility VM image. If not supplied, the runtime will search the container filesystem layers from the bottom-most layer upwards, until it locates "UtilityVM", and default to that path.
 
-* **`sandboxpath`** *(string, REQUIRED)* - specifies the root of the path to the sandbox to be used for the container.
-
 ### Example
 
 ```json
     "windows": {
         "hyperv": {
-            "utilityvmpath": "C:\\\\path\\\\to\\utilityvm",
-            "sandboxpath": "C:\\\\programdata\\\\docker\\\\windowsfilter
+            "utilityvmpath": "C:\\path\\to\\utilityvm"
         }
     }
 ```

--- a/config.md
+++ b/config.md
@@ -31,7 +31,7 @@ For example, if a configuration is compliant with version 1.1 of this specificat
 * **`path`** (string, OPTIONAL) Specifies the path to the root filesystem for the container. The path is either an absolute path or a relative path to the bundle.
     Users SHOULD consider using a conventional name, such as `rootfs`.
 
-    On Windows, for Windows Server Containers, this field is REQUIRED. For Hyper-V Containers, this field MUST be omitted.
+    On Windows, for Windows Server Containers, this field is REQUIRED and MUST be specified as a [volume GUID path][naming-a-volume]. For Hyper-V Containers, this field MUST be omitted.
 
     On all other platforms, this field is REQUIRED.
 
@@ -40,12 +40,20 @@ For example, if a configuration is compliant with version 1.1 of this specificat
     If defined, a directory MUST exist at the path declared by the field.
 * **`readonly`** (bool, OPTIONAL) If true then the root filesystem MUST be read-only inside the container, defaults to false. On Windows, this field must be omitted or false.
 
-### Example
+### Example (POSIX)
 
 ```json
 "root": {
     "path": "rootfs",
     "readonly": true
+}
+```
+
+### Example (Windows)
+
+```json
+"root": {
+    "path": "\\\\?\\Volume{ec84d99e-3f02-11e7-ac6c-00155d7682cf}\\"
 }
 ```
 
@@ -841,8 +849,7 @@ Here is a full example `config.json` for reference.
 [go-environment]: https://golang.org/doc/install/source#environment
 [ieee-1003.1-2001-xbd-c8.1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html#tag_08_01
 [ieee-1003.1-2001-xsh-exec]: http://pubs.opengroup.org/onlinepubs/009695399/functions/exec.html
-[mountvol]: http://ss64.com/nt/mountvol.html
-[set-volume-mountpoint]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx
+[naming-a-volume]: https://aka.ms/nb3hqb
 
 [capabilities.7]: http://man7.org/linux/man-pages/man7/capabilities.7.html
 [mount.2]: http://man7.org/linux/man-pages/man2/mount.2.html

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -97,10 +97,6 @@
                     "utilityvmpath": {
                         "id": "https://opencontainers.org/schema/bundle/windows/hyperv/utilityvmpath",
                         "type": "string"
-                    },
-                    "sandboxpath": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/hyperv/sandboxpath",
-                        "type": "string"
                     }
                 }
             }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -494,8 +494,6 @@ type WindowsNetwork struct {
 
 // WindowsHyperV contains information for configuring a container to run with Hyper-V isolation.
 type WindowsHyperV struct {
-	// SandboxPath is a required host-path to the sandbox to be used by the container.
-	SandboxPath string `json:"sandboxpath"`
 	// UtilityVMPath is an optional path to the image used for the Utility VM.
 	UtilityVMPath string `json:"utilityvmpath,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This relates to conversations internally here finalising and verifying the changes necessary to support Windows in the v1.0 OCI spec. Specifically the first part of this comment: https://github.com/opencontainers/runtime-spec/pull/828#issuecomment-303537717.

It turns out that between Technical Preview 5 (TP5) and RTM of Windows Server 2016, there was a platform change whereby the SandboxPath no longer needed to be passed, but was kept in for backwards compatibility as long as the layerfolderpath is populated between the runtime and HCS. I wasn't aware of this. Hence it's no longer needed in the spec. Apologies for the noise introducing it.

There are three other clarifications in this PR:

a) Clarify the root.Path for Windows Server containers and give an explicit example.
b) Fix the double-escaping in the utilityvmpath in `config-windows.md`.
c) Removed old unused hyperlinks