### PR TITLE
config-windows: fix the type of maximum

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -51,7 +51,7 @@ The following parameters can be specified:
 
 * **`count`** *(uint64, OPTIONAL)* - specifies the number of CPUs available to the container.
 * **`shares`** *(uint16, OPTIONAL)* - specifies the relative weight to other containers with CPU shares.
-* **`maximum`** *(uint, OPTIONAL)* - specifies the portion of processor cycles that this container can use as a percentage times 100.
+* **`maximum`** *(uint16, OPTIONAL)* - specifies the portion of processor cycles that this container can use as a percentage times 100.
 
 #### Example
 


### PR DESCRIPTION

https://github.com/opencontainers/runtime-spec/blame/master/specs-go/config.go#L459
https://github.com/opencontainers/runtime-spec/blame/master/schema/config-windows.json#L43

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>