### PR TITLE
config: Explicily make consoleSize unspecified if terminal is false or unset

### DIFF
--- a/config.md
+++ b/config.md
@@ -137,7 +137,8 @@ For all platform-specific configuration values, the scope defined below in the [
 
 * **`terminal`** (bool, OPTIONAL) specifies whether a terminal is attached to that process, defaults to false.
     As an example, if set to true on Linux a pseudoterminal pair is allocated for the container process and the pseudoterminal slave is duplicated on the container process's [standard streams][stdin.3].
-* **`consoleSize`** (object, OPTIONAL) specifies the console size in characters of the terminal if attached, containing the following properties:
+* **`consoleSize`** (object, OPTIONAL) specifies the console size in characters of the terminal.
+    Runtimes MUST ignore `consoleSize` if `terminal` is `false` or unset.
     * **`height`** (uint, REQUIRED)
     * **`width`** (uint, REQUIRED)
 * **`cwd`** (string, REQUIRED) is the working directory that will be set for the executable.


### PR DESCRIPTION
The old language is from #563, where nobody commented on the “if attached” wording.  But reading the old line now, it's not clear to me what `consoleSize` means when `terminal` is not `true`.

This commit explicitly declares `consoleSize` unspecified in that condition, so runtimes are free to do what they want short of erroring out.  I considered making the property undefined or requiring it to be unset, but those seemed too strict given our permissive “[MUST ignore unknown properties][1]” extensibility requirement.

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc5/config.md#extensibility