### PR TITLE
defs-linux: add action to to syscalls required

### DIFF
--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -97,7 +97,8 @@
                 }
             },
             "required": [
-                "names"
+                "names",
+                "action"
             ]
         },
         "Major": {


### PR DESCRIPTION
According to https://github.com/opencontainers/runtime-spec/blame/master/config-linux.md#L544.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>