### PR TITLE
Add create-host, create-container, start-container hooks

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -55,18 +55,24 @@ The lifecycle describes the timeline of events that happen from when a container
     If the runtime is unable to create the environment specified in the [`config.json`](config.md), it MUST [generate an error](#errors).
     While the resources requested in the [`config.json`](config.md) MUST be created, the user-specified program (from [`process`](config.md#process)) MUST NOT be run at this time.
     Any updates to [`config.json`](config.md) after this step MUST NOT affect the container.
-3. Runtime's [`start`](runtime.md#start) command is invoked with the unique identifier of the container.
-4. The [prestart hooks](config.md#prestart) MUST be invoked by the runtime.
-    If any prestart hook fails, the runtime MUST [generate an error](#errors), stop the container, and continue the lifecycle at step 9.
-5. The runtime MUST run the user-specified program, as specified by [`process`](config.md#process).
-6. The [poststart hooks](config.md#poststart) MUST be invoked by the runtime.
-    If any poststart hook fails, the runtime MUST [log a warning](#warnings), but the remaining hooks and lifecycle continue as if the hook had succeeded.
-7. The container process exits.
+3. The [`prestart` hooks](config.md#prestart) MUST be invoked by the runtime.
+    If any `prestart` hook fails, the runtime MUST [generate an error](#errors), stop the container, and continue the lifecycle at step 12.
+4. The [`createRuntime` hooks](config.md#createRuntime-hooks) MUST be invoked by the runtime.
+    If any `createRuntime` hook fails, the runtime MUST [generate an error](#errors), stop the container, and continue the lifecycle at step 12.
+5. The [`createContainer` hooks](config.md#createContainer-hooks) MUST be invoked by the runtime.
+    If any `createContainer` hook fails, the runtime MUST [generate an error](#errors), stop the container, and continue the lifecycle at step 12.
+6. Runtime's [`start`](runtime.md#start) command is invoked with the unique identifier of the container.
+7. The [`startContainer` hooks](config.md#startContainer-hooks) MUST be invoked by the runtime.
+    If any `startContainer` hook fails, the runtime MUST [generate an error](#errors), stop the container, and continue the lifecycle at step 12.
+8. The runtime MUST run the user-specified program, as specified by [`process`](config.md#process).
+9. The [`poststart` hooks](config.md#poststart) MUST be invoked by the runtime.
+    If any `poststart` hook fails, the runtime MUST [log a warning](#warnings), but the remaining hooks and lifecycle continue as if the hook had succeeded.
+10. The container process exits.
     This MAY happen due to erroring out, exiting, crashing or the runtime's [`kill`](runtime.md#kill) operation being invoked.
-8. Runtime's [`delete`](runtime.md#delete) command is invoked with the unique identifier of the container.
-9. The container MUST be destroyed by undoing the steps performed during create phase (step 2).
-10. The [poststop hooks](config.md#poststop) MUST be invoked by the runtime.
-    If any poststop hook fails, the runtime MUST [log a warning](#warnings), but the remaining hooks and lifecycle continue as if the hook had succeeded.
+11. Runtime's [`delete`](runtime.md#delete) command is invoked with the unique identifier of the container.
+12. The container MUST be destroyed by undoing the steps performed during create phase (step 2).
+13. The [`poststop` hooks](config.md#poststop) MUST be invoked by the runtime.
+    If any `poststop` hook fails, the runtime MUST [log a warning](#warnings), but the remaining hooks and lifecycle continue as if the hook had succeeded.
 
 ## <a name="runtimeErrors" />Errors
 

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -12,6 +12,15 @@
                 "prestart": {
                     "$ref": "defs.json#/definitions/ArrayOfHooks"
                 },
+                "createRuntime": {
+                    "$ref": "defs.json#/definitions/ArrayOfHooks"
+                },
+                "createContainer": {
+                    "$ref": "defs.json#/definitions/ArrayOfHooks"
+                },
+                "startContainer": {
+                    "$ref": "defs.json#/definitions/ArrayOfHooks"
+                },
                 "poststart": {
                     "$ref": "defs.json#/definitions/ArrayOfHooks"
                 },

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -155,6 +155,28 @@
                 "path": "/usr/bin/setup-network"
             }
         ],
+        "createRuntime": [
+            {
+                "path": "/usr/bin/fix-mounts",
+                "args": ["fix-mounts", "arg1", "arg2"],
+                "env":  [ "key1=value1"]
+            },
+            {
+                "path": "/usr/bin/setup-network"
+            }
+        ],
+        "createContainer": [
+            {
+                "path": "/usr/bin/mount-hook",
+                "args": ["-mount", "arg1", "arg2"],
+                "env":  [ "key1=value1"]
+            }
+        ],
+        "startContainer": [
+            {
+                "path": "/usr/bin/refresh-ldcache"
+            }
+        ],
         "poststart": [
             {
                 "path": "/usr/bin/notify-start",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -125,13 +125,26 @@ type Hook struct {
 	Timeout *int     `json:"timeout,omitempty"`
 }
 
+// Hooks specifies a command that is run in the container at a particular event in the lifecycle of a container
 // Hooks for container setup and teardown
 type Hooks struct {
-	// Prestart is a list of hooks to be run before the container process is executed.
+	// Prestart is Deprecated. Prestart is a list of hooks to be run before the container process is executed.
+	// It is called in the Runtime Namespace
 	Prestart []Hook `json:"prestart,omitempty"`
+	// CreateRuntime is a list of hooks to be run after the container has been created but before pivot_root or any equivalent operation has been called
+	// It is called in the Runtime Namespace
+	CreateRuntime []Hook `json:"createRuntime,omitempty"`
+	// CreateContainer is a list of hooks to be run after the container has been created but before pivot_root or any equivalent operation has been called
+	// It is called in the Container Namespace
+	CreateContainer []Hook `json:"createContainer,omitempty"`
+	// StartContainer is a list of hooks to be run after the start operation is called but before the container process is started
+	// It is called in the Container Namespace
+	StartContainer []Hook `json:"startContainer,omitempty"`
 	// Poststart is a list of hooks to be run after the container process is started.
+	// It is called in the Runtime Namespace
 	Poststart []Hook `json:"poststart,omitempty"`
 	// Poststop is a list of hooks to be run after the container process exits.
+	// It is called in the Runtime Namespace
 	Poststop []Hook `json:"poststop,omitempty"`
 }
 


### PR DESCRIPTION
Hello!

Since we discussed this during the last OCI weekly meeting, I wanted to continue the conversation on a more concrete change.
Related:
- https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/WTHcf-b3wXA
- https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/_dmqMkvX_iE

I've used the same names as LXC for the hooks. I'm happy to change them if we feel there are more appropriate names.
My reasoning while drafting this was to answer some of these questions:
- Definition: How can we define the `mount` hook in a way that would clearly define the ability to mount "stuff" inside the container
- Ordering: Is there an ordering that is required?
  Here it would be helpful to define the ordering such that the pre-start hook detects that it doesn't need to be executed in a setting where we specify both pre-start hook and mount hook for backwards compat reasons.

Questions still open:
- Should we define "outside" and "inside" (in relation to the VM debate)

What do you think about this first draft?

Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>