### PR TITLE
[RFC] Remove effective and permitted capabilities

### DIFF
--- a/config.md
+++ b/config.md
@@ -191,10 +191,8 @@ For Linux-based systems, the `process` object supports the following process-spe
     Any value which cannot be mapped to a relevant kernel interface MUST cause an error.
     `capabilities` contains the following properties:
 
-    * **`effective`** (array of strings, OPTIONAL) the `effective` field is an array of effective capabilities that are kept for the process.
     * **`bounding`** (array of strings, OPTIONAL) the `bounding` field is an array of bounding capabilities that are kept for the process.
     * **`inheritable`** (array of strings, OPTIONAL) the `inheritable` field is an array of inheritable capabilities that are kept for the process.
-    * **`permitted`** (array of strings, OPTIONAL) the `permitted` field is an array of permitted capabilities that are kept for the process.
     * **`ambient`** (array of strings, OPTIONAL) the `ambient` field is an array of ambient capabilities that are kept for the process.
 * **`noNewPrivileges`** (bool, OPTIONAL) setting `noNewPrivileges` to true prevents the process from gaining additional privileges.
     As an example, the [`no_new_privs`][no-new-privs] article in the kernel documentation has information on how this is achieved using a `prctl` system call on Linux.
@@ -252,19 +250,10 @@ _Note: symbolic name for uid and gid, such as uname and gname respectively, are 
             "CAP_KILL",
             "CAP_NET_BIND_SERVICE"
         ],
-       "permitted": [
+        "inheritable": [
             "CAP_AUDIT_WRITE",
             "CAP_KILL",
             "CAP_NET_BIND_SERVICE"
-        ],
-       "inheritable": [
-            "CAP_AUDIT_WRITE",
-            "CAP_KILL",
-            "CAP_NET_BIND_SERVICE"
-        ],
-        "effective": [
-            "CAP_AUDIT_WRITE",
-            "CAP_KILL"
         ],
         "ambient": [
             "CAP_NET_BIND_SERVICE"
@@ -497,19 +486,10 @@ Here is a full example `config.json` for reference.
                 "CAP_KILL",
                 "CAP_NET_BIND_SERVICE"
             ],
-            "permitted": [
-                "CAP_AUDIT_WRITE",
-                "CAP_KILL",
-                "CAP_NET_BIND_SERVICE"
-            ],
             "inheritable": [
                 "CAP_AUDIT_WRITE",
                 "CAP_KILL",
                 "CAP_NET_BIND_SERVICE"
-            ],
-            "effective": [
-                "CAP_AUDIT_WRITE",
-                "CAP_KILL"
             ],
             "ambient": [
                 "CAP_NET_BIND_SERVICE"

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -104,12 +104,6 @@
                         "bounding": {
                             "$ref": "defs.json#/definitions/ArrayOfStrings"
                         },
-                        "permitted": {
-                            "$ref": "defs.json#/definitions/ArrayOfStrings"
-                        },
-                        "effective": {
-                            "$ref": "defs.json#/definitions/ArrayOfStrings"
-                        },
                         "inheritable": {
                             "$ref": "defs.json#/definitions/ArrayOfStrings"
                         },

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -24,19 +24,10 @@
                 "CAP_KILL",
                 "CAP_NET_BIND_SERVICE"
             ],
-            "permitted": [
-                "CAP_AUDIT_WRITE",
-                "CAP_KILL",
-                "CAP_NET_BIND_SERVICE"
-            ],
             "inheritable": [
                 "CAP_AUDIT_WRITE",
                 "CAP_KILL",
                 "CAP_NET_BIND_SERVICE"
-            ],
-            "effective": [
-                "CAP_AUDIT_WRITE",
-                "CAP_KILL"
             ],
             "ambient": [
                 "CAP_NET_BIND_SERVICE"

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -63,12 +63,8 @@ type Process struct {
 type LinuxCapabilities struct {
 	// Bounding is the set of capabilities checked by the kernel.
 	Bounding []string `json:"bounding,omitempty" platform:"linux"`
-	// Effective is the set of capabilities checked by the kernel.
-	Effective []string `json:"effective,omitempty" platform:"linux"`
 	// Inheritable is the capabilities preserved across execve.
 	Inheritable []string `json:"inheritable,omitempty" platform:"linux"`
-	// Permitted is the limiting superset for effective capabilities.
-	Permitted []string `json:"permitted,omitempty" platform:"linux"`
 	// Ambient is the ambient set of capabilities that are kept.
 	Ambient []string `json:"ambient,omitempty" platform:"linux"`
 }


### PR DESCRIPTION
Both `effective` and `permitted` capabilities cannot be passed to a container because the Linux kernel will reset them during the exec of the pid1 process in the container. In practice, no matter how these two capabilities are set in a runtime config file, those can be set in the container to a totally different values.

So let's remove these capabilities from the runtime spec, because it's not possible to make them work inside containers.

NOTE: I'm aware that it would take much time for removing anything from the spec, because then all relevant runtimes and tools need to be also updated. However, I would like to get feedback from maintainers, to know if this removal makes sense at all. I waited for a reply since the last week, but got no answer. So I'm creating this PR. Any comment would be welcome.

Fixes https://github.com/opencontainers/runtime-spec/issues/979

Signed-off-by: Dongsu Park <dongsu@kinvolk.io>