### PR TITLE
config: Remove "MAY support any valid values" sentence

### DIFF
--- a/config.md
+++ b/config.md
@@ -340,7 +340,6 @@ For Windows based systems the user structure has the following fields:
 ## <a name="configPlatformSpecificConfiguration" />Platform-specific configuration
 
 [**`platform.os`**](#platform) is used to specify platform-specific configuration.
-    Runtime implementations MAY support any valid values for platform-specific fields as part of this configuration.
 
 * **`linux`** (object, OPTIONAL) [Linux-specific configuration](config-linux.md).
     This MAY be set if **`platform.os`** is `linux` and MUST NOT be set otherwise.


### PR DESCRIPTION
This line landed in #673, but I'm not clear on the motivation.  The wording reads to me like “you don't have to support valid values for platform-specific fields if you don't want to”, but we already cover unsupported value handling with the [valid values section][1] separated out in #681.  This commit removes the ambiguous line.

Related issue in #813, although this commit will not close that issue.

[1]: https://github.com/opencontainers/runtime-spec/blob/837ee7659b0c115bb32598e4454a1f6d2460b1ea/config.md#valid-values