### PR TITLE
config-linux: Fix indentation in example

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -202,8 +202,8 @@ Runtimes MAY attach the container process to additional cgroup controllers beyon
     "cgroupsPath": "/myRuntime/myContainer",
     "resources": {
         "memory": {
-        "limit": 100000,
-        "reservation": 200000
+            "limit": 100000,
+            "reservation": 200000
         },
         "devices": [
             {


### PR DESCRIPTION
Obsoletes #911

Reported-by:    Gary M. Josack <gary@byoteki.com>
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>