### PR TITLE
config-linux: Explicitly allow symlinks for providing devices

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -110,7 +110,7 @@ Note that the number of mapping entries MAY be limited by the [kernel][user-name
 ## <a name="configLinuxDevices" />Devices
 
 **`devices`** (array of objects, OPTIONAL) lists devices that MUST be available in the container.
-The runtime MAY supply them however it likes (with [`mknod`][mknod.2], by bind mounting from the runtime mount namespace, etc.).
+The runtime MAY supply them however it likes (with [`mknod`][mknod.2], by bind mounting from the runtime mount namespace, using symlinks, etc.).
 
 Each entry has the following structure:
 


### PR DESCRIPTION
I'd rather address runtime compliance by breaking this down into explicit checks based on POSIX stat(3) calls.  But with [that approach rejected][1], mentioning symlinks here helps motivate [runtime-tools' choice][2] of [`os.Stat`][3] (which follows symlinks) vs. [`os.Lstat`][4] (which does not).

Spun off as a non-controversial portion of the rejected #829, as requested by @crosbymichael on 2017-06-01 (although that request didn't make it [into the log][5]).

[1]: https://github.com/opencontainers/runtime-spec/pull/829#issuecomment-305582159
[2]: https://github.com/opencontainers/runtime-tools/blob/f5c82b3918bdfc3ed4b594dcfab4d1554beaf992/cmd/runtimetest/main.go#L319
[3]: https://golang.org/pkg/os/#Stat
[4]: https://golang.org/pkg/os/#Lstat
[5]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2017/opencontainers.2017-06-01-17.41.log.html#l-69