### PR TITLE
config: Clarify execution environment for hooks

### DIFF
--- a/config.md
+++ b/config.md
@@ -375,6 +375,7 @@ For POSIX platforms, the configuration structure supports `hooks` for configurin
         Entries in the array contain the following properties:
         * **`path`** (string, REQUIRED) with similar semantics to [IEEE Std 1003.1-2008 `execv`'s *path*][ieee-1003.1-2008-functions-exec].
             This specification extends the IEEE standard in that **`path`** MUST be absolute.
+            Runtimes MUST resolve this value in the [runtime namespace](glossary.md#runtime-namespace).
         * **`args`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008 `execv`'s *argv*][ieee-1003.1-2008-functions-exec].
         * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008's `environ`][ieee-1003.1-2008-xbd-c8.1].
         * **`timeout`** (int, OPTIONAL) is the number of seconds before aborting the hook.
@@ -386,6 +387,7 @@ For POSIX platforms, the configuration structure supports `hooks` for configurin
 
 Hooks allow users to specify programs to run before or after various lifecycle events.
 Hooks MUST be called in the listed order.
+Hooks MUST be executed in the [runtime namespace](glossary.md#runtime-namespace).
 The [state](runtime.md#state) of the container MUST be passed to hooks over stdin so that they may do work appropriate to the current state of the container.
 
 ### <a name="configHooksPrestart" />Prestart


### PR DESCRIPTION
The spec didn't say whether the hooks are executed in the container
environment or not (in Linux namespaces, with cgroups and rlimits
applied).

In rkt, hooks are executed in the container environment. In runc, hooks
are executed outside of the container environment.

The example with setting up the network namespace in "prestart" suggests
that the command is generic and does not have to exist in the container
rootfs. So I assume the spec was meant to say hooks are executed outside
of the container environment.

Signed-off-by: Alban Crequy <alban@kinvolk.io>