### PR TITLE
config-linux: RFC 2119 MUST for absolute linux.namespaces[].path

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -35,7 +35,8 @@ The following parameters can be specified to set up namespaces:
     * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container.
     * **`cgroup`** the container will have an isolated view of the cgroup hierarchy.
 
-* **`path`** *(string, OPTIONAL)* - an absolute path to namespace file in the [runtime mount namespace](glossary.md#runtime-namespace).
+* **`path`** *(string, OPTIONAL)* - namespace file.
+    This value MUST be an absolute path in the [runtime mount namespace](glossary.md#runtime-namespace).
     The runtime MUST place the container process in the namespace associated with that `path`.
     The runtime MUST [generate an error](runtime.md#errors) if `path` is not associated with a namespace of type `type`.
 


### PR DESCRIPTION
The old language is from 72cbff67 (#720), but without RFC 2119 language in the absolute path wording, it's not a compliance requirement (per [`spec.md`'s “compliant” definition][1]).  This commit adjusts the language to bring it in line with our current wording for [`maskedPaths`][2] and [`readonlyPaths`][3], which we've had since 25f44dd0 (#587).

This is technically a breaking change, because a config with a relative namespace path would have been compliant before, but will be non compliant with this PR.  However, I think the previous “an absolute path to namespace file” wording is clear enough that config authors are unlikely to be relying on relative namespace paths in configs.  If we are comfortable enough with that assumption (I am, but I'm not a maintainer), we can push this out as a patch-level change without fear of breaking config authors.  If we aren't comfortable with that assumption, we'll want to queue this change up for 2.0.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0/spec.md#L40-L41
[2]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0/config-linux.md#L597
[3]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0/config-linux.md#L610