### PR TITLE
spec: add field for NIS domain name

### DIFF
--- a/config.md
+++ b/config.md
@@ -341,6 +341,19 @@ For Windows based systems the user structure has the following fields:
 "hostname": "mrsdalloway"
 ```
 
+## <a name="configDomainName" />Domain Name
+
+* **`domainname`** (string, OPTIONAL) specifies the container's NIS domain name as seen by processes running inside the container.
+    On Linux, for example, this will [change the domain name][setdomainname.2] in the [container](glossary.md#container-namespace) [UTS namespace][uts-namespace.7].
+    Depending on your [namespace configuration](config-linux.md#namespaces), the container UTS namespace may be the [runtime](glossary.md#runtime-namespace) [UTS namespace][uts-namespace.7].
+
+### Example
+
+```json
+"hostname": "mrsdalloway",
+"domainname": "opencontainers.org"
+```
+
 ## <a name="configPlatformSpecificConfiguration" />Platform-specific configuration
 
 * **`linux`** (object, OPTIONAL) [Linux-specific configuration](config-linux.md).
@@ -860,5 +873,6 @@ Here is a full example `config.json` for reference.
 [getrlimit.2]: http://man7.org/linux/man-pages/man2/getrlimit.2.html
 [getrlimit.3]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getrlimit.html
 [stdin.3]: http://man7.org/linux/man-pages/man3/stdin.3.html
+[setdomainname.2]: http://man7.org/linux/man-pages/man2/setdomainname.2.html
 [uts-namespace.7]: http://man7.org/linux/man-pages/man7/namespaces.7.html
 [zonecfg.1m]: http://docs.oracle.com/cd/E86824_01/html/E54764/zonecfg-1m.html

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -26,6 +26,9 @@
         "hostname": {
             "type": "string"
         },
+        "domainname": {
+            "type": "string"
+        },
         "mounts": {
             "type": "array",
             "items": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -12,6 +12,8 @@ type Spec struct {
 	Root *Root `json:"root,omitempty"`
 	// Hostname configures the container's hostname.
 	Hostname string `json:"hostname,omitempty"`
+	// Domainname configures the container's NIS domain name.
+	Domainname string `json:"domainname,omitempty"`
 	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
 	// Hooks configures callbacks for container lifecycle events.


### PR DESCRIPTION
A common complaint is that there is no way to explicitly set the NIS
domain name of a container (through setdomainname(2) and
kernel.domainname). Some legacy software uses the domain name of the
host for license verification and other similar functions, so having
this is a very useful feature for people who use such software.

Part of moby/moby#27067.
Signed-off-by: Aleksa Sarai <asarai@suse.de>