### PR TITLE
config-vm: Recycle the hook-process schema

### DIFF
--- a/config-vm.md
+++ b/config-vm.md
@@ -5,17 +5,14 @@ The virtual-machine container specification provides additional configuration fo
 
 ## <a name="HypervisorObject" /> Hypervisor Object
 
-**`hypervisor`** (object, OPTIONAL) specifies details of the hypervisor that manages the container virtual machine.
-* **`path`** (string, REQUIRED) path to the hypervisor binary that manages the container virtual machine.
-    This value MUST be an absolute path in the [runtime mount namespace](glossary.md#runtime-namespace).
-* **`parameters`** (array of strings, OPTIONAL) specifies an array of parameters to pass to the hypervisor.
+**`hypervisor`** (object, OPTIONAL) configures the hypervisor process using the [hook-process schema](config.md#hook-process).
 
 ### Example
 
 ```json
     "hypervisor": {
         "path": "/path/to/vmm",
-        "parameters": ["opts1=foo", "opts2=bar"]
+        "args": ["vmm", "opts1=foo", "opts2=bar"]
     }
 ```
 

--- a/config.md
+++ b/config.md
@@ -372,21 +372,26 @@ For POSIX platforms, the configuration structure supports `hooks` for configurin
 
 * **`hooks`** (object, OPTIONAL) MAY contain any of the following properties:
     * **`prestart`** (array of objects, OPTIONAL) is an array of [pre-start hooks](#prestart).
-        Entries in the array contain the following properties:
-        * **`path`** (string, REQUIRED) with similar semantics to [IEEE Std 1003.1-2008 `execv`'s *path*][ieee-1003.1-2008-functions-exec].
-            This specification extends the IEEE standard in that **`path`** MUST be absolute.
-        * **`args`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008 `execv`'s *argv*][ieee-1003.1-2008-functions-exec].
-        * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008's `environ`][ieee-1003.1-2008-xbd-c8.1].
-        * **`timeout`** (int, OPTIONAL) is the number of seconds before aborting the hook.
-            If set, `timeout` MUST be greater than zero.
+        Entries in the array are [hook-process objects](#hook-process).
     * **`poststart`** (array of objects, OPTIONAL) is an array of [post-start hooks](#poststart).
-        Entries in the array have the same schema as pre-start entries.
+        Entries in the array are [hook-process objects](#hook-process).
     * **`poststop`** (array of objects, OPTIONAL) is an array of [post-stop hooks](#poststop).
-        Entries in the array have the same schema as pre-start entries.
+        Entries in the array are [hook-process objects](#hook-process).
 
 Hooks allow users to specify programs to run before or after various lifecycle events.
 Hooks MUST be called in the listed order.
 The [state](runtime.md#state) of the container MUST be passed to hooks over stdin so that they may do work appropriate to the current state of the container.
+
+### <a name="configHook" />Hook process
+
+Process configuration contains the following properties:
+
+* **`path`** (string, REQUIRED) with similar semantics to [IEEE Std 1003.1-2008 `execv`'s *path*][ieee-1003.1-2008-functions-exec].
+    This specification extends the IEEE standard in that **`path`** MUST be absolute.
+* **`args`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008 `execv`'s *argv*][ieee-1003.1-2008-functions-exec].
+* **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008's `environ`][ieee-1003.1-2008-xbd-c8.1].
+* **`timeout`** (int, OPTIONAL) is the number of seconds before aborting the hook.
+    If set, `timeout` MUST be greater than zero.
 
 ### <a name="configHooksPrestart" />Prestart
 

--- a/schema/config-vm.json
+++ b/schema/config-vm.json
@@ -7,19 +7,7 @@
         ],
         "properties": {
             "hypervisor": {
-                "description": "hypervisor config used by VM-based containers",
-                "type": "object",
-                "required": [
-                    "path"
-                ],
-                "properties": {
-                    "path": {
-                        "$ref": "defs.json#/definitions/FilePath"
-                    },
-                    "parameters": {
-                        "$ref": "defs.json#/definitions/ArrayOfStrings"
-                    }
-                }
+                "$ref": "defs.json#/definitions/Hook"
             },
             "kernel": {
                 "description": "kernel config used by VM-based containers",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -504,19 +504,11 @@ type WindowsHyperV struct {
 // VM contains information for virtual-machine-based containers.
 type VM struct {
 	// Hypervisor specifies hypervisor-related configuration for virtual-machine-based containers.
-	Hypervisor VMHypervisor `json:"hypervisor,omitempty"`
+	Hypervisor *Hook `json:"hypervisor,omitempty"`
 	// Kernel specifies kernel-related configuration for virtual-machine-based containers.
 	Kernel VMKernel `json:"kernel"`
 	// Image specifies guest image related configuration for virtual-machine-based containers.
 	Image VMImage `json:"image,omitempty"`
-}
-
-// VMHypervisor contains information about the hypervisor to use for a virtual machine.
-type VMHypervisor struct {
-	// Path is the host path to the hypervisor used to manage the virtual machine.
-	Path string `json:"path"`
-	// Parameters specifies parameters to pass to the hypervisor.
-	Parameters string `json:"parameters,omitempty"`
 }
 
 // VMKernel contains information about the kernel to use for a virtual machine.


### PR DESCRIPTION
We've had two ways to specify a process to launch (for the container process and for hooks) [for a while now][0].  Last week, we landed #949 with a third process-launching structure.  This pull request replaced that third structure with a recycled hook-process schema for launcing the hypervisor.  I prefer using the more-fundamental container process schema, but @crosbymichael felt [it had too many properties that wouldn't apply to the hypervisor-launching case][1].  Versus master, this pull request adds:

* The ability to set `argv[0]` independently of `path` (like [`execv`][2] and similar).
* The ability to set `env` and `timeout` for the hypervisor process.
* The ability to lean on existing hook-launching code for launching hypervisor processes, with the difference being just whether you [pass the state in on stdin][3] or not.

And removes:

* 18 lines of source (says `git diff --diffstat origin/master`).
* A third take at [`argv` phrasing][4] which is much different from our [existing][5] [phrasing][6].

If we get this or a similar unification landed before we cut a release that includes #949, then I think this change is all positive with no downside.  If we punt on this until after 1.1.0, then this is probably just going to end up as one of those unfortunate historical quirks that are not worth the migration pain of fixing.

Ping @sameo and @crosbymichael, since they're the only two who have [expressed][7] [opinions][1] on this sort of thing so far.

[0]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/Cn5L6g1prgA
[1]: https://github.com/opencontainers/runtime-spec/pull/949#issuecomment-373730290
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
[3]: https://github.com/opencontainers/runtime-spec/blame/d362ed3abe646248f1f84a6e5871d05513f9167b/config.md#L389
[4]: https://github.com/opencontainers/runtime-spec/blame/d362ed3abe646248f1f84a6e5871d05513f9167b/config-vm.md#L11
[5]: https://github.com/opencontainers/runtime-spec/blame/d362ed3abe646248f1f84a6e5871d05513f9167b/config.md#L157-L158
[6]: https://github.com/opencontainers/runtime-spec/blame/d362ed3abe646248f1f84a6e5871d05513f9167b/config.md#L378
[7]: https://github.com/opencontainers/runtime-spec/pull/949#issuecomment-372299408