### PR TITLE
fix docs.oracle.com links #864

### DIFF
--- a/config-solaris.md
+++ b/config-solaris.md
@@ -115,6 +115,6 @@ Mapped to `link-protection` in the [zonecfg(1M)][zonecfg.1m_2] man page.
 ```
 
 
-[priv-str-to-set.3c]: http://docs.oracle.com/cd/E53394_01/html/E54766/priv-str-to-set-3c.html
-[zoneadmd.1m]: http://docs.oracle.com/cd/E53394_01/html/E54764/zoneadmd-1m.html
-[zonecfg.1m_2]: https://docs.oracle.com/cd/E36784_01/html/E36871/zonecfg-1m.html
+[priv-str-to-set.3c]: http://docs.oracle.com/cd/E86824_01/html/E54766/priv-str-to-set-3c.html
+[zoneadmd.1m]: http://docs.oracle.com/cd/E86824_01/html/E54764/zoneadmd-1m.html
+[zonecfg.1m_2]: http://docs.oracle.com/cd/E86824_01/html/E54764/zonecfg-1m.html

--- a/config.md
+++ b/config.md
@@ -859,4 +859,4 @@ Here is a full example `config.json` for reference.
 [setrlimit.2]: http://man7.org/linux/man-pages/man2/setrlimit.2.html
 [stdin.3]: http://man7.org/linux/man-pages/man3/stdin.3.html
 [uts-namespace.7]: http://man7.org/linux/man-pages/man7/namespaces.7.html
-[zonecfg.1m]: https://docs.oracle.com/cd/E36784_01/html/E36871/zonecfg-1m.html
+[zonecfg.1m]: http://docs.oracle.com/cd/E86824_01/html/E54764/zonecfg-1m.html


### PR DESCRIPTION
hey all.  i recently started working on the solaris docker port and that means i'm also responsible for the solaris components of the container runtime spec.  while looking at the spec i noticed that some of our doc links were broken.  i've never worked directly on github.com before, so i figured that fixing this would be a good way to learn the ropes and introduce myself.  so apologies in advance if i've made any noob mistakes.  cheers.