### PR TITLE
config: Remove incorrect "after the container namespaces are created"

### DIFF
--- a/config.md
+++ b/config.md
@@ -365,7 +365,6 @@ Runtime implementations MAY support any valid values for platform-specific field
 ## <a name="configHooks" />Hooks
 
 Hooks allow for the configuration of custom actions related to the [lifecycle](runtime.md#lifecycle) of the container if supported by the platform.
-On Linux, they are run after the container namespaces are created.
 
 * **`hooks`** (object, OPTIONAL) MAY contain any of the following properties:
     * **`prestart`** (array of objects, OPTIONAL) is an array of [pre-start hooks](#prestart).


### PR DESCRIPTION
Not all hooks are run after creation.  In fact, there are currently no `postcreate` hooks (`prestart` hooks are called “[after the `start` operation is called but before the user-specified program command is executed][1]”.  I suggest not adding this line (and removing it from the Go comment).

There's an outside chance that folks could read the line as “after namespaces are created, not necessarily before `create` returns”, and that's correct.  But I don't think it adds anything with each hook already clearly defining when it is triggered.

Spun off from [this comment][2].

[1]: https://github.com/opencontainers/runtime-spec/blob/2ec18c02474dd49ce20aa30236959a8a80763042/config.md#prestart
[2]: https://github.com/opencontainers/runtime-spec/pull/855#discussion_r118341546