### PR TITLE
Linux devices: uid/gid relative to container

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -122,8 +122,8 @@ Each entry has the following structure:
 * **`major, minor`** *(int64, REQUIRED unless `type` is `p`)* - [major, minor numbers][devices] for the device.
 * **`fileMode`** *(uint32, OPTIONAL)* - file mode for the device.
     You can also control access to devices [with cgroups](#device-whitelist).
-* **`uid`** *(uint32, OPTIONAL)* - id of device owner.
-* **`gid`** *(uint32, OPTIONAL)* - id of device group.
+* **`uid`** *(uint32, OPTIONAL)* - id of device owner in the [container namespace](glossary.md#container-namespace).
+* **`gid`** *(uint32, OPTIONAL)* - id of device group in the [container namespace](glossary.md#container-namespace).
 
 The same `type`, `major` and `minor` SHOULD NOT be used for multiple devices.
 


### PR DESCRIPTION
It was not clear in the spec if the uid and gid owning a Linux device
were relative to the runtime namespace or to the container namespace.
This patch clarifies that.

Fixes https://github.com/opencontainers/runtime-spec/issues/957

Signed-off-by: Alban Crequy <alban@kinvolk.io>