### PR TITLE
schema: add devicecgroup type pattern

### DIFF
--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -209,7 +209,8 @@
                     "type": "boolean"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^[abc]$"
                 },
                 "major": {
                     "$ref": "#/definitions/Major"


### PR DESCRIPTION
There is type limitation for deviceCgroup, I still think we should add such check in schema

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>