### PR TITLE
glossary: Bump JSON spec to RFC 8259

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -32,7 +32,7 @@ It reads the [configuration files](#configuration) from a [bundle](#bundle), use
 
 On Linux, the namespaces from which new [container namespaces](#container-namespace) are [created](config-linux.md#namespaces) and from which some configured resources are accessed.
 
-[JSON]: https://tools.ietf.org/html/rfc7159
+[JSON]: https://tools.ietf.org/html/rfc8259
 [UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf
 
 [namespaces.7]: http://man7.org/linux/man-pages/man7/namespaces.7.html


### PR DESCRIPTION
The new RFC was released in 2017-12 and obsoletes 7159.  No real changes for us, although it does [fix some minor errata][1].

[1]: https://tools.ietf.org/html/rfc8259#appendix-A