### PR TITLE
runtime: Clarify ociVersion as based on the state schema

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -9,7 +9,7 @@ Whether other entities using the same, or other, instance of the runtime can see
 
 The state of a container includes the following properties:
 
-* **`ociVersion`** (string, REQUIRED) is the OCI specification version used when creating the container.
+* **`ociVersion`** (string, REQUIRED) is version of the Open Container Initiative Runtime Specification with which the state complies.
 * **`id`** (string, REQUIRED) is the container's ID.
     This MUST be unique across all containers on this host.
     There is no requirement that it be unique across hosts.


### PR DESCRIPTION
The old wording was ambiguous.  For example, if the configuration had ociVersion set to 1.0.0 and the container was created with a 1.1.0 runtime, which version should show up in the state?

With this commit, we use the version which matches the state schema, because the config/runtime versions used for creation don't seem particularly important once the container has been created, while the state schema version is important for state consumers.  For example, if new properties were added to the state spec between 1.0.0 and 1.1.0, a consumer would want to see 1.1.0 in the state's ociVersion so it could decide whether it could rely on those new properties.