### PR TITLE
config: Dedent root paragraphs, since they aren't a list entry

### DIFF
--- a/config.md
+++ b/config.md
@@ -27,10 +27,10 @@ For all platform-specific configuration values, the scope defined below in the [
 ## <a name="configRoot" />Root
 
 **`root`** (object, OPTIONAL) specifies the container's root filesystem.
-    On Windows, for Windows Server Containers, this field is REQUIRED.
-    For [Hyper-V Containers](config-windows.md#hyperv), this field MUST NOT be set.
+On Windows, for Windows Server Containers, this field is REQUIRED.
+For [Hyper-V Containers](config-windows.md#hyperv), this field MUST NOT be set.
 
-    On all other platforms, this field is REQUIRED.
+On all other platforms, this field is REQUIRED.
 
 * **`path`** (string, REQUIRED) Specifies the path to the root filesystem for the container.
 


### PR DESCRIPTION
I'd broken this in 2022e3ec (#838), where I'd misread the initial bolding `**` as a list bullet or something :/.  The extra indents don't cause a problem for the first paragraph, but they [cause the “On all other platforms…” paragraph to be interpreted as a `<pre>` block][1].

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#root