### PR TITLE
config*: Dedent paragraphs that aren't a list entry

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -458,10 +458,10 @@ The following parameters can be specified to set up the controller:
 ## <a name="configLinuxIntelRdt" />IntelRdt
 
 **`intelRdt`** (object, OPTIONAL) represents the [Intel Resource Director Technology][intel-rdt-cat-kernel-interface].
-    If `intelRdt` is set, the runtime MUST write the container process ID to the `<container-id>/tasks` file in a mounted `resctrl` pseudo-filesystem, using the container ID from [`start`](runtime.md#start) and creating the `<container-id>` directory if necessary.
-    If no mounted `resctrl` pseudo-filesystem is available in the [runtime mount namespace](glossary.md#runtime-namespace), the runtime MUST [generate an error](runtime.md#errors).
+If `intelRdt` is set, the runtime MUST write the container process ID to the `<container-id>/tasks` file in a mounted `resctrl` pseudo-filesystem, using the container ID from [`start`](runtime.md#start) and creating the `<container-id>` directory if necessary.
+If no mounted `resctrl` pseudo-filesystem is available in the [runtime mount namespace](glossary.md#runtime-namespace), the runtime MUST [generate an error](runtime.md#errors).
 
-    If `intelRdt` is not set, the runtime MUST NOT manipulate any `resctrl` pseudo-filesystems.
+If `intelRdt` is not set, the runtime MUST NOT manipulate any `resctrl` pseudo-filesystems.
 
 The following parameters can be specified for the container:
 
@@ -592,8 +592,8 @@ The following parameters can be specified to set up seccomp:
 ## <a name="configLinuxRootfsMountPropagation" />Rootfs Mount Propagation
 
 **`rootfsPropagation`** (string, OPTIONAL) sets the rootfs's mount propagation.
-    Its value is either slave, private, shared or unbindable.
-    The [Shared Subtrees][sharedsubtree] article in the kernel documentation has more information about mount propagation.
+Its value is either slave, private, shared or unbindable.
+The [Shared Subtrees][sharedsubtree] article in the kernel documentation has more information about mount propagation.
 
 ### Example
 
@@ -604,7 +604,7 @@ The following parameters can be specified to set up seccomp:
 ## <a name="configLinuxMaskedPaths" />Masked Paths
 
 **`maskedPaths`** (array of strings, OPTIONAL) will mask over the provided paths inside the container so that they cannot be read.
-    The values MUST be absolute paths in the [container namespace](glossary.md#container_namespace).
+The values MUST be absolute paths in the [container namespace](glossary.md#container_namespace).
 
 ### Example
 
@@ -617,7 +617,7 @@ The following parameters can be specified to set up seccomp:
 ## <a name="configLinuxReadonlyPaths" />Readonly Paths
 
 **`readonlyPaths`** (array of strings, OPTIONAL) will set the provided paths as readonly inside the container.
-    The values MUST be absolute paths in the [container namespace](glossary.md#container-namespace).
+The values MUST be absolute paths in the [container namespace](glossary.md#container-namespace).
 
 ### Example
 

--- a/config.md
+++ b/config.md
@@ -65,9 +65,9 @@ On all other platforms, this field is REQUIRED.
 ## <a name="configMounts" />Mounts
 
 **`mounts`** (array of objects, OPTIONAL) specifies additional mounts beyond [`root`](#root).
-    The runtime MUST mount entries in the listed order.
-    For Linux, the parameters are as documented in [mount(2)][mount.2] system call man page.
-    For Solaris, the mount entry corresponds to the 'fs' resource in the [zonecfg(1M)][zonecfg.1m] man page.
+The runtime MUST mount entries in the listed order.
+For Linux, the parameters are as documented in [mount(2)][mount.2] system call man page.
+For Solaris, the mount entry corresponds to the 'fs' resource in the [zonecfg(1M)][zonecfg.1m] man page.
 
 * **`destination`** (string, REQUIRED) Destination of mount point: path inside container.
     This value MUST be an absolute path.
@@ -143,7 +143,7 @@ For POSIX platforms the `mounts` structure has the following fields:
 ## <a name="configProcess" />Process
 
 **`process`** (object, OPTIONAL) specifies the container process.
-    This property is REQUIRED when [`start`](runtime.md#start) is called.
+This property is REQUIRED when [`start`](runtime.md#start) is called.
 
 * **`terminal`** (bool, OPTIONAL) specifies whether a terminal is attached to the process, defaults to false.
     As an example, if set to true on Linux a pseudoterminal pair is allocated for the process and the pseudoterminal slave is duplicated on the process's [standard streams][stdin.3].
@@ -433,18 +433,18 @@ Cleanup or debugging functions are examples of such a hook.
 ## <a name="configAnnotations" />Annotations
 
 **`annotations`** (object, OPTIONAL) contains arbitrary metadata for the container.
-    This information MAY be structured or unstructured.
-    Annotations MUST be a key-value map.
-    If there are no annotations then this property MAY either be absent or an empty map.
+This information MAY be structured or unstructured.
+Annotations MUST be a key-value map.
+If there are no annotations then this property MAY either be absent or an empty map.
 
-    Keys MUST be strings.
-    Keys MUST NOT be an empty string.
-    Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
-    Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
-    Implementations that are reading/processing this configuration file MUST NOT generate an error if they encounter an unknown annotation key.
+Keys MUST be strings.
+Keys MUST NOT be an empty string.
+Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
+Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
+Implementations that are reading/processing this configuration file MUST NOT generate an error if they encounter an unknown annotation key.
 
-    Values MUST be strings.
-    Values MAY be an empty string.
+Values MUST be strings.
+Values MAY be an empty string.
 
 ```json
 "annotations": {


### PR DESCRIPTION
Like #936.  @Mashimiao pointed out that [there may be more instances of this][1], and this commit fixes all instances turned up with:

```console
$ git grep -B1 '^    [^ ]' | grep -A1 '[:-]\*\*'
```

[1]: https://github.com/opencontainers/runtime-spec/pull/934#discussion_r154246493