### PR TITLE
*: update link to v1.0.0

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -43,5 +43,5 @@ Then use it like:
 Or like:
 
 ```bash
-./validate https://raw.githubusercontent.com/opencontainers/runtime-spec/v1.0.0-rc1/schema/schema.json <yourpath>/config.json
+./validate https://raw.githubusercontent.com/opencontainers/runtime-spec/v1.0.0/schema/schema.json <yourpath>/config.json
 ```


### PR DESCRIPTION
Despite this not being a valid link, until this spec has its v1.0.0
release, this URL ought to be accurate for once the this spec is tagged
v1.0.0

Part of #726 

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>