### PR TITLE
glossary: Define "set" and "unset"

### DIFF
--- a/config-solaris.md
+++ b/config-solaris.md
@@ -84,11 +84,11 @@ For additional information on properties, check the [zonecfg(1M)][zonecfg.1m_2] 
 * **`lowerLink`** *(string, OPTIONAL)* Specify the link over which the VNIC will be created.
 Mapped to `lower-link` in the [zonecfg(1M)][zonecfg.1m_2] man page.
 * **`allowedAddress`** *(string, OPTIONAL)* The set of IP addresses that the container can use might be constrained by specifying the `allowedAddress` property.
-    If `allowedAddress` has not been specified, then they can use any IP address on the associated physical interface for the network resource.
-    Otherwise, when `allowedAddress` is specified, the container cannot use IP addresses that are not in the `allowedAddress` list for the physical address.
+    If `allowedAddress` is [unset](glossary.md#set), then they can use any IP address on the associated physical interface for the network resource.
+    Otherwise, when `allowedAddress` is [set](glossary.md#set), the container cannot use IP addresses that are not in the `allowedAddress` list for the physical address.
     Mapped to `allowed-address` in the [zonecfg(1M)][zonecfg.1m_2] man page.
-* **`configureAllowedAddress`** *(string, OPTIONAL)* If `configureAllowedAddress` is set to true, the addresses specified by `allowedAddress` are automatically configured on the interface each time the container starts.
-    When it is set to false, the `allowedAddress` will not be configured on container start.
+* **`configureAllowedAddress`** *(string, OPTIONAL)* If `configureAllowedAddress` is `true`, the addresses specified by `allowedAddress` are automatically configured on the interface each time the container starts.
+    When it is `false`, the `allowedAddress` will not be configured on container start.
     Mapped to `configure-allowed-address` in the [zonecfg(1M)][zonecfg.1m_2] man page.
 * **`defrouter`** *(string, OPTIONAL)* The value for the OPTIONAL default router.
 * **`macAddress`** *(string, OPTIONAL)* Set the VNIC's MAC addresses based on the specified value or keyword.

--- a/config-windows.md
+++ b/config-windows.md
@@ -155,14 +155,14 @@ You can indicate that a container should be started in an a mode where disk flus
 ## <a name="configWindowsHyperV" />HyperV
 
 `hyperv` is an OPTIONAL field of the Windows configuration.
-If present, the container MUST be run with Hyper-V isolation.
-If omitted, the container MUST be run as a Windows Server container.
+If [set](glossary.md#set), the container MUST be run with Hyper-V isolation.
+If [unset](glossary.md#set), the container MUST be run as a Windows Server container.
 
 The following parameters can be specified:
 
 * **`utilityVMPath`** *(string, OPTIONAL)* - specifies the path to the image used for the utility VM.
     This would be specified if using a base image which does not contain a utility VM image.
-    If not supplied, the runtime will search the container filesystem layers from the bottom-most layer upwards, until it locates "UtilityVM", and default to that path.
+    If [unset](glossary.md#set), the runtime MUST search the container filesystem layers from the bottom-most layer upwards, until it locates "UtilityVM", and default to that path.
 
 ### Example
 

--- a/config.md
+++ b/config.md
@@ -32,14 +32,15 @@ For all platform-specific configuration values, the scope defined below in the [
     The path is either an absolute path or a relative path to the bundle.
     Users SHOULD consider using a conventional name, such as `rootfs`.
 
-    * On Windows, for Windows Server Containers, this field is REQUIRED and MUST be specified as a [volume GUID path][naming-a-volume].
-      For Hyper-V Containers, this field MUST be omitted.
+    * On Windows, for Windows Server Containers, this field is REQUIRED and MUST be a [volume GUID path][naming-a-volume].
+      For Hyper-V Containers, this field MUST be [unset](glossary.md#set).
     * On all other platforms, this field is REQUIRED.
     * On Linux, for example, with a bundle at `/to/bundle` and a root filesystem at `/to/bundle/rootfs`, the `path` value can be either `/to/bundle/rootfs` or `rootfs`.
 
     If defined, a directory MUST exist at the path declared by the field.
-* **`readonly`** (bool, OPTIONAL) If true then the root filesystem MUST be read-only inside the container, defaults to false.
-    * On Windows, this field MUST be omitted or false.
+* **`readonly`** (bool, OPTIONAL) If true then the root filesystem MUST be read-only inside the container.
+    Defaults to `false`.
+    * On Windows, this field MUST be [unset](glossary.md#set) or `false`.
 
 ### Example (POSIX)
 
@@ -173,8 +174,8 @@ For Linux-based systems the process structure supports the following process-spe
 * **`apparmorProfile`** (string, OPTIONAL) specifies the name of the AppArmor profile to be applied to processes in the container.
     For more information about AppArmor, see [AppArmor documentation][apparmor].
 * **`oomScoreAdj`** *(int, OPTIONAL)* adjusts the oom-killer score in `[pid]/oom_score_adj` for the container process's `[pid]` in a [proc pseudo-filesystem][procfs].
-    If `oomScoreAdj` is set, the runtime MUST set `oom_score_adj` to the given value.
-    If `oomScoreAdj` is not set, the runtime MUST NOT change the value of `oom_score_adj`.
+    If `oomScoreAdj` is [set](glossary.md#set), the runtime MUST set `oom_score_adj` to the given value.
+    If `oomScoreAdj` is [unset](glossary.md#set), the runtime MUST NOT change the value of `oom_score_adj`.
 
     This is a per-process setting, where as [`disableOOMKiller`](config-linux.md#disable-out-of-memory-killer) is scoped for a memory cgroup.
     For more information on how these two settings work together, see [the memory cgroup documentation section 10. OOM Contol][cgroup-v1-memory_2].
@@ -343,11 +344,11 @@ For Windows based systems the user structure has the following fields:
     Runtime implementations MAY support any valid values for platform-specific fields as part of this configuration.
 
 * **`linux`** (object, OPTIONAL) [Linux-specific configuration](config-linux.md).
-    This MAY be set if **`platform.os`** is `linux` and MUST NOT be set otherwise.
+    This MAY be [set](glossary.md#set) if **`platform.os`** is `linux` and MUST be [unset](glossary.md#set) otherwise.
 * **`windows`** (object, OPTIONAL) [Windows-specific configuration](config-windows.md).
-    This MUST be set if **`platform.os`** is `windows` and MUST NOT be set otherwise.
+    This MUST be [set](glossary.md#set) if **`platform.os`** is `windows` and MUST NOT be set otherwise.
 * **`solaris`** (object, OPTIONAL) [Solaris-specific configuration](config-solaris.md).
-    This MAY be set if **`platform.os`** is `solaris` and MUST NOT be set otherwise.
+    This MAY be [set](glossary.md#set) if **`platform.os`** is `solaris` and MUST be [unset](glossary.md#set) otherwise.
 
 ### Example (Linux)
 
@@ -380,7 +381,7 @@ On Linux, they are run after the container namespaces are created.
         * **`args`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2001 `execv`'s *argv*][ieee-1003.1-2001-xsh-exec].
         * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2001's `environ`][ieee-1003.1-2001-xbd-c8.1].
         * **`timeout`** (int, OPTIONAL) is the number of seconds before aborting the hook.
-            If set, `timeout` MUST be greater than zero.
+            If [set](glossary.md#set), `timeout` MUST be greater than zero.
     * **`poststart`** (array of objects, OPTIONAL) is an array of [post-start hooks](#poststart).
         Entries in the array have the same schema as pre-start entries.
     * **`poststop`** (array of objects, OPTIONAL) is an array of [post-stop hooks](#poststop).

--- a/glossary.md
+++ b/glossary.md
@@ -33,6 +33,9 @@ It reads the [configuration files](#configuration) from a [bundle](#bundle), use
 On Linux, a leaf in the [namespace][namespaces.7] hierarchy from which the [runtime](#runtime) process is executed.
 New container namespaces will be created as children of the runtime namespaces.
 
+## <a name="glossarySet" />Set
+
+A property is "set" if its key appears in the parent JSON object and "unset" if its key does not appear in the parent JSON object.
 
 [JSON]: https://tools.ietf.org/html/rfc7159
 [UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf

--- a/runtime.md
+++ b/runtime.md
@@ -117,7 +117,7 @@ This operation MUST [generate an error](#errors) if it is not provided the conta
 Attempting to start a container that does not exist MUST [generate an error](#errors).
 Attempting to start an already started container MUST have no effect on the container and MUST [generate an error](#errors).
 This operation MUST run the user-specified program as specified by [`process`](config.md#process).
-This operation MUST generate an error if `process` was not set.
+This operation MUST generate an error if `process` was [unset](glossary.md#set).
 
 ### <a name="runtimeKill" />Kill
 `kill <container-id> <signal>`


### PR DESCRIPTION
There [seems to be confusion about whether the empty string (and possible other values that match Go's zero values) qualifies as "set" or not][1].  This commit clarifies that Go zero values are not relevant to the spec, but it does not address how they should be handled (I'm leaving that to follow-up work).

[1]: https://github.com/opencontainers/runtime-spec/pull/823#discussion_r118620374