### PR TITLE
*: Add "Initiative" to OCI Runtime Specification and expand OCI

### DIFF
--- a/config.md
+++ b/config.md
@@ -14,8 +14,8 @@ For all platform-specific configuration values, the scope defined below in the [
 
 ## <a name="configSpecificationVersion" />Specification version
 
-* **`ociVersion`** (string, REQUIRED) MUST be in [SemVer v2.0.0][semver-v2.0.0] format and specifies the version of the Open Container Runtime Specification with which the bundle complies.
-    The Open Container Runtime Specification follows semantic versioning and retains forward and backward compatibility within major versions.
+* **`ociVersion`** (string, REQUIRED) MUST be in [SemVer v2.0.0][semver-v2.0.0] format and specifies the version of the Open Container Initiative Runtime Specification with which the bundle complies.
+    The Open Container Initiative Runtime Specification follows semantic versioning and retains forward and backward compatibility within major versions.
     For example, if a configuration is compliant with version 1.1 of this specification, it is compatible with all runtimes that support any 1.1 or later release of this specification, but is not compatible with a runtime that supports 1.0 and not 1.1.
 
 ### Example

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -1,5 +1,5 @@
 {
-    "description": "Open Container Runtime Specification Container Configuration Schema",
+    "description": "Open Container Initiative Runtime Specification Container Configuration Schema",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://opencontainers.org/schema/bundle",
     "type": "object",

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -1,5 +1,5 @@
 {
-    "description": "Definitions used throughout the Open Container Runtime Specification",
+    "description": "Definitions used throughout the Open Container Initiative Runtime Specification",
     "definitions": {
         "int8": {
             "type": "integer",
@@ -145,7 +145,7 @@
             ]
         },
         "ociVersion": {
-            "description": "The version of Open Container Runtime Specification that the document complies with",
+            "description": "The version of Open Container Initiative Runtime Specification that the document complies with",
             "type": "string"
         },
         "annotations": {

--- a/spec.md
+++ b/spec.md
@@ -4,7 +4,7 @@ The [Open Container Initiative][oci] develops specifications for standards on Op
 
 # <a name="ociRuntimeSpecAbstract" />Abstract
 
-The OCI Runtime Specification aims to specify the configuration, execution environment, and lifecycle of a container.
+The Open Container Initiative Runtime Specification aims to specify the configuration, execution environment, and lifecycle of a container.
 
 A container's configuration is specified as the `config.json` for the supported platforms and details the fields that enable the creation of a container.
 The execution environment is specified to ensure that applications running inside a container have a consistent environment between runtimes along with common actions defined for the container's lifecycle.

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -4,7 +4,7 @@ import "os"
 
 // Spec is the base configuration for the container.
 type Spec struct {
-	// Version of the Open Container Runtime Specification with which the bundle complies.
+	// Version of the Open Container Initiative Runtime Specification with which the bundle complies.
 	Version string `json:"ociVersion"`
 	// Process configures the container process.
 	Process *Process `json:"process,omitempty"`


### PR DESCRIPTION
Consistently reference ourselves.  Adding “Initiative” catches us up with #571, and expanding OCI is more consistent with the rest of the spec:

    $ git --no-pager grep --count 'Open Container Initiative Runtime Specification'
    README.md:1
    config.md:2
    schema/config-schema.json:1
    schema/defs.json:2
    spec.md:1
    specs-go/config.go:1
    $ git --no-pager grep --count 'OCI Runtime Specification'
    spec.md:1