### PR TITLE
Mounts: allow runtimes to create the destination

### DIFF
--- a/config.md
+++ b/config.md
@@ -70,7 +70,7 @@ On all other platforms, this field is REQUIRED.
     For Solaris, the mount entry corresponds to the 'fs' resource in the [zonecfg(1M)][zonecfg.1m] man page.
 
 * **`destination`** (string, REQUIRED) Destination of mount point: path inside container.
-    This value MUST be an absolute path.
+    This value MUST be an absolute path. If the path does not exist, the runtime MAY create it.
     * Windows: one mount destination MUST NOT be nested within another mount (e.g., c:\\foo and c:\\foo\\bar).
     * Solaris: corresponds to "dir" of the fs resource in [zonecfg(1M)][zonecfg.1m].
 * **`source`** (string, OPTIONAL) A device name, but can also be a directory name or a dummy.


### PR DESCRIPTION
Consider the following mount:
```
"mounts": [
  {
    "destination": "/non-existent",
    "source": "/etc/resolv.conf",
    "options": ["bind","ro"]
  }
]
```

When /non-existent does not exist in the container rootfs, the spec does
not say whether the runtime can create it or if it should let the mount
fails.

runc just calls 'mkdir' if it does not exist, after creating and
entering the namespaces. It works most of the times but fails if:
- the source of the bind mount is a file instead of a directory, or
- the container does not have the rights for the mkdir (readonly rootfs
  or rootfs belonging to an unmapped uid).

Doing the mkdir/touch before entering the namespaces is difficult to get
correctly because:
- symlinks would need to be resolved manually as if we were chrooted in
  the container (symlinks are resolved by the mount syscall: a symlink
  itself cannot be a source or a target of a bind mount), and
- ordering nested mounts is complicated by possible symlinks

So I'd prefer if the spec does not mandate to create the file or
directory in all possible scenarios because it's overly complicated. But
the runtime should be allowed to address the simple case like runc does.
Hence the "MAY" wording.

Signed-off-by: Alban Crequy <alban@kinvolk.io>