### PR TITLE
Remove platform field

### DIFF
--- a/config.md
+++ b/config.md
@@ -321,47 +321,19 @@ For Windows based systems the user structure has the following fields:
 "hostname": "mrsdalloway"
 ```
 
-## <a name="configPlatform" />Platform
-
-**`platform`** (object, REQUIRED) specifies the configuration's target platform.
-
-* **`os`** (string, REQUIRED) specifies the operating system family of the container configuration's specified [`root`](#root) filesystem bundle.
-    The runtime MUST generate an error if it does not support the specified **`os`**.
-    Values SHOULD be, and runtimes SHOULD understand, **`os`** entries listed in the Go Language document for [`GOOS`][go-environment].
-    If an operating system is not included in the `GOOS` documentation, it SHOULD be submitted to this specification for standardization.
-* **`arch`** (string, REQUIRED) specifies the instruction set for which the binaries in the specified [`root`](#root) filesystem bundle have been compiled.
-    The runtime MUST generate an error if it does not support the specified **`arch`**.
-    Values SHOULD be, and runtimes SHOULD understand, **`arch`** entries listed in the Go Language document for [`GOARCH`][go-environment].
-    If an architecture is not included in the `GOARCH` documentation, it SHOULD be submitted to this specification for standardization.
-
-### Example
-
-```json
-"platform": {
-    "os": "linux",
-    "arch": "amd64"
-}
-```
-
 ## <a name="configPlatformSpecificConfiguration" />Platform-specific configuration
 
-[**`platform.os`**](#platform) is used to specify platform-specific configuration.
-
 * **`linux`** (object, OPTIONAL) [Linux-specific configuration](config-linux.md).
-    This MAY be set if **`platform.os`** is `linux` and MUST NOT be set otherwise.
+    This MAY be set if the target platform of this spec is `linux`.
 * **`windows`** (object, OPTIONAL) [Windows-specific configuration](config-windows.md).
-    This MUST be set if **`platform.os`** is `windows` and MUST NOT be set otherwise.
+    This MUST be set if the target platform of this spec is `windows`.
 * **`solaris`** (object, OPTIONAL) [Solaris-specific configuration](config-solaris.md).
-    This MAY be set if **`platform.os`** is `solaris` and MUST NOT be set otherwise.
+    This MAY be set if the target platform of this spec is `solaris`.
 
 ### Example (Linux)
 
 ```json
 {
-    "platform": {
-        "os": "linux",
-        "arch": "amd64"
-    },
     "linux": {
         "namespaces": [
             {
@@ -477,10 +449,6 @@ Here is a full example `config.json` for reference.
 ```json
 {
     "ociVersion": "0.5.0-dev",
-    "platform": {
-        "os": "linux",
-        "arch": "amd64"
-    },
     "process": {
         "terminal": true,
         "user": {
@@ -856,7 +824,6 @@ Here is a full example `config.json` for reference.
 [no-new-privs]: https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt
 [procfs_2]: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 [semver-v2.0.0]: http://semver.org/spec/v2.0.0.html
-[go-environment]: https://golang.org/doc/install/source#environment
 [ieee-1003.1-2008-xbd-c8.1]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_01
 [ieee-1003.1-2008-xsh-exec]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
 [naming-a-volume]: https://aka.ms/nb3hqb

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -37,24 +37,6 @@
                 "$ref": "defs.json#/definitions/Mount"
             }
         },
-        "platform": {
-            "id": "https://opencontainers.org/schema/bundle/platform",
-            "type": "object",
-            "required": [
-                "arch",
-                "os"
-            ],
-            "properties": {
-                "arch": {
-                    "id": "https://opencontainers.org/schema/bundle/platform/arch",
-                    "type": "string"
-                },
-                "os": {
-                    "id": "https://opencontainers.org/schema/bundle/platform/os",
-                    "type": "string"
-                }
-            }
-        },
         "root": {
             "description": "Configures the container's root filesystem.",
             "id": "https://opencontainers.org/schema/bundle/root",
@@ -233,7 +215,6 @@
     },
     "required": [
         "ociVersion",
-        "platform",
         "root"
     ]
 }

--- a/schema/test/config/good/minimal-for-start.json
+++ b/schema/test/config/good/minimal-for-start.json
@@ -1,9 +1,5 @@
 {
     "ociVersion": "1.0.0",
-    "platform": {
-        "os": "linux",
-        "arch": "amd64"
-    },
     "root": {
         "path": "rootfs"
     },

--- a/schema/test/config/good/minimal.json
+++ b/schema/test/config/good/minimal.json
@@ -1,9 +1,5 @@
 {
     "ociVersion": "1.0.0",
-    "platform": {
-        "os": "linux",
-        "arch": "amd64"
-    },
     "root": {
         "path": "rootfs"
     }

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -1,9 +1,5 @@
 {
     "ociVersion": "0.5.0-dev",
-    "platform": {
-        "os": "linux",
-        "arch": "amd64"
-    },
     "process": {
         "terminal": true,
         "user": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -6,8 +6,6 @@ import "os"
 type Spec struct {
 	// Version of the Open Container Runtime Specification with which the bundle complies.
 	Version string `json:"ociVersion"`
-	// Platform specifies the configuration's target platform.
-	Platform Platform `json:"platform"`
 	// Process configures the container process.
 	Process *Process `json:"process,omitempty"`
 	// Root configures the container's root filesystem.
@@ -99,15 +97,6 @@ type Root struct {
 	Path string `json:"path,omitempty"`
 	// Readonly makes the root filesystem for the container readonly before the process is executed.
 	Readonly bool `json:"readonly,omitempty"`
-}
-
-// Platform specifies OS and arch information for the host system that the container
-// is created for.
-type Platform struct {
-	// OS is the operating system.
-	OS string `json:"os"`
-	// Arch is the architecture
-	Arch string `json:"arch"`
 }
 
 // Mount specifies a mount for a container.


### PR DESCRIPTION
Close: #725

See discussion in #830 and dev-weekly-meeting discussion
in http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2017/opencontainers.2017-06-14-21.03.log.txt

We don't use this field in runc, and mostly only
image-spec cares about this, we can assume tools know
what specific platform this spec is built for.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>