### PR TITLE
Add Linux personality support

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -684,6 +684,23 @@ The following parameters can be specified to set up seccomp:
     "mountLabel": "system_u:object_r:svirt_sandbox_file_t:s0:c715,c811"
 ```
 
+## <a name="configLinuxPersonality" />Personality
+
+**`personality`** (object, OPTIONAL) sets the Linux execution personality. For more information
+see the [personality](personality.2) syscall documentation. As most of the options are
+obsolete and rarely used, and some reduce security, the currently supported set is a small
+subset of the available options.
+
+* **`domain`** *(string, REQUIRED)* - the execution domain.
+    The valid list of constants is shown below. `LINUX32` will set the `uname` system call to show
+    a 32 bit CPU type, such as `i686`.
+
+    * `LINUX`
+    * `LINUX32`
+
+* **`flags`** *(array of strings, OPTIONAL)* - the additional flags to apply.
+    Currently no flag values are supported.
+
 
 [cgroup-v1]: https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
 [cgroup-v1-blkio]: https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt
@@ -711,6 +728,7 @@ The following parameters can be specified to set up seccomp:
 [mknod.2]: http://man7.org/linux/man-pages/man2/mknod.2.html
 [namespaces.7_2]: http://man7.org/linux/man-pages/man7/namespaces.7.html
 [null.4]: http://man7.org/linux/man-pages/man4/null.4.html
+[personality.2]: http://man7.org/linux/man-pages/man2/personality.2.html
 [pts.4]: http://man7.org/linux/man-pages/man4/pts.4.html
 [random.4]: http://man7.org/linux/man-pages/man4/random.4.html
 [sysctl.8]: http://man7.org/linux/man-pages/man8/sysctl.8.html

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -165,6 +165,8 @@ type Linux struct {
 	// IntelRdt contains Intel Resource Director Technology (RDT) information for
 	// handling resource constraints (e.g., L3 cache, memory bandwidth) for the container
 	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
+	// Personality contains configuration for the Linux personality syscall
+	Personality *LinuxPersonality `json:"personality,omitempty"`
 }
 
 // LinuxNamespace is the configuration for a Linux namespace
@@ -384,6 +386,28 @@ type LinuxDeviceCgroup struct {
 	Minor *int64 `json:"minor,omitempty"`
 	// Cgroup access permissions format, rwm.
 	Access string `json:"access,omitempty"`
+}
+
+// LinuxPersonalityDomain refers to a personality domain.
+type LinuxPersonalityDomain string
+
+// LinuxPersonalityFlag refers to an additional personality flag. None are currently defined.
+type LinuxPersonalityFlag string
+
+// Define domain and flags for Personality
+const (
+	// PerLinux is the standard Linux personality
+	PerLinux LinuxPersonalityDomain = "LINUX"
+	// PerLinux32 sets personality to 32 bit
+	PerLinux32 LinuxPersonalityDomain = "LINUX32"
+)
+
+// LinuxPersonality represents the Linux personality syscall input
+type LinuxPersonality struct {
+	// Domain for the personality
+	Domain LinuxPersonalityDomain `json:"domain"`
+	// Additional flags
+	Flags []LinuxPersonalityFlag `json:"flags,omitempty"`
 }
 
 // Solaris contains platform-specific configuration for Solaris application containers.


### PR DESCRIPTION
A lot of people use the Linux `personality` support to allow a 64 bit machine
to emulate a 32 bit machine. In particular if you just run 32 bit binaries, many
build processes will fail as `uname` will still return a value appropriate for
a 64 bit system. Including the personality syscall wil change this to reflect the
value from a 32 bit system, such as `i686` rather than `x86_64`.

Note that this patch only supports the base 32 bit/64 bit calls. The other options
are largely obsolete and rarely used. I left flexibility to add other base domains
and to add flags in future, but I am not sure there is any demand for them. The
only use case I found in the recent past was the `ADDR_NO_RANDOMIZE` option that
disables ASLR, which older versions of Emacs required, but generally they set this
themselves, so it is not needed as a Runc option, and it is a serious security
reduction. The 32 bit option is different as if you are running 32 bit containers
for build, they generally do not know they are "supposed" to run 32 bit, and so
this option allows you do do the equivalent of running a `chroot` with `linux32`
as is often done on non containerised build systems.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>