### PR TITLE
config: Add a trailing period to the "cannot be mapped" rlimits line

### DIFF
--- a/config.md
+++ b/config.md
@@ -168,7 +168,7 @@ For systems that support POSIX rlimits (for example Linux and Solaris), the `pro
         * Linux: valid values are defined in the [`getrlimit(2)`][getrlimit.2] man page, such as `RLIMIT_MSGQUEUE`.
         * Solaris: valid values are defined in the [`getrlimit(3)`][getrlimit.3] man page, such as `RLIMIT_CORE`.
 
-        The runtime MUST [generate an error](runtime.md#errors) for any values which cannot be mapped to a relevant kernel interface
+        The runtime MUST [generate an error](runtime.md#errors) for any values which cannot be mapped to a relevant kernel interface.
         For each entry in `rlimits`, a [`getrlimit(3)`][getrlimit.3] on `type` MUST succeed.
         For the following properties, `rlim` refers to the status returned by the `getrlimit(3)` call.
 


### PR DESCRIPTION
Fixing a typo I'd made in 5292e9c8 (#880).

I think this is a patch-level change, so it can be tagged [v1.0.Z][1] (although we have had a few patch-level PRs merged without adding them to that milestone).

[1]: https://github.com/opencontainers/runtime-spec/milestone/16