### PR TITLE
config-linux: add Intel RDT CLOS name sharing support

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -228,6 +228,9 @@
             "intelRdt": {
                 "type": "object",
                 "properties": {
+                    "closID": {
+                        "type": "string"
+                    },
                     "l3CacheSchema": {
                         "type": "string"
                     }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -624,6 +624,8 @@ type LinuxSyscall struct {
 // LinuxIntelRdt has container runtime resource constraints
 // for Intel RDT/CAT which introduced in Linux 4.10 kernel
 type LinuxIntelRdt struct {
+	// The identity for RDT Class of Service
+	ClosID string `json:"closID,omitempty"`
 	// The schema for L3 cache id and capacity bitmask (CBM)
 	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
 	L3CacheSchema string `json:"l3CacheSchema,omitempty"`


### PR DESCRIPTION
Previously, it will create a dedicated RDT Class of Service (CLOS) for each running container, even they have exactly same Scheam. This will lead to short of CLOS, since there is a hardware limit for the number of CLOS, around 16 CLOS per platform.

This PR add one parameter 'closID' into existed spec to allow user to specify which RDT Class of Service (CLOS) the container will be located. So it can place these containers with same Schema into one single CLOS.

Example:

```
"linux": {
    "intelRdt": {
        "closID": "guaranteed_group",
        "l3CacheSchema": "L3:0=ffff0;1=3ff"
    }
}
```

Fixes: [runc issue 1878](https://github.com/opencontainers/runc/issues/1878)