### PR TITLE
change new pid namespace description

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -27,7 +27,7 @@ Namespaces are specified as an array of entries inside the `namespaces` root fie
 The following parameters can be specified to set up namespaces:
 
 * **`type`** *(string, REQUIRED)* - namespace type. The following namespace types are supported:
-    * **`pid`** processes inside the container will only be able to see other processes inside the same container.
+    * **`pid`** processes inside the container will only be able to see other processes inside the same container or inside the same pid namespace.
     * **`network`** the container will have its own network stack.
     * **`mount`** the container will have an isolated mount table.
     * **`ipc`** processes inside the container will only be able to communicate to other processes inside the same container via system level IPC.


### PR DESCRIPTION
If container b joins container a's pid namespace, processes inside container b can be able to see other processes in container a, not only inside it's own container..

For example:

Use busybox image as rootfs, with start arg ["sleep", "100000"]:

For `container a`: use new pid namesapce without path: `"namespaces": [{"type": "pid"}`
```
root@demo:/opt/busybox# ../runc/runc run -d a
root@demo:/opt/busybox# ../runc/runc list
ID          PID         STATUS      BUNDLE                                            CREATED                          OWNER
a           3162        running     /opt/busybox   2019-04-08T11:34:02.449638033Z   root
root@demo:/opt/busybox# ../runc/runc exec -t a ps -ef
PID   USER     TIME  COMMAND
    1 root      0:00 sleep 100000
    6 root      0:00 ps -ef
```

For `container b`: use new pid namesapce with path: `"namespaces": [{"type": "pid", "path": "/proc/3162/ns/pid"}`
```
root@demo:/opt/busybox# ../runc/runc run -d b
root@demo:/opt/busybox# ../runc/runc list
ID          PID         STATUS      BUNDLE                                            CREATED                          OWNER
a           3162        running     /opt/busybox   2019-04-08T11:34:02.449638033Z   root
b           3581        running     /opt/busybox   2019-04-08T11:35:05.241568752Z   root
# now they can see each other
root@demo:/opt/busybox# ../runc/runc exec -t a ps -ef
PID   USER     TIME  COMMAND
    1 root      0:00 sleep 100000
   11 root      0:00 sleep 100000
   16 root      0:00 ps -ef
root@demo:/opt/busybox# ../runc/runc exec -t b ps -ef
PID   USER     TIME  COMMAND
    1 root      0:00 sleep 100000
   11 root      0:00 sleep 100000
   24 root      0:00 ps -ef
```

Signed-off-by: Lifubang <lifubang@acmcoder.com>