### PR TITLE
config: Drop 'type' from bind-mount example

### DIFF
--- a/config.md
+++ b/config.md
@@ -115,7 +115,6 @@ For POSIX platforms the `mounts` structure has the following fields:
     },
     {
         "destination": "/data",
-        "type": "bind",
         "source": "/volumes/testing",
         "options": ["rbind","rw"]
     }


### PR DESCRIPTION
This example initially came in with b3918a25, but the `bind` value is not one of the types you can get out of `/proc/filesystems`.  Instead, bind mounts should leave the type unset and put either `bind` or `rbind` in options (although neither of those are documented either, #771).  Since documenting `(r)bind` seems to be too difficult (for reasons [I don't understand][1]), we should at least stop setting type in the example to stop [confusing][2] [users][3].

Runc still checks `.Type` instead of `.Options` for bind-ness in [a][4] [few][5] [places][6], but we can address all of those by setting `.Device` to `bind` depending on `.Options` [here][4].

[1]: https://github.com/opencontainers/runtime-spec/pull/771#issuecomment-314193121
[2]: https://github.com/opencontainers/runc/issues/1744
[3]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/2gia6t1Dnv0
[4]: https://github.com/opencontainers/runc/blob/v1.0.0-rc5/libcontainer/specconv/spec_linux.go#L272-L276
[5]: https://github.com/opencontainers/runc/blob/v1.0.0-rc5/libcontainer/rootfs_linux.go#L33
[6]: https://github.com/opencontainers/runc/blob/v1.0.0-rc5/libcontainer/rootfs_linux.go#L234