### PR TITLE
Fix ociVersion of Configuration Schema Example to support ambient capability

### DIFF
--- a/config.md
+++ b/config.md
@@ -476,7 +476,7 @@ Here is a full example `config.json` for reference.
 
 ```json
 {
-    "ociVersion": "0.5.0-dev",
+    "ociVersion": "1.0.1",
     "process": {
         "terminal": true,
         "user": {


### PR DESCRIPTION
Correct ociVersion is not specified in Configuration Schema Example.
ociVersion 0.5.0-dev does not support Linux ambient capability.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>