### PR TITLE
runtime: Document state annotations as a copy of config annotations

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -26,7 +26,8 @@ The state of a container includes the following properties:
 * **`bundle`** (string, REQUIRED) is the absolute path to the container's bundle directory.
     This is provided so that consumers can find the container's configuration and root filesystem on the host.
 * **`annotations`** (map, OPTIONAL) contains the list of annotations associated with the container.
-    If no annotations were provided then this property MAY either be absent or an empty map.
+    If the configuration set [`annotations`](config.md#annotations), this value MUST exactly match the configured `annotations`.
+    If no annotations were configured then this property MAY either be absent or an empty map.
 
 The state MAY include additional properties.
 


### PR DESCRIPTION
The spec was not very clear on how state annotations are related to config annotations.  In the pull-request that landed state annotations (#484), it sounds like [these were supposed to be copied opaquely from the config][1].  It's still not clear to me [why we'd copy annotations but not the rest of the config][2], but I'm leaving that
alone for now.

There was [previous][3] [interest][4] in runtime-specified annotations (e.g. [a RunV socket path][5]), but this commit does not allow runtimes to inject additional entries because I don't like:

* Relying on config authors to avoid squatting on the namespace used by the runtime (if ties are broken in favor of the config) or
* Silently clobbering configured annotations (if ties are broken in favor of the runtime).

My preference would be to follow #118 and:

* Only include runtime-specified information in the state `annotations`.
* Require state readers to follow `bundle` to the `config.json` if they wanted configured annotations (or embed the whole `config.json` in the state).

But with 1.0 released and spec-maintainer comments like [this][1], I think it's too late to return to that approach.  If we want to expose runtime-specified annotations, I think we'll need a new state property.  There has been previous discussion of [using `labels` and `annotations` to carry both types of information in the state][6], and while it's not as elegant as a full config copy, the labels/annotations approach is still viable.

Related to opencontainers/runc#1687.  ~~I'm not clear on whether libcontainer's `Labels` mixes configured and runtime-specified annotations or not, so I'm not sure if it would be compatible with this change.~~ Looks like [runc is removing their injected `bundle`][7], so opencontainers/runc#1687 would be compatible with this PR as it stands.

I don't think this is a breaking change, because the previous content of `annotations` was unspecified, so state consumers shouldn't have been relying on a particular semantic behavior.

[1]: https://github.com/opencontainers/runtime-spec/pull/484#issuecomment-223645095
[2]: https://github.com/opencontainers/runtime-spec/pull/484#issuecomment-223413336
[3]: https://github.com/opencontainers/runtime-spec/pull/188
[4]: https://github.com/opencontainers/runtime-spec/pull/331#issuecomment-192463221
[5]: https://github.com/opencontainers/runtime-spec/pull/188#issuecomment-140296423
[6]: https://github.com/opencontainers/runtime-spec/pull/331#issuecomment-192441264
[7]: https://github.com/opencontainers/runc/pull/1687/commits/cd1e7abee2aba375e2315dcbd456d8542b1fa46e#diff-7b8effb45402944e445a664e4d9c296dR311