### PR TITLE
Windows:Have native CommandLine in Process

### DIFF
--- a/config.md
+++ b/config.md
@@ -155,8 +155,11 @@ For POSIX platforms the `mounts` structure has the following fields:
 * **`cwd`** (string, REQUIRED) is the working directory that will be set for the executable.
     This value MUST be an absolute path.
 * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008's `environ`][ieee-1003.1-2008-xbd-c8.1].
-* **`args`** (array of strings, REQUIRED) with similar semantics to [IEEE Std 1003.1-2008 `execvp`'s *argv*][ieee-1003.1-2008-functions-exec].
-    This specification extends the IEEE standard in that at least one entry is REQUIRED, and that entry is used with the same semantics as `execvp`'s *file*.
+* **`args`** (array of strings, OPTIONAL) with similar semantics to [IEEE Std 1003.1-2008 `execvp`'s *argv*][ieee-1003.1-2008-functions-exec].
+    This specification extends the IEEE standard in that at least one entry is REQUIRED (non-Windows), and that entry is used with the same semantics as `execvp`'s *file*. This field is OPTIONAL on Windows, and `commandLine` is REQUIRED if this field is omitted.
+* **`commandLine`** (string, OPTIONAL) specifies the full command line to be executed on Windows.
+    This is the preferred means of supplying the command line on Windows. If omitted, the runtime will fall back to escaping and concatenating fields from `args` before making the system call into Windows.
+
 
 ### <a name="configPOSIXProcess" />POSIX process
 

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -50,12 +50,14 @@
         "process": {
             "type": "object",
             "required": [
-                "cwd",
-                "args"
+                "cwd"
             ],
             "properties": {
                 "args": {
                     "$ref": "defs.json#/definitions/ArrayOfStrings"
+                },
+                "commandLine": {
+                    "type": "string"
                 },
                 "consoleSize": {
                     "type": "object",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -38,7 +38,9 @@ type Process struct {
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
-	Args []string `json:"args"`
+	Args []string `json:"args,omitempty"`
+	// CommandLine specifies the full command line for the application to execute on Windows.
+	CommandLine string `json:"commandLine,omitempty" platform:"windows"`
 	// Env populates the process environment for the process.
 	Env []string `json:"env,omitempty"`
 	// Cwd is the current working directory for the process and must be


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Windows natively doesn't launch processes through an array of arguments. Instead, it uses a command line single string, which the startup code (eg https://docs.microsoft.com/en-us/previous-versions/ms880421(v=msdn.10)) interprets into an argv set. Golang does identical parsing of the command-line on Windows in commandLineToArgv: https://github.com/golang/go/blob/ff7b245a31394b700a252fd547cf16ad0ad838b6/src/os/exec_windows.go#L100-L174

See the MSDN `CreateProcess` documentation for the actual API into Windows: https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa

Using args alone on Windows has possible loss of fidelity causing some commands to not operate as expected. (This has long been the case on Windows in docker for example). A contrived (but real) example in a test case in the moby repo where fidelity is lost is the following command-line:

`cmd /S /C mkdir "c:/foo"`

When parsed into a JSON array (such as the args), this becomes 5 elements as follows:

 - `cmd`
 - `/S`
 - `/C`
 - `mkdir`
 - `c:/foo`

Note specifically that the lost information are the double-quotes around `c:/foo`. When using the required contatenation/space separation, and argument escaping required on Windows (https://github.com/golang/sys/blob/c4afb3effaa53fd9a06ca61262dc7ce8df4c081b/windows/exec_windows.go#L9-L18), this becomes the following command line:

`cmd /S /C mkdir c:/foo`

When the double-quotes are missing, mkdir here fails, but with the double-quotes succeeds as expected, as shown in the following screenshot.

![image](https://user-images.githubusercontent.com/10522484/51640691-0df03400-1f19-11e9-8c0f-173b764e22ae.png)

The addition of a full `commandLine` in Process for use on Windows alleviates issues where fidelity can be lost. 

If commandLine is omitted, the Windows runtime will fall-back to existing behaviour of contatenation/escaping described previously.

@crosbymichael PTAL

@dmcgowan & @jterry75 FYI.




