### PR TITLE
config: Simplify title to "Configuration"

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,4 +1,4 @@
-# <a name="containerConfigurationFile" />Container Configuration file
+# <a name="configuration" />Configuration
 
 This configuration file contains metadata necessary to implement [standard operations](runtime.md#operations) against the container.
 This includes the process to run, environment variables to inject, sandboxing features to use, etc.


### PR DESCRIPTION
The capitalization in “Container Configuration file” (which we've used since #176) was halfway between “Title Case” and “Sentence case”.  The current spec isn't particularly consistent (e.g. we have both “Specification version” and “POSIX-platform Mounts”), but the ToC has used “Configuration” for this file since #626, so dodge the sentence/title issue and use that here too.