### PR TITLE
config-linux: "may" -> "MAY" for supplying linux.devices

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -110,7 +110,7 @@ Note that the number of mapping entries MAY be limited by the [kernel][user-name
 ## <a name="configLinuxDevices" />Devices
 
 **`devices`** (array of objects, OPTIONAL) lists devices that MUST be available in the container.
-The runtime may supply them however it likes (with [mknod][mknod.2], by bind mounting from the runtime mount namespace, etc.).
+The runtime MAY supply them however it likes (with [`mknod`][mknod.2], by bind mounting from the runtime mount namespace, etc.).
 
 Each entry has the following structure:
 


### PR DESCRIPTION
The way that the runtime supplies these is “[truly optional][1]”, as long as they get supplied.  Also backtick `mknod`.

An uncontentious change spun off from #829.

[1]: https://tools.ietf.org/html/rfc2119#section-5