### PR TITLE
.travis: Bump minimum Go version to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 go:
-  - 1.7
-  - 1.6.3
-  - 1.5.4
+  - "1.10.x"
+  - "1.9.x"
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ services:
 before_install:
   - make install.tools
   - docker pull vbatts/pandoc
+  - go get -d ./schema/...
 
 install: true
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test: .govet .golint .gitvalidation
 
 # `go get github.com/golang/lint/golint`
 .golint:
-ifeq ($(call ALLOWED_GO_VERSION,1.6,$(HOST_GOLANG_VERSION)),true)
+ifeq ($(call ALLOWED_GO_VERSION,1.7,$(HOST_GOLANG_VERSION)),true)
 	@which golint > /dev/null 2>/dev/null || (echo "ERROR: golint not found. Consider 'make install.tools' target" && false)
 	golint ./...
 endif
@@ -79,9 +79,9 @@ endif
 
 install.tools: .install.golint .install.gitvalidation
 
-# golint does not even build for <go1.6
+# golint does not even build for <go1.7
 .install.golint:
-ifeq ($(call ALLOWED_GO_VERSION,1.6,$(HOST_GOLANG_VERSION)),true)
+ifeq ($(call ALLOWED_GO_VERSION,1.7,$(HOST_GOLANG_VERSION)),true)
 	go get -u github.com/golang/lint/golint
 endif
 


### PR DESCRIPTION
[Go 1.10 was released on 2018-02-16][1] and [Go only supports the last two major releases][2] (so currently 1.9 and 1.10).  Besides ensuring that we are compatible with the currently-maintained releases, this will avoid our current test failure now that [golint has dropped support for Go 1.6][3]:

```console
$ make install.tools
go get -u github.com/golang/lint/golint
../../../golang.org/x/tools/go/internal/gcimporter/iimport.go:77: undefined: io.SeekCurrent
../../../golang.org/x/tools/go/internal/gcimporter/iimport.go:80: undefined: io.SeekCurrent
../../../golang.org/x/tools/go/internal/gcimporter/iimport.go:156: undefined: io.SeekCurrent
../../../golang.org/x/tools/go/internal/gcimporter/iimport.go:187: r.declReader.Reset undefined (type bytes.Reader has no field or method Reset)
../../../golang.org/x/tools/go/internal/gcimporter/iimport.go:226: r.declReader.Reset undefined (type bytes.Reader has no field or method Reset)
make: *** [.install.golint] Error 2
```

[1]: https://golang.org/doc/devel/release.html#go1.10
[2]: https://golang.org/doc/devel/release.html#policy
[3]: https://travis-ci.org/opencontainers/runtime-spec/jobs/376692151#L469