### PR TITLE
config: add "umask" field to POSIX "user" section

### DIFF
--- a/config.md
+++ b/config.md
@@ -217,6 +217,7 @@ For POSIX platforms the `user` structure has the following fields:
 
 * **`uid`** (int, REQUIRED) specifies the user ID in the [container namespace](glossary.md#container-namespace).
 * **`gid`** (int, REQUIRED) specifies the group ID in the [container namespace](glossary.md#container-namespace).
+* **`umask`** (int, OPTIONAL) specifies the [umask][umask_2] of the user. If unspecified, the umask should not be changed from the calling process' umask.
 * **`additionalGids`** (array of ints, OPTIONAL) specifies additional group IDs in the [container namespace](glossary.md#container-namespace) to be added to the process.
 
 _Note: symbolic name for uid and gid, such as uname and gname respectively, are left to upper levels to derive (i.e. `/etc/passwd` parsing, NSS, etc)_
@@ -233,6 +234,7 @@ _Note: symbolic name for uid and gid, such as uname and gname respectively, are 
     "user": {
         "uid": 1,
         "gid": 1,
+        "umask": 63,
         "additionalGids": [5, 6]
     },
     "env": [
@@ -291,6 +293,7 @@ _Note: symbolic name for uid and gid, such as uname and gname respectively, are 
     "user": {
         "uid": 1,
         "gid": 1,
+        "umask": 7,
         "additionalGids": [2, 8]
     },
     "env": [
@@ -843,6 +846,7 @@ Here is a full example `config.json` for reference.
 [selinux]:http://selinuxproject.org/page/Main_Page
 [no-new-privs]: https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt
 [proc_2]: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+[umask.2]: http://pubs.opengroup.org/onlinepubs/009695399/functions/umask.html
 [semver-v2.0.0]: http://semver.org/spec/v2.0.0.html
 [ieee-1003.1-2008-xbd-c8.1]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_01
 [ieee-1003.1-2008-functions-exec]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -109,6 +109,10 @@
                             "id": "https://opencontainers.org/schema/bundle/process/user/gid",
                             "$ref": "defs.json#/definitions/GID"
                         },
+                        "umask": {
+                            "id": "https://opencontainers.org/schema/bundle/process/user/umask",
+                            "$ref": "defs.json#/definitions/Umask"
+                        },
                         "additionalGids": {
                             "id": "https://opencontainers.org/schema/bundle/process/user/additionalGids",
                             "$ref": "defs.json#/definitions/ArrayOfGIDs"

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -60,6 +60,9 @@
         "GID": {
             "$ref": "#/definitions/uint32"
         },
+		"Umask": {
+            "$ref": "#/definitions/uint32"
+		},
         "ArrayOfGIDs": {
             "type": "array",
             "items": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -85,6 +85,8 @@ type User struct {
 	UID uint32 `json:"uid" platform:"linux,solaris"`
 	// GID is the group id.
 	GID uint32 `json:"gid" platform:"linux,solaris"`
+	// Umask is the umask for the init process.
+	Umask uint32 `json:"umask,omitempty" platform:"linux,solaris"`
 	// AdditionalGids are additional group ids set for the container's process.
 	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
 	// Username is the user name.


### PR DESCRIPTION
Users may want to specify the umask(2) of the init process in a
container. This value is identical in semantics to POSIX. This is in
order to allow usage of an OCI container for a service which normally
only inherits the umask given to it.

See-also: https://github.com/opencontainers/runc/issues/1650
Requested-by: @leberknecht
Signed-off-by: Aleksa Sarai <asarai@suse.de>