### PR TITLE
config: Require hook support on Linux and Solaris

### DIFF
--- a/config.md
+++ b/config.md
@@ -362,9 +362,9 @@ Runtime implementations MAY support any valid values for platform-specific field
 }
 ```
 
-## <a name="configHooks" />Hooks
+## <a name="configHooks" />Linux and Solaris Hooks
 
-Hooks allow for the configuration of custom actions related to the [lifecycle](runtime.md#lifecycle) of the container if supported by the platform.
+For Linux- and Solaris-based systems, the configuration structure supports `hooks` for configuring custom actions related to the [lifecycle](runtime.md#lifecycle) of the container.
 
 * **`hooks`** (object, OPTIONAL) MAY contain any of the following properties:
     * **`prestart`** (array of objects, OPTIONAL) is an array of [pre-start hooks](#prestart).

--- a/config.md
+++ b/config.md
@@ -365,7 +365,6 @@ Runtime implementations MAY support any valid values for platform-specific field
 ## <a name="configHooks" />Hooks
 
 Hooks allow for the configuration of custom actions related to the [lifecycle](runtime.md#lifecycle) of the container if supported by the platform.
-On Linux, they are run after the container namespaces are created.
 
 * **`hooks`** (object, OPTIONAL) MAY contain any of the following properties:
     * **`prestart`** (array of objects, OPTIONAL) is an array of [pre-start hooks](#prestart).


### PR DESCRIPTION
This builds on #869, so review that one first.

Clarifying the language from #855 according to [this comment][0].  Without something like this commit, there's no clear way for config authors to know if their runtime will support hooks or not, and there was previous agreement that [that sort of ambiguity was not helpful][1].  This also gives normative Markdown grounding for the [Go platform tag][2] added in 28e8f68.

[0]: https://github.com/opencontainers/runtime-spec/pull/855/files#r118342685
[1]: https://github.com/opencontainers/runtime-spec/pull/472#r78088802
[2]: https://github.com/opencontainers/runtime-spec/pull/855/files#diff-7f24d60f0cbb9c433e165467e3d34838R20