### PR TITLE
config: Collapse extensibility to a single MUST

### DIFF
--- a/config.md
+++ b/config.md
@@ -441,7 +441,7 @@ Cleanup or debugging functions are examples of such a hook.
     Keys MUST NOT be an empty string.
     Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
     Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
-    Implementations that are reading/processing this configuration file MUST NOT generate an error if they encounter an unknown annotation key.
+    Runtimes MUST handle unknown annotation keys like any other [unknown property](#extensibility).
 
     Values MUST be strings.
     Values MAY be an empty string.
@@ -454,12 +454,12 @@ Cleanup or debugging functions are examples of such a hook.
 
 ## <a name="configExtensibility" />Extensibility
 
-Runtimes that are reading or processing this configuration file MUST NOT generate an error if they encounter an unknown property.
-Instead they MUST ignore unknown properties.
+Runtimes MAY [log](runtime.md#warnings) unknown properties but MUST otherwise ignore them.
+That includes not [generating errors](runtime.md#errors) if they encounter an unknown property.
 
 ## Valid values
 
-Runtimes that are reading or processing this configuration file MUST generate an error when invalid or unsupported values are encountered.
+Runtimes MUST generate an error when invalid or unsupported values are encountered.
 Unless support for a valid value is explicitly required, runtimes MAY choose which subset of the valid values it will support.
 
 ## Configuration Schema Example


### PR DESCRIPTION
Generating an error seems like one potential violation of the requirement to ignore unknown properties.  Compliance testing for the ignore requirement can cite the MUST I've written here for any noticeable runtime activity around the unknown property without needing a error-specific MUST.

We've had the two MUSTs since #510, citing opencontainers/image-spec#164.  [I'd][2] [asked][3] for consolidated phrasing then, but hadn't followed up after the commit landed.

I've left a line mentioning the error activity as non-normative clarification, but am also happy to drop that line completely.

Also:

* Update the unknown annotation entry to reference the generic extensibility section, because there's nothing annotation-specific in how we want runtimes to handle unknown keys.

* Remove “reading or processing” language.  This initially landed in #510 with a bump in #811.  [Some][4] [thought][5] was put into this phrasing there and [earlier][6] in #510, but we never got around to dropping this qualifier.  However, the purpose of this qualifier is unclear to me.  What is the point of compliance requirements for runtimes which don't read or process a configuration?

[2]: https://github.com/opencontainers/runtime-spec/pull/510#r69845853
[3]: https://github.com/opencontainers/runtime-spec/pull/510#r69846114
[4]: https://github.com/opencontainers/runtime-spec/pull/811#discussion_r116294608
[5]: https://github.com/opencontainers/runtime-spec/pull/811#discussion_r116465503
[6]: https://github.com/opencontainers/runtime-spec/pull/510#r69846021