### PR TITLE
schema: Completely drop our JSON Schema 'id' properties

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -1,32 +1,27 @@
 {
     "linux": {
         "description": "Linux platform-specific configurations",
-        "id": "https://opencontainers.org/schema/bundle/linux",
         "type": "object",
         "properties": {
             "devices": {
-                "id": "https://opencontainers.org/schema/bundle/linux/devices",
                 "type": "array",
                 "items": {
                     "$ref": "defs-linux.json#/definitions/Device"
                 }
             },
             "uidMappings": {
-                "id": "https://opencontainers.org/schema/bundle/linux/uidMappings",
                 "type": "array",
                 "items": {
                     "$ref": "defs.json#/definitions/IDMapping"
                 }
             },
             "gidMappings": {
-                "id": "https://opencontainers.org/schema/bundle/linux/gidMappings",
                 "type": "array",
                 "items": {
                     "$ref": "defs.json#/definitions/IDMapping"
                 }
             },
             "namespaces": {
-                "id": "https://opencontainers.org/schema/bundle/linux/namespaces",
                 "type": "array",
                 "items": {
                     "anyOf": [
@@ -37,22 +32,18 @@
                 }
             },
             "resources": {
-                "id": "https://opencontainers.org/schema/bundle/linux/resources",
                 "type": "object",
                 "properties": {
                     "devices": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/devices",
                         "type": "array",
                         "items": {
                             "$ref": "defs-linux.json#/definitions/DeviceCgroup"
                         }
                     },
                     "pids": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/pids",
                         "type": "object",
                         "properties": {
                             "limit": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/pids/limit",
                                 "$ref": "defs.json#/definitions/int64"
                             }
                         },
@@ -61,47 +52,39 @@
                         ]
                     },
                     "blockIO": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO",
                         "type": "object",
                         "properties": {
                             "weight": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/weight",
                                 "$ref": "defs-linux.json#/definitions/weight"
                             },
                             "leafWeight": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/leafWeight",
                                 "$ref": "defs-linux.json#/definitions/weight"
                             },
                             "throttleReadBpsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/throttleReadBpsDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceThrottle"
                                 }
                             },
                             "throttleWriteBpsDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/throttleWriteBpsDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceThrottle"
                                 }
                             },
                             "throttleReadIOPSDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/throttleReadIOPSDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceThrottle"
                                 }
                             },
                             "throttleWriteIOPSDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/throttleWriteIOPSDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceThrottle"
                                 }
                             },
                             "weightDevice": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/blockIO/weightDevice",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/blockIODeviceWeight"
