### PR TITLE
runtime: Change "process in the container" -> "container process"

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -123,7 +123,7 @@ This operation MUST generate an error if `process` was not set.
 
 This operation MUST [generate an error](#errors) if it is not provided the container ID.
 Attempting to send a signal to a container that is neither [`created` nor `running`](#state) MUST have no effect on the container and MUST [generate an error](#errors).
-This operation MUST send the specified signal to the process in the container.
+This operation MUST send the specified signal to the container process.
 
 ### <a name="runtimeDelete" />Delete
 `delete <container-id>`


### PR DESCRIPTION
The latter is much more common:

```
$ git --no-pager grep -ic "process in the container" origin/master -- *.md
origin/master:runtime.md:1
$ git --no-pager grep -ic "container process" origin/master -- *.md
origin/master:config-linux.md:4
origin/master:config.md:2
origin/master:glossary.md:1
origin/master:runtime.md:5
```

Spun off from [here][1].

This seems like a patch-level change to me, so folks may want to put it in the [v1.0.Z milestone][2].

[1]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-08-03.log.html#t2017-08-03T21:27:57
[2]: https://github.com/opencontainers/runtime-spec/milestone/16