### PR TITLE
config: RFC 2119 language for uid, gid, and additionalGids

### DIFF
--- a/config.md
+++ b/config.md
@@ -185,8 +185,11 @@ The user for the process is a platform-specific structure that allows specific c
 For Linux and Solaris based systems the user structure has the following fields:
 
 * **`uid`** (int, REQUIRED) specifies the user ID in the [container namespace](glossary.md#container-namespace).
+    The runtime MUST set the [real user ID][real-user-id] of the process such that a call to [`getuid(3)`][getuid.3] returns the configured value.
 * **`gid`** (int, REQUIRED) specifies the group ID in the [container namespace](glossary.md#container-namespace).
-* **`additionalGids`** (array of ints, OPTIONAL) specifies additional group IDs (in the [container namespace](glossary.md#container-namespace) to be added to the process.
+    The runtime MUST set the [real group ID][real-group-id] of the process such that a call to [`getgid(3)`][getgid.3] returns the configured value.
+* **`additionalGids`** (array of ints, OPTIONAL) specifies additional group IDs (in the [container namespace](glossary.md#container-namespace)) to be added to the process.
+    The runtime MUST set the [supplementary group IDs][supplementary-group-id] of the process such that the union of group IDs from a call to [`getgroups(3)`][getgroups.3] and a call to [`getegid(3)`][getegid] equals the union of the configured `additionalGroups` and `gid` values.
 
 _Note: symbolic name for uid and gid, such as uname and gname respectively, are left to upper levels to derive (i.e. `/etc/passwd` parsing, NSS, etc)_
 
@@ -850,8 +853,15 @@ Here is a full example `config.json` for reference.
 [ieee-1003.1-2001-xbd-c8.1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html#tag_08_01
 [ieee-1003.1-2001-xsh-exec]: http://pubs.opengroup.org/onlinepubs/009695399/functions/exec.html
 [naming-a-volume]: https://aka.ms/nb3hqb
+[real-group-id]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_312
+[real-user-id]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_315
+[supplementary-group-id]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_378
 
 [capabilities.7]: http://man7.org/linux/man-pages/man7/capabilities.7.html
+[getegid.3]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getegid.html
+[getgid.3]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getgid.html
+[getgroups.3]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getgroups.html
+[getuid.3]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getuid.html
 [mount.2]: http://man7.org/linux/man-pages/man2/mount.2.html
 [mount.8]: http://man7.org/linux/man-pages/man8/mount.8.html
 [mount.8-filesystem-independent]: http://man7.org/linux/man-pages/man8/mount.8.html#FILESYSTEM-INDEPENDENT_MOUNT%20OPTIONS


### PR DESCRIPTION
Also link to POSIX for the associated definitions.

This adds runtime-oriented requirements similar to what runtime-tools is [already checking][1].  However, runtime-tools is currently allowing additional groups in the `getgroups()` response beyond those specified in `additionalGids`, with “superset” wording documented in opencontainers/runtime-tools@0ad3c80a.  I'm not sure if that superset logic is intended to be an open door, or if it is a workaround for the implementation-defined inclusion of the effective group ID in the [`getgroups()` response][2]:

> It is implementation-defined whether `getgroups()` also returns the effective group ID in the grouplist array.
>
> …
>
> Duplication may exist, but the application needs to call `getegid()` to be sure of getting all of the information.

@mrunalp, 2015 was a while ago, but do you remember why you went with the superset approach?

The wording I'm using glosses over a potential distinction between the real and effective group ID, since it's using the `gid` value as the effective group ID in the `additionalGids` comparison and as the real group ID in the `gid` comparison.  That could conceivably be an issue if `process.args` points to a setgid binary, but I think that is unlikely to be a major issue in the wild, and it is certainly avoidable within runtime-tools' compliance testing, so I haven't addressed it in this commit.

[1]: https://github.com/opencontainers/runtime-tools/blob/f49d861b69e359dc9278fcfa6948034a4af58705/cmd/runtimetest/main.go#L100-L123
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getgroups.html