### PR TITLE
Windows: Fix camelCase inconsistencies

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -106,8 +106,8 @@ The following parameters can be specified:
 
 ## <a name="configWindowsCredentialSpec" />Credential Spec
 
-You can configure a container's group Managed Service Account (gMSA) via the OPTIONAL `credentialspec` field of the Windows configuration.
-The `credentialspec` is a JSON object whose properties are implementation-defined.
+You can configure a container's group Managed Service Account (gMSA) via the OPTIONAL `credentialSpec` field of the Windows configuration.
+The `credentialSpec` is a JSON object whose properties are implementation-defined.
 For more information about gMSAs, see [Active Directory Service Accounts for Windows Containers][gMSAOverview].
 For more information about tooling to generate a gMSA, see [Deployment Overview][gMSATooling].
 
@@ -130,13 +130,13 @@ You can indicate that a container should be started in a mode to apply pending s
 
 ## <a name="configWindowsIgnoreFlushesDuringBoot" />IgnoreFlushesDuringBoot
 
-You can indicate that a container should be started in an a mode where disk flushes are not performed during container boot via the OPTIONAL `ignoreflushesduringboot` field of the Windows configuration.
+You can indicate that a container should be started in an a mode where disk flushes are not performed during container boot via the OPTIONAL `ignoreFlushesDuringBoot` field of the Windows configuration.
 
 ### Example
 
 ```json
     "windows": {
-        "ignoreflushesduringboot": true
+        "ignoreFlushesDuringBoot": true
     }
 ```
 
@@ -146,14 +146,14 @@ You can indicate that a container should be started in an a mode where disk flus
 
 The following parameters can be specified:
 
-* **`utilityvmpath`** *(string, OPTIONAL)* - specifies the path to the image used for the utility VM. This would be specified if using a base image which does not contain a utility VM image. If not supplied, the runtime will search the container filesystem layers from the bottom-most layer upwards, until it locates "UtilityVM", and default to that path.
+* **`utilityVMPath`** *(string, OPTIONAL)* - specifies the path to the image used for the utility VM. This would be specified if using a base image which does not contain a utility VM image. If not supplied, the runtime will search the container filesystem layers from the bottom-most layer upwards, until it locates "UtilityVM", and default to that path.
 
 ### Example
 
 ```json
     "windows": {
         "hyperv": {
-            "utilityvmpath": "C:\\path\\to\\utilityvm"
+            "utilityVMPath": "C:\\path\\to\\utilityvm"
         }
     }
 ```

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -78,24 +78,24 @@
                     }
                 }
             },
-            "credentialspec": {
-                "id": "https://opencontainers.org/schema/bundle/windows/credentialspec",
+            "credentialSpec": {
+                "id": "https://opencontainers.org/schema/bundle/windows/credentialSpec",
                 "type": "object"
             },
             "servicing": {
                 "id": "https://opencontainers.org/schema/bundle/windows/servicing",
                 "type": "boolean"
             },
-            "ignoreflushesduringboot": {
-                "id": "https://opencontainers.org/schema/bundle/windows/ignoreflushesduringboot",
+            "ignoreFlushesDuringBoot": {
+                "id": "https://opencontainers.org/schema/bundle/windows/ignoreFlushesDuringBoot",
                 "type": "boolean"
             },
             "hyperv": {
                 "id": "https://opencontainers.org/schema/bundle/windows/hyperv",
                 "type": "object",
                 "properties": {
-                    "utilityvmpath": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/hyperv/utilityvmpath",
+                    "utilityVMPath": {
+                        "id": "https://opencontainers.org/schema/bundle/windows/hyperv/utilityVMPath",
                         "type": "string"
                     }
                 }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -433,11 +433,11 @@ type Windows struct {
 	// Resources contains information for handling resource constraints for the container.
 	Resources *WindowsResources `json:"resources,omitempty"`
 	// CredentialSpec contains a JSON object describing a group Managed Service Account (gMSA) specification.
-	CredentialSpec interface{} `json:"credentialspec,omitempty"`
+	CredentialSpec interface{} `json:"credentialSpec,omitempty"`
 	// Servicing indicates if the container is being started in a mode to apply a Windows Update servicing operation.
 	Servicing bool `json:"servicing,omitempty"`
 	// IgnoreFlushesDuringBoot indicates if the container is being started in a mode where disk writes are not flushed during its boot process.
-	IgnoreFlushesDuringBoot bool `json:"ignoreflushesduringboot,omitempty"`
+	IgnoreFlushesDuringBoot bool `json:"ignoreFlushesDuringBoot,omitempty"`
 	// HyperV contains information for running a container with Hyper-V isolation.
 	HyperV *WindowsHyperV `json:"hyperv,omitempty"`
 	// Network restriction configuration.
@@ -495,7 +495,7 @@ type WindowsNetwork struct {
 // WindowsHyperV contains information for configuring a container to run with Hyper-V isolation.
 type WindowsHyperV struct {
 	// UtilityVMPath is an optional path to the image used for the Utility VM.
-	UtilityVMPath string `json:"utilityvmpath,omitempty"`
+	UtilityVMPath string `json:"utilityVMPath,omitempty"`
 }
 
 // LinuxSeccomp represents syscall restrictions


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

As per https://github.com/opencontainers/runtime-spec/pull/828#discussion_r118537284, fixes https://github.com/opencontainers/runtime-spec/issues/857.

Addresses `credentialSpec`, `utilityVMPath`, and `ignoreFlushesDuringBoot`.

REMOVED ~~~I noticed there were discrepancies also, particularly in the `SolarisAnet` structure (camelCase and non-matching field names to json names), so I fixed these up at the same time.~~~