@@ -110,41 +93,32 @@
                         }
                     },
                     "cpu": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu",
                         "type": "object",
                         "properties": {
                             "cpus": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/cpus",
                                 "type": "string"
                             },
                             "mems": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/mems",
                                 "type": "string"
                             },
                             "period": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/period",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "quota": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/quota",
                                 "$ref": "defs.json#/definitions/int64"
                             },
                             "realtimePeriod": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimePeriod",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "realtimeRuntime": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/realtimeRuntime",
                                 "$ref": "defs.json#/definitions/int64"
                             },
                             "shares": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/cpu/shares",
                                 "$ref": "defs.json#/definitions/uint64"
                             }
                         }
                     },
                     "hugepageLimits": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/hugepageLimits",
                         "type": "array",
                         "items": {
                             "type": "object",
@@ -163,49 +137,38 @@
                         }
                     },
                     "memory": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/memory",
                         "type": "object",
                         "properties": {
                             "kernel": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/kernel",
                                 "$ref": "defs.json#/definitions/int64"
                             },
                             "kernelTCP": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/kernelTCP",
                                 "$ref": "defs.json#/definitions/int64"
                             },
                             "limit": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/limit",
                                 "$ref": "defs.json#/definitions/int64"
                             },
                             "reservation": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/reservation",
                                 "$ref": "defs.json#/definitions/int64"
                             },
                             "swap": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swap",
                                 "$ref": "defs.json#/definitions/int64"
                             },
                             "swappiness": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swappiness",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "disableOOMKiller": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/disableOOMKiller",
                                 "type": "boolean"
                             }
                         }
                     },
                     "network": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/resources/network",
                         "type": "object",
                         "properties": {
                             "classID": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/network/classId",
                                 "$ref": "defs.json#/definitions/uint32"
                             },
                             "priorities": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/resources/network/priorities",
                                 "type": "array",
                                 "items": {
                                     "$ref": "defs-linux.json#/definitions/NetworkInterfacePriority"
@@ -216,30 +179,24 @@
                 }
             },
             "cgroupsPath": {
-                "id": "https://opencontainers.org/schema/bundle/linux/cgroupsPath",
                 "type": "string"
             },
             "rootfsPropagation": {
-                "id": "https://opencontainers.org/schema/bundle/linux/rootfsPropagation",
                 "$ref": "defs-linux.json#/definitions/RootfsPropagation"
             },
             "seccomp": {
-                "id": "https://opencontainers.org/schema/bundle/linux/seccomp",
                 "type": "object",
                 "properties": {
                     "defaultAction": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/seccomp/defaultAction",
                         "$ref": "defs-linux.json#/definitions/SeccompAction"
                     },
                     "architectures": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/seccomp/architectures",
                         "type": "array",
                         "items": {
                             "$ref": "defs-linux.json#/definitions/SeccompArch"
                         }
                     },
                     "syscalls": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/seccomp/syscalls",
                         "type": "array",
                         "items": {
                             "$ref": "defs-linux.json#/definitions/Syscall"
@@ -251,27 +208,21 @@
                 ]
             },
             "sysctl": {
-                "id": "https://opencontainers.org/schema/bundle/linux/sysctl",
                 "$ref": "defs.json#/definitions/mapStringString"
             },
             "maskedPaths": {
-                "id": "https://opencontainers.org/schema/bundle/linux/maskedPaths",
                 "$ref": "defs.json#/definitions/ArrayOfStrings"
             },
             "readonlyPaths": {
-                "id": "https://opencontainers.org/schema/bundle/linux/readonlyPaths",
                 "$ref": "defs.json#/definitions/ArrayOfStrings"
             },
             "mountLabel": {
-                "id": "https://opencontainers.org/schema/bundle/linux/mountLabel",
                 "type": "string"
             },
             "intelRdt": {
-                "id": "https://opencontainers.org/schema/bundle/linux/intelRdt",
                 "type": "object",
                 "properties": {
                     "l3CacheSchema": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/intelRdt/l3CacheSchema",
                         "type": "string"
                     }
                 }

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -1,15 +1,12 @@
 {
     "description": "Open Container Initiative Runtime Specification Container Configuration Schema",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://opencontainers.org/schema/bundle",
     "type": "object",
     "properties": {
         "ociVersion": {
-            "id": "https://opencontainers.org/schema/bundle/ociVersion",
             "$ref": "defs.json#/definitions/ociVersion"
         },
         "hooks": {
-            "id": "https://opencontainers.org/schema/bundle/hooks",
             "type": "object",
             "properties": {
                 "prestart": {
@@ -27,11 +24,9 @@
             "$ref": "defs.json#/definitions/annotations"
         },
         "hostname": {
-            "id": "https://opencontainers.org/schema/bundle/hostname",
             "type": "string"
         },
         "mounts": {
-            "id": "https://opencontainers.org/schema/bundle/mounts",
             "type": "array",
             "items": {
                 "$ref": "defs.json#/definitions/Mount"
@@ -39,24 +34,20 @@
         },
         "root": {
             "description": "Configures the container's root filesystem.",
-            "id": "https://opencontainers.org/schema/bundle/root",
             "type": "object",
             "required": [
                 "path"
             ],
             "properties": {
                 "path": {
-                    "id": "https://opencontainers.org/schema/bundle/root/path",
                     "$ref": "defs.json#/definitions/FilePath"
                 },
                 "readonly": {
-                    "id": "https://opencontainers.org/schema/bundle/root/readonly",
                     "type": "boolean"
                 }
             }
         },
         "process": {
-            "id": "https://opencontainers.org/schema/bundle/process",
             "type": "object",
             "required": [
                 "cwd",
@@ -64,11 +55,9 @@
             ],
             "properties": {
                 "args": {
-                    "id": "https://opencontainers.org/schema/bundle/process/args",
                     "$ref": "defs.json#/definitions/ArrayOfStrings"
                 },
                 "consoleSize": {
-                    "id": "https://opencontainers.org/schema/bundle/process/consoleSize",
                     "type": "object",
                     "required": [
                         "height",
@@ -76,96 +65,74 @@
                     ],
                     "properties": {
                         "height": {
-                            "id": "https://opencontainers.org/schema/bundle/process/consoleSize/height",
                             "$ref": "defs.json#/definitions/uint64"
                         },
                         "width": {
-                            "id": "https://opencontainers.org/schema/bundle/process/consoleSize/width",
                             "$ref": "defs.json#/definitions/uint64"
                         }
                     }
                 },
                 "cwd": {
-                    "id": "https://opencontainers.org/schema/bundle/process/cwd",
                     "type": "string"
                 },
                 "env": {
-                    "id": "https://opencontainers.org/schema/bundle/process/env",
                     "$ref": "defs.json#/definitions/Env"
                 },
                 "terminal": {
-                    "id": "https://opencontainers.org/schema/bundle/process/terminal",
                     "type": "boolean"
                 },
                 "user": {
-                    "id": "https://opencontainers.org/schema/bundle/process/user",
                     "type": "object",
                     "properties": {
                         "uid": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/uid",
                             "$ref": "defs.json#/definitions/UID"
                         },
                         "gid": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/gid",
                             "$ref": "defs.json#/definitions/GID"
                         },
                         "additionalGids": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/additionalGids",
                             "$ref": "defs.json#/definitions/ArrayOfGIDs"
                         },
                         "username": {
-                            "id": "https://opencontainers.org/schema/bundle/process/user/username",
                             "type": "string"
                         }
                     }
                 },
                 "capabilities": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities",
                     "type": "object",
                     "properties": {
                         "bounding": {
-                            "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/bounding",
                             "$ref": "defs.json#/definitions/ArrayOfStrings"
                         },
                         "permitted": {
-                            "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/permitted",
                             "$ref": "defs.json#/definitions/ArrayOfStrings"
                         },
                         "effective": {
-                            "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/effective",
                             "$ref": "defs.json#/definitions/ArrayOfStrings"
                         },
                         "inheritable": {
-                            "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/inheritable",
                             "$ref": "defs.json#/definitions/ArrayOfStrings"
                         },
                         "ambient": {
-                            "id": "https://opencontainers.org/schema/bundle/process/linux/capabilities/ambient",
                             "$ref": "defs.json#/definitions/ArrayOfStrings"
                         }
                     }
                 },
                 "apparmorProfile": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/apparmorProfile",
                     "type": "string"
                 },
                 "oomScoreAdj": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/oomScoreAdj",
                     "type": "integer"
                 },
                 "selinuxLabel": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/selinuxLabel",
                     "type": "string"
                 },
                 "noNewPrivileges": {
-                    "id": "https://opencontainers.org/schema/bundle/process/linux/noNewPrivileges",
                     "type": "boolean"
                 },
                 "rlimits": {
-                    "id": "https://opencontainers.org/schema/bundle/linux/rlimits",
                     "type": "array",
                     "items": {
-                        "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0",
                         "type": "object",
                         "required": [
                             "type",
@@ -174,15 +141,12 @@
                         ],
                         "properties": {
                             "hard": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/hard",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "soft": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/soft",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "type": {
-                                "id": "https://opencontainers.org/schema/bundle/linux/rlimits/0/type",
                                 "type": "string",
                                 "pattern": "^RLIMIT_[A-Z]+$"
                             }

--- a/schema/config-solaris.json
+++ b/schema/config-solaris.json
@@ -1,47 +1,37 @@
 {
     "solaris": {
         "description": "Solaris platform-specific configurations",
-        "id": "https://opencontainers.org/schema/bundle/solaris",
         "type": "object",
         "properties": {
             "milestone": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/milestone",
                 "type": "string"
             },
             "limitpriv": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/limitpriv",
                 "type": "string"
             },
             "maxShmMemory": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/maxShmMemory",
                 "type": "string"
             },
             "cappedCPU": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/cappedCPU",
                 "type": "object",
                 "properties": {
                     "ncpus": {
-                        "id": "https://opencontainers.org/schema/bundle/solaris/cappedCPU/ncpus",
                         "type": "string"
                     }
                 }
             },
             "cappedMemory": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/cappedMemory",
                 "type": "object",
                 "properties": {
                     "physical": {
-                        "id": "https://opencontainers.org/schema/bundle/solaris/cappedMemory/physical",
                         "type": "string"
                     },
                     "swap": {
-                        "id": "https://opencontainers.org/schema/bundle/solaris/cappedMemory/swap",
                         "type": "string"
                     }
                 }
             },
             "anet": {
-                "id": "https://opencontainers.org/schema/bundle/solaris/anet",
                 "type": "array",
                 "items": {
                     "type": "object",

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -1,11 +1,9 @@
 {
     "windows": {
         "description": "Windows platform-specific configurations",
-        "id": "https://opencontainers.org/schema/bundle/windows",
         "type": "object",
         "properties": {
             "layerFolders": {
-                "id": "https://opencontainers.org/schema/bundle/windows/layerFolders",
                 "type": "array",
                 "items": {
                     "$ref": "defs.json#/definitions/FilePath"
@@ -13,51 +11,40 @@
                 "minItems": 1
             },
             "resources": {
-                "id": "https://opencontainers.org/schema/bundle/windows/resources",
                 "type": "object",
                 "properties": {
                     "memory": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/resources/memory",
                         "type": "object",
                         "properties": {
                             "limit": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/memory/limit",
                                 "$ref": "defs.json#/definitions/uint64"
                             }
                         }
                     },
                     "cpu": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu",
                         "type": "object",
                         "properties": {
                             "count": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/count",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "shares": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/shares",
                                 "$ref": "defs.json#/definitions/uint16"
                             },
                             "maximum": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/cpu/maximum",
                                 "$ref": "defs.json#/definitions/uint16"
                             }
                         }
                     },
                     "storage": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/resources/storage",
                         "type": "object",
                         "properties": {
                             "iops": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/iops",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "bps": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/bps",
                                 "$ref": "defs.json#/definitions/uint64"
                             },
                             "sandboxSize": {
-                                "id": "https://opencontainers.org/schema/bundle/windows/resources/storage/sandboxSize",
                                 "$ref": "defs.json#/definitions/uint64"
                             }
                         }
@@ -65,45 +52,35 @@
                 }
             },
             "network": {
-                "id": "https://opencontainers.org/schema/bundle/windows/network",
                 "type": "object",
                 "properties": {
                     "endpointList": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/network/endpointList",
                         "$ref": "defs.json#/definitions/ArrayOfStrings"
                     },
                     "allowUnqualifiedDNSQuery": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/network/allowUnqualifiedDNSQuery",
                         "type": "boolean"
                     },
                     "DNSSearchList": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/network/DNSSearchList",
                         "$ref": "defs.json#/definitions/ArrayOfStrings"
                     },
                     "networkSharedContainerName": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/network/networkSharedContainerName",
                         "type": "string"
                     }
                 }
             },
             "credentialSpec": {
-                "id": "https://opencontainers.org/schema/bundle/windows/credentialSpec",
                 "type": "object"
             },
             "servicing": {
-                "id": "https://opencontainers.org/schema/bundle/windows/servicing",
                 "type": "boolean"
             },
             "ignoreFlushesDuringBoot": {
-                "id": "https://opencontainers.org/schema/bundle/windows/ignoreFlushesDuringBoot",
                 "type": "boolean"
             },
             "hyperv": {
-                "id": "https://opencontainers.org/schema/bundle/windows/hyperv",
                 "type": "object",
                 "properties": {
                     "utilityVMPath": {
-                        "id": "https://opencontainers.org/schema/bundle/windows/hyperv/utilityVMPath",
                         "type": "string"
                     }
                 }

--- a/schema/state-schema.json
+++ b/schema/state-schema.json
@@ -1,20 +1,16 @@
 {
     "description": "Open Container Runtime State Schema",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://opencontainers.org/schema/state",
     "type": "object",
     "properties": {
         "ociVersion": {
-            "id": "https://opencontainers.org/schema/runtime/state/ociVersion",
             "$ref": "defs.json#/definitions/ociVersion"
         },
         "id": {
-            "id": "https://opencontainers.org/schema/runtime/state/id",
             "description": "the container's ID",
             "type": "string"
         },
         "status": {
-            "id": "https://opencontainers.org/schema/runtime/state/status",
             "type": "string",
             "enum": [
                 "creating",
@@ -24,12 +20,10 @@
             ]
         },
         "pid": {
-            "id": "https://opencontainers.org/schema/runtime/state/pid",
             "type": "integer",
             "minimum": 0
         },
         "bundle": {
-            "id": "https://opencontainers.org/schema/runtime/state/bundle",
             "type": "string"
         },
         "annotations": {


### PR DESCRIPTION
We're using [JSON Schema draft-04][1], as [declared][1.5] by our [`$schema` properties][2].  In draft-04, the `id` keyword alters the resolution scope.  But our current `$ref` values use [JSON Pointers][4] with relative references like `defs-linux.json#/definitions/Device` that ignore the `id`s.

By draft-07, `id` has become `$id`, and [the docs say][5]:

> The root schema of a JSON Schema document SHOULD contain an "$id" keyword with a URI (containing a scheme).

But since xeipuuv/gojsonschema@83a7f6369d5, including any URI that cannot be retrieved generates an error:

```console
$ ./validate config-schema.json test/config/good/minimal.json
Could not read schema from HTTP, response status is 404 Not Found
```

While a root `id` entry would be nice, we don't currently host these anywhere with a useful URI.  We could use GitHub links like [this][7], but then testing pull requests would be difficult.

By draft-07, the purpose of internal `$id` entries is clearly [explained][5]:

> Providing a plain name fragment enables a subschema to be relocated within a schema without requiring that JSON Pointer references are updated.

We don't need that, because we control all the references.  In the infrequent event of a subschema move, we can update the consuming references in the same commit.

The draft-07 `$ref` docs also explain that `$ref` targets [may be URNs][8]:

> The URI is not a network locator, only an identifier.  A schema need not be downloadable from the address if it is a network-addressable URL, and implementations SHOULD NOT assume they should perform a network operation when they encounter a network-addressable URI.

I haven't found analogous wording for `$id`, but it's possible that gojsonschema is being overly agressive with its attempted retrievals.

This commit removes all of our `id` entries.  The resulting JSON Schema is valid (regardless of where you host it) and does not generate the 404s.

If/when we merge/release this it should address opencontainers/runc#1680.

[1]: https://tools.ietf.org/html/draft-zyp-json-schema-04#section-7.2
[1.5]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/schema/config-schema.json#L3
[2]: https://tools.ietf.org/html/draft-zyp-json-schema-04#section-6
[3]: https://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07
[4]: https://tools.ietf.org/html/rfc6901
[5]: https://tools.ietf.org/html/draft-handrews-json-schema-00#section-9.2
[6]: https://github.com/xeipuuv/gojsonschema/commit/83a7f6369d552cba07cdeea7dc622f1161a07deb
[7]: https://raw.githubusercontent.com/opencontainers/runtime-spec/v1.0.1/schema/config-schema.json
[8]: https://tools.ietf.org/html/draft-handrews-json-schema-00#section-8