### PR TITLE
schema/config-linux: Check swappiness for zero to 100 range

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -188,7 +188,7 @@
                             },
                             "swappiness": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swappiness",
-                                "$ref": "defs.json#/definitions/uint64"
+                                "$ref": "defs.json#/definitions/percent"
                             },
                             "disableOOMKiller": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/disableOOMKiller",


### PR DESCRIPTION
Catch the JSON Schema up with #876, which carried the kernel's 0 to 100 range into the spec.  I'd [argued against carrying those limits locally][1], but as long as we have them in the normative Markdown spec we should be enforcing them in the JSON Schema.

As of v1.0.0, the Markdown line carrying the kernel's limits is [here][2].

[1]: https://github.com/opencontainers/runtime-spec/pull/876#discussion_r123856763
[2]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0/config-linux.md#L272