### PR TITLE
glossary: Remove "leaf" and "hierarchy" from runtime namespace definition

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -30,9 +30,8 @@ It reads the [configuration files](#configuration) from a [bundle](#bundle), use
 
 ## <a name="glossaryRuntimeNamespace" />Runtime namespace
 
-On Linux, a leaf in the [namespace][namespaces.7] hierarchy from which the [runtime](#runtime) process is executed.
-New container namespaces will be created as children of the runtime namespaces.
-
+On Linux, the namespaces from which new [container namespaces](#container-namespace) are [created](config-linux.md#namespaces) and from which some configured resources are accessed.
+Examples of resources retrieved from this namespace include [`linux.namespaces[].path`](config-linux.md#namespaces) and the [`resctrl` psuedo-filesystem used for `linux.intelRdt`](config-linux.md#intelrdt).
 
 [JSON]: https://tools.ietf.org/html/rfc7159
 [UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf


### PR DESCRIPTION
Namespaces are not all hierarchical and processes aren't always in leaves.  Also punt to `config-linux.md` for details about namespace creation, although currently that section doesn't talk much about how the runtime namespaces relate to new container namespaces (#795).

Also mention resource access, because runtime namespaces play a role even if no new container namespaces are created.  I've used resources that currently explicitly mention runtime namespaces as examples, although I think more resources (e.g. `root.path` and `mounts[].source`, see [here][2] and [here][3]) deserve wording about that as well and would be better examples if they'd already landed such wording.

Spun off from #795.  The first line is similar to #852, but for runtime namespaces instead of container namespaces.

[1]: https://github.com/opencontainers/runtime-spec/pull/795#issuecomment-303768518
[2]: https://github.com/opencontainers/runtime-spec/pull/735#issuecomment-301198710
[3]: https://github.com/opencontainers/runtime-spec/commit/604205e5e1b58854c43e07901d3ec241df31df4e#diff-c9c91c29b41257aea3a3403cc606ad99R65