### PR TITLE
bind is not a valid mount type

### DIFF
--- a/config.md
+++ b/config.md
@@ -115,7 +115,6 @@ For POSIX platforms the `mounts` structure has the following fields:
     },
     {
         "destination": "/data",
-        "type": "bind",
         "source": "/volumes/testing",
         "options": ["rbind","rw"]
     }


### PR DESCRIPTION
Per spec, "bind" is not a valid mount type. To use bind mount,
the spec compatible way is to set either "bind" or "rbind"
in the mount options.

Although in practice, setting the type as "bind" won't actually
cause an error (at the moment using runc, as well as the system
call mount(7) itself) as long as either "bind" or "rbind" is set
as well, it provide an incorrect example that "bind" is avalid
type, and make people think following config is a valid one for
bind mount, which in fact will throw an error in runc.

{
 "destination": "/data",
 "type": "bind"
 "source": "/volumes/testing",
}

[1] tried to automatically add a MS_BIND flag when the type is "bind"
but was rejected on the ground it "encourage" the incorrect usage of
bind as the mount type, which I agree. Hence, here I change the example
in the spec in the hope making it clearer that for bind mount to work,
we should use the correct mount options, instead of the "bind" mount type.

[1]https://github.com/opencontainers/runc/pull/1799

Signed-off-by: Bin Chen <Bin Chen nk@devicu.com>