### PR TITLE
uidMappings: change order of fields for clarity

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -82,8 +82,8 @@ If a `namespaces` field contains duplicated namespaces with same `type`, the run
 
 Each entry has the following structure:
 
-* **`hostID`** *(uint32, REQUIRED)* - is the starting uid/gid on the host to be mapped to *containerID*.
 * **`containerID`** *(uint32, REQUIRED)* - is the starting uid/gid in the container.
+* **`hostID`** *(uint32, REQUIRED)* - is the starting uid/gid on the host to be mapped to *containerID*.
 * **`size`** *(uint32, REQUIRED)* - is the number of ids to be mapped.
 
 The runtime SHOULD NOT modify the ownership of referenced filesystems to realize the mapping.
@@ -94,15 +94,15 @@ Note that the number of mapping entries MAY be limited by the [kernel][user-name
 ```json
     "uidMappings": [
         {
-            "hostID": 1000,
             "containerID": 0,
+            "hostID": 1000,
             "size": 32000
         }
     ],
     "gidMappings": [
         {
-            "hostID": 1000,
             "containerID": 0,
+            "hostID": 1000,
             "size": 32000
         }
     ]

--- a/config.md
+++ b/config.md
@@ -664,15 +664,15 @@ Here is a full example `config.json` for reference.
         ],
         "uidMappings": [
             {
-                "hostID": 1000,
                 "containerID": 0,
+                "hostID": 1000,
                 "size": 32000
             }
         ],
         "gidMappings": [
             {
-                "hostID": 1000,
                 "containerID": 0,
+                "hostID": 1000,
                 "size": 32000
             }
         ],

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -108,10 +108,10 @@
         "IDMapping": {
             "type": "object",
             "properties": {
-                "hostID": {
+                "containerID": {
                     "$ref": "#/definitions/uint32"
                 },
-                "containerID": {
+                "hostID": {
                     "$ref": "#/definitions/uint32"
                 },
                 "size": {
@@ -119,8 +119,8 @@
                 }
             },
             "required": [
-                "hostID",
                 "containerID",
+                "hostID",
                 "size"
             ]
         },

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -194,15 +194,15 @@
         ],
         "uidMappings": [
             {
-                "hostID": 1000,
                 "containerID": 0,
+                "hostID": 1000,
                 "size": 32000
             }
         ],
         "gidMappings": [
             {
-                "hostID": 1000,
                 "containerID": 0,
+                "hostID": 1000,
                 "size": 32000
             }
         ],

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -194,10 +194,10 @@ const (
 
 // LinuxIDMapping specifies UID/GID mappings
 type LinuxIDMapping struct {
-	// HostID is the starting UID/GID on the host to be mapped to 'ContainerID'
-	HostID uint32 `json:"hostID"`
 	// ContainerID is the starting UID/GID in the container
 	ContainerID uint32 `json:"containerID"`
+	// HostID is the starting UID/GID on the host to be mapped to 'ContainerID'
+	HostID uint32 `json:"hostID"`
 	// Size is the number of IDs to be mapped
 	Size uint32 `json:"size"`
 }


### PR DESCRIPTION
"man 7 user_namespaces" explains the format of uid_map and gid_map:
```
    <containerID> <hostID> <mapSize>
```

The order of map entries in JSON does not matter. But for the clarity of
the spec, I find it easier to understand if the order of the JSON fields is
the same as the order of the fields in the underlying uid_map/gid_map
files.

I am about to file a PR in runtime-tools because the fields in
uid_map/gid_map were parsed in the wrong order.

Signed-off-by: Alban Crequy <alban@kinvolk.io>