### PR TITLE
runtime: do not require pid while created

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -22,7 +22,7 @@ The state of a container includes the following properties:
     * `stopped`: the container process has exited (step 7 in the [lifecycle](#lifecycle))
 
     Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
-* **`pid`** (int, REQUIRED when `status` is `created` or `running`) is the ID of the container process, as seen by the host.
+* **`pid`** (int, REQUIRED when `status` is `created` or `running` under Linux, OPTIONAL on other platforms) is the ID of the container process, as seen by the host.
 * **`bundle`** (string, REQUIRED) is the absolute path to the container's bundle directory.
     This is provided so that consumers can find the container's configuration and root filesystem on the host.
 * **`annotations`** (map, OPTIONAL) contains the list of annotations associated with the container.

--- a/schema/state-schema.json
+++ b/schema/state-schema.json
@@ -40,7 +40,6 @@
         "ociVersion",
         "id",
         "status",
-        "pid",
         "bundle"
     ]
 }

--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -9,7 +9,7 @@ type State struct {
 	// Status is the runtime status of the container.
 	Status string `json:"status"`
 	// Pid is the process ID for the container process.
-	Pid int `json:"pid"`
+	Pid *int `json:"pid"`
 	// Bundle is the path to the container's bundle directory.
 	Bundle string `json:"bundle"`
 	// Annotations are key values associated with the container.


### PR DESCRIPTION
It seems odd to me that the `pid` is REQUIRED when the `status` is `created`, as at that time, the container process is not running. How would one know the `pid` for a process that is not yet running (or created, as the lifecycle only requires that `create` creates the namespace, and prohibits it from creating the process)?

If this is not the case, then the language for container process should be clarified.

Signed-off-by: Darren Stahl <darst@microsoft.com>