### PR TITLE
Hooks to linux,solaris and doc clarification

### DIFF
--- a/config.md
+++ b/config.md
@@ -356,7 +356,8 @@ Runtime implementations MAY support any valid values for platform-specific field
 
 ## <a name="configHooks" />Hooks
 
-Hooks allow for the configuration of custom actions related to the [lifecycle](runtime.md#lifecycle) of the container.
+Hooks allow for the configuration of custom actions related to the [lifecycle](runtime.md#lifecycle) of the container if supported by the platform.
+On Linux, they are run after the container namespaces are created.
 
 * **`hooks`** (object, OPTIONAL) MAY contain any of the following properties:
     * **`prestart`** (array of objects, OPTIONAL) is an array of [pre-start hooks](#prestart).

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -17,7 +17,7 @@ type Spec struct {
 	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
 	// Hooks configures callbacks for container lifecycle events.
-	Hooks *Hooks `json:"hooks,omitempty"`
+	Hooks *Hooks `json:"hooks,omitempty" platform:"linux,solaris"`
 	// Annotations contains arbitrary metadata for the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
@@ -134,7 +134,6 @@ type Hook struct {
 // Hooks for container setup and teardown
 type Hooks struct {
 	// Prestart is a list of hooks to be run before the container process is executed.
-	// On Linux, they are run after the container namespaces are created.
 	Prestart []Hook `json:"prestart,omitempty"`
 	// Poststart is a list of hooks to be run after the container process is started.
 	Poststart []Hook `json:"poststart,omitempty"`


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Made `hooks` Linux and solaris. Windows does not currently support hooks. While we might at a later date, have clarified that in the .go and .md file.

Also, as I mentioned in the description of https://github.com/opencontainers/runtime-spec/pull/854, platform-specific things are generally in the `.md` file, not the `.go` file. Hence moved the Linux comment.
