### PR TITLE
.pullapprove.yml: Switch to v2 and other project-template updates

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,12 +1,27 @@
-approve_by_comment: true
-approve_regex: ^LGTM
-reject_regex: ^Rejected
-reset_on_push: true
-author_approval: ignored
-signed_off_by:
-  required: true
-reviewers:
-  teams:
-  - runtime-spec-maintainers
-  name: default
+version: 2
+
+requirements:
+  signed_off_by:
+    required: true
+
+group_defaults:
   required: 2
+  approve_by_comment:
+    enabled: true
+    approve_regex: ^LGTM
+    reject_regex: ^Rejected
+  reset_on_push:
+    enabled: true
+  author_approval:
+    ignored: true
+  always_pending:
+    title_regex: ^WIP
+    explanation: 'Work in progress...'
+  conditions:
+    branches:
+      - master
+
+groups:
+  runtime-spec:
+    teams:
+      - runtime-spec-maintainers


### PR DESCRIPTION
Pull in changes from opencontainers/project-template#29.  The only changes vs. the upstream version is removing all the groups except for the `runtime-spec` group.