### PR TITLE
config-linux: Drop redundant 'blkio' prefix from blockIO properties

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -328,16 +328,16 @@ For more information, see the kernel cgroups documentation about [blkio][cgroup-
 
 The following parameters can be specified to set up the controller:
 
-* **`blkioWeight`** *(uint16, OPTIONAL)* - specifies per-cgroup weight. This is default weight of the group on all devices until and unless overridden by per-device rules.
-* **`blkioLeafWeight`** *(uint16, OPTIONAL)* - equivalents of `blkioWeight` for the purpose of deciding how much weight tasks in the given cgroup has while competing with the cgroup's child cgroups.
-* **`blkioWeightDevice`** *(array of objects, OPTIONAL)* - specifies the list of devices which will be bandwidth rate limited. The following parameters can be specified per-device:
+* **`weight`** *(uint16, OPTIONAL)* - specifies per-cgroup weight. This is default weight of the group on all devices until and unless overridden by per-device rules.
+* **`leafWeight`** *(uint16, OPTIONAL)* - equivalents of `weight` for the purpose of deciding how much weight tasks in the given cgroup has while competing with the cgroup's child cgroups.
+* **`weightDevice`** *(array of objects, OPTIONAL)* - specifies the list of devices which will be bandwidth rate limited. The following parameters can be specified per-device:
     * **`major, minor`** *(int64, REQUIRED)* - major, minor numbers for device. More info in [mknod(1)][mknod.1] man page.
     * **`weight`** *(uint16, OPTIONAL)* - bandwidth rate for the device.
     * **`leafWeight`** *(uint16, OPTIONAL)* - bandwidth rate for the device while competing with the cgroup's child cgroups, CFQ scheduler only
 
     You MUST specify at least one of `weight` or `leafWeight` in a given entry, and MAY specify both.
 
-* **`blkioThrottleReadBpsDevice`**, **`blkioThrottleWriteBpsDevice`**, **`blkioThrottleReadIOPSDevice`**, **`blkioThrottleWriteIOPSDevice`** *(array of objects, OPTIONAL)* - specify the list of devices which will be IO rate limited.
+* **`throttleReadBpsDevice`**, **`throttleWriteBpsDevice`**, **`throttleReadIOPSDevice`**, **`throttleWriteIOPSDevice`** *(array of objects, OPTIONAL)* - specify the list of devices which will be IO rate limited.
     The following parameters can be specified per-device:
     * **`major, minor`** *(int64, REQUIRED)* - major, minor numbers for device. More info in [mknod(1)][mknod.1] man page.
     * **`rate`** *(uint64, REQUIRED)* - IO rate limit for the device
@@ -346,9 +346,9 @@ The following parameters can be specified to set up the controller:
 
 ```json
     "blockIO": {
-        "blkioWeight": 10,
-        "blkioLeafWeight": 10,
-        "blkioWeightDevice": [
+        "weight": 10,
+        "leafWeight": 10,
+        "weightDevice": [
             {
                 "major": 8,
                 "minor": 0,
@@ -361,14 +361,14 @@ The following parameters can be specified to set up the controller:
                 "weight": 500
             }
         ],
-        "blkioThrottleReadBpsDevice": [
+        "throttleReadBpsDevice": [
             {
                 "major": 8,
                 "minor": 0,
                 "rate": 600
             }
         ],
-        "blkioThrottleWriteIOPSDevice": [
+        "throttleWriteIOPSDevice": [
             {
                 "major": 8,
                 "minor": 16,

--- a/config.md
+++ b/config.md
@@ -752,9 +752,9 @@ Here is a full example `config.json` for reference.
                 }
             ],
             "blockIO": {
-                "blkioWeight": 10,
-                "blkioLeafWeight": 10,
-                "blkioWeightDevice": [
+                "weight": 10,
+                "leafWeight": 10,
+                "weightDevice": [
                     {
                         "major": 8,
                         "minor": 0,
@@ -767,14 +767,14 @@ Here is a full example `config.json` for reference.
                         "weight": 500
                     }
                 ],
-                "blkioThrottleReadBpsDevice": [
+                "throttleReadBpsDevice": [
                     {
                         "major": 8,
                         "minor": 0,
                         "rate": 600
                     }
                 ],
-                "blkioThrottleWriteIOPSDevice": [
+                "throttleWriteIOPSDevice": [
                     {
                         "major": 8,
                         "minor": 16,

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -64,44 +64,44 @@
                         "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO",
                         "type": "object",
                         "properties": {
-                            "blkioWeight": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioWeight",
-                                "$ref": "defs-linux.json#/definitions/blkioWeight"
+                            "weight": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/weight",
+                                "$ref": "defs-linux.json#/definitions/weight"
                             },
-                            "blkioLeafWeight": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioLeafWeight",
-                                "$ref": "defs-linux.json#/definitions/blkioWeight"
+                            "leafWeight": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/leafWeight",
+                                "$ref": "defs-linux.json#/definitions/weight"
                             },
-                            "blkioThrottleReadBpsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleReadBpsDevice",
+                            "throttleReadBpsDevice": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/throttleReadBpsDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceThrottle"
                                 }
                             },
-                            "blkioThrottleWriteBpsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleWriteBpsDevice",
+                            "throttleWriteBpsDevice": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/throttleWriteBpsDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceThrottle"
                                 }
                             },
-                            "blkioThrottleReadIopsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleReadIopsDevice",
+                            "throttleReadIopsDevice": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/throttleReadIopsDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceThrottle"
                                 }
                             },
-                            "blkioThrottleWriteIopsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioThrottleWriteIopsDevice",
+                            "throttleWriteIopsDevice": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/throttleWriteIopsDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceThrottle"
                                 }
                             },
-                            "blkioWeightDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/blkioWeightDevice",
+                            "weightDevice": {
+                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/weightDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceWeight"

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -144,7 +144,7 @@
                 }
             }
         },
-        "blkioWeight": {
+        "weight": {
             "type": "integer"
         },
         "blockIODevice": {
@@ -172,10 +172,10 @@
                     "type": "object",
                     "properties": {
                         "weight": {
-                            "$ref": "#/definitions/blkioWeight"
+                            "$ref": "#/definitions/weight"
                         },
                         "leafWeight": {
-                            "$ref": "#/definitions/blkioWeight"
+                            "$ref": "#/definitions/weight"
                         }
                     }
                 }

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -278,9 +278,9 @@
                 }
             ],
             "blockIO": {
-                "blkioWeight": 10,
-                "blkioLeafWeight": 10,
-                "blkioWeightDevice": [
+                "weight": 10,
+                "leafWeight": 10,
+                "weightDevice": [
                     {
                         "major": 8,
                         "minor": 0,
@@ -293,14 +293,14 @@
                         "weight": 500
                     }
                 ],
-                "blkioThrottleReadBpsDevice": [
+                "throttleReadBpsDevice": [
                     {
                         "major": 8,
                         "minor": 0,
                         "rate": 600
                     }
                 ],
-                "blkioThrottleWriteIOPSDevice": [
+                "throttleWriteIOPSDevice": [
                     {
                         "major": 8,
                         "minor": 16,

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -248,7 +248,7 @@ type linuxBlockIODevice struct {
 	Minor int64 `json:"minor"`
 }
 
-// LinuxWeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
+// LinuxWeightDevice struct holds a `major:minor weight` pair for weightDevice
 type LinuxWeightDevice struct {
 	linuxBlockIODevice
 	// Weight is the bandwidth rate for the device.
@@ -267,19 +267,19 @@ type LinuxThrottleDevice struct {
 // LinuxBlockIO for Linux cgroup 'blkio' resource management
 type LinuxBlockIO struct {
 	// Specifies per cgroup weight
-	Weight *uint16 `json:"blkioWeight,omitempty"`
+	Weight *uint16 `json:"weight,omitempty"`
 	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, CFQ scheduler only
-	LeafWeight *uint16 `json:"blkioLeafWeight,omitempty"`
+	LeafWeight *uint16 `json:"leafWeight,omitempty"`
 	// Weight per cgroup per device, can override BlkioWeight
-	WeightDevice []LinuxWeightDevice `json:"blkioWeightDevice,omitempty"`
+	WeightDevice []LinuxWeightDevice `json:"weightDevice,omitempty"`
 	// IO read rate limit per cgroup per device, bytes per second
-	ThrottleReadBpsDevice []LinuxThrottleDevice `json:"blkioThrottleReadBpsDevice,omitempty"`
+	ThrottleReadBpsDevice []LinuxThrottleDevice `json:"throttleReadBpsDevice,omitempty"`
 	// IO write rate limit per cgroup per device, bytes per second
-	ThrottleWriteBpsDevice []LinuxThrottleDevice `json:"blkioThrottleWriteBpsDevice,omitempty"`
+	ThrottleWriteBpsDevice []LinuxThrottleDevice `json:"throttleWriteBpsDevice,omitempty"`
 	// IO read rate limit per cgroup per device, IO per second
-	ThrottleReadIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleReadIOPSDevice,omitempty"`
+	ThrottleReadIOPSDevice []LinuxThrottleDevice `json:"throttleReadIOPSDevice,omitempty"`
 	// IO write rate limit per cgroup per device, IO per second
-	ThrottleWriteIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleWriteIOPSDevice,omitempty"`
+	ThrottleWriteIOPSDevice []LinuxThrottleDevice `json:"throttleWriteIOPSDevice,omitempty"`
 }
 
 // LinuxMemory for Linux cgroup 'memory' resource management


### PR DESCRIPTION
These are long enough without the prefix, and `linux.resources.blockIO.blkioWeight`, etc. are just as specific as `linux.resources.blockIO.weight`.  Generated with:

```
$ sed -i s/blkioWeight/weight/g $(git grep -l blkioWeight)
$ sed -i s/blkioLeaf/leaf/g $(git grep -l blkioLeaf)
$ sed -i s/blkioThrottle/throttle/g $(git grep -l blkioThrottle)
```

Property-name polishing inspired by #859, in case we want to clean this sort of thing up before 1.0.  If not, we can just close this PR.