### PR TITLE
README: Make meetings monthly (were weekly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,12 @@ It also guarantees that the design is sound before code is written; a GitHub pul
 Typos and grammatical errors can go straight to a pull-request.
 When in doubt, start on the [mailing-list](#mailing-list).
 
-### Weekly Call
+### Meetings
 
-The contributors and maintainers of all OCI projects have a weekly meeting on Wednesdays at:
-
-* 8:00 AM (USA Pacific), during [odd weeks][iso-week].
-* 2:00 PM (USA Pacific), during [even weeks][iso-week].
-
+The contributors and maintainers of all OCI projects have monthly meetings at 2:00 PM (USA Pacific) on the first Wednesday of every month.
 There is an [iCalendar][rfc5545] format for the meetings [here](meeting.ics).
-
 Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: +1 415 968 0849 (no PIN needed).
-An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+An initial agenda will be posted to the [mailing list](#mailing-list) in the week before each meeting, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
 Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes], with minutes from especially old meetings (September 2015 and earlier) archived [here][runtime-wiki].
 
 ### Mailing List

--- a/meeting.ics
+++ b/meeting.ics
@@ -20,30 +20,15 @@ TZNAME:PDT
 END:DAYLIGHT
 END:VTIMEZONE
 BEGIN:VEVENT
-UID:tdc-meeting-1@opencontainers.org
-DTSTAMP:20170405T220000Z
-DTSTART;TZID=America/Los_Angeles:20170329T080000
-RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
+UID:tdc-meeting@opencontainers.org
+DTSTAMP:20170821T200000Z
+DTSTART;TZID=America/Los_Angeles:20170906T140000
+RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=1WE
 DURATION:PT1H
 SUMMARY:OCI TDC Meeting
 DESCRIPTION;ALTREP="https://github.com/opencontainers/runtime-spec#
- weekly-call":Open Containers Initiative Developer Meeting\n
- https://github.com/opencontainers/runtime-spec#weekly-call\n
- Web: https://www.uberconference.com/opencontainers\n
- Audio-only: +1 415 968 0849 (no PIN needed)
-LOCATION:https://www.uberconference.com/opencontainers
-URL:https://github.com/opencontainers/runtime-spec/blob/master/meeting.ics
-END:VEVENT
-BEGIN:VEVENT
-UID:tdc-meeting-2@opencontainers.org
-DTSTAMP:20170517T143500Z
-DTSTART;TZID=America/Los_Angeles:20170517T140000
-RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
-DURATION:PT1H
-SUMMARY:OCI TDC Meeting
-DESCRIPTION;ALTREP="https://github.com/opencontainers/runtime-spec#
- weekly-call":Open Containers Initiative Developer Meeting\n
- https://github.com/opencontainers/runtime-spec#weekly-call\n
+ meetings":Open Containers Initiative Developer Meeting\n
+ https://github.com/opencontainers/runtime-spec#meetings\n
  Web: https://www.uberconference.com/opencontainers\n
  Audio-only: +1 415 968 0849 (no PIN needed)
 LOCATION:https://www.uberconference.com/opencontainers


### PR DESCRIPTION
On @caniszczyk's [recommendation][1], make the meetings 5pm Pacific on the first Wednesday of each month.

I've also removed the requirement for posting minutes to the mailing list.  We have a good track record of pushing MeetBot minutes to the same place, so I don't think we add any usefulness by mailing that link to the list.  I'm happy to split that off into a separate PR if there's any pushback on it.

[1]: https://groups.google.com/a/opencontainers.org/d/msg/dev/PC2DzxarMqA/SVF0KiY3AgAJ