### PR TITLE
[Runtime] Allow for excluding pid from state

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -23,6 +23,7 @@ The state of a container includes the following properties:
 
     Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`** (int, REQUIRED when `status` is `created` or `running`) is the ID of the container process, as seen by the host.
+    The pid MAY be excluded or set to a value indicating empty or null if it is not seen by the host. 
 * **`bundle`** (string, REQUIRED) is the absolute path to the container's bundle directory.
     This is provided so that consumers can find the container's configuration and root filesystem on the host.
 * **`annotations`** (map, OPTIONAL) contains the list of annotations associated with the container.


### PR DESCRIPTION
Re-base of #459; does not impact functionality but may be helpful for certification

Signed-off-by: Rob Dolin <robdolin@microsoft.com>