### PR TITLE
config: Drop "subset of the valid values" line

### DIFF
--- a/config.md
+++ b/config.md
@@ -460,7 +460,6 @@ Instead they MUST ignore unknown properties.
 ## Valid values
 
 Runtimes that are reading or processing this configuration file MUST generate an error when invalid or unsupported values are encountered.
-Unless support for a valid value is explicitly required, runtimes MAY choose which subset of the valid values it will support.
 
 ## Configuration Schema Example
 


### PR DESCRIPTION
In #673 we got:

> Implementations MUST error out when invalid values are encountered and MUST generate an error message and error out when encountering valid values it chooses to not support.

In #681, I'd moved that out into the current “Valid values” section with the line I'm removing in this commit.  However, giving runtimes a blanket clause to ignore valid values makes it harder to use runtimes, because you can't be sure an OCI-compliant runtime supports the spec-defined value you need (#813).

There have been concerns about [requiring runtimes to support values which are not supported by the host system][2].  But since #559 we've had `runtime.md` wording that gives the runtime the ability to compliantly die in those cases.  That text had a wording tweak in #700, and is now:

> [If the runtime cannot apply a property as specified in the configuration, it MUST generate an error and a new container MUST NOT be created.][3]

~~With this commit, consumers will be able to rely on valid-value support in compliant runtimes.~~ (edit: this commit is not enough for this, see [here][4]) Many properties could use clearer runtimes-MUST-support wording for those values, but we can sort those out on a per-property basis in follow-up work.

And runtimes are still allowed to support extention values not defined in the spec (e.g. new capability types, or mount options, or whatever).  Like all extentions, it is up to the runtime and runtime-caller to negotiate support in those cases.

[1]: https://github.com/opencontainers/runtime-spec/issues/813#issue-228291125
[2]: https://github.com/opencontainers/runtime-spec/pull/673#discussion_r99696863
[3]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0/runtime.md#L106
[4]: https://github.com/opencontainers/runtime-spec/pull/927#issuecomment-334300252