### PR TITLE
Fix markdown escape in config-linux

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -394,9 +394,9 @@ For more information, see the kernel cgroups documentation about [HugeTLB][cgrou
 Each entry has the following structure:
 
 * **`pageSize`** *(string, REQUIRED)* - hugepage size
-    The value has the format "<size><unit-prefix>B" (64KB, 2MB, 1GB), and must match the <hugepagesize> of the
-    corresponding control file found in "/sys/fs/cgroup/hugetlb/hugetlb.<hugepagesize>.limit_in_bytes".
-    Values of <unit-prefix> are intended to be parsed using base 1024 ("1KB" = 1024, "1MB" = 1048576, etc).
+    The value has the format `<size><unit-prefix>B` (64KB, 2MB, 1GB), and must match the `<hugepagesize>` of the
+    corresponding control file found in `/sys/fs/cgroup/hugetlb/hugetlb.<hugepagesize>.limit_in_bytes`.
+    Values of `<unit-prefix>` are intended to be parsed using base 1024 ("1KB" = 1024, "1MB" = 1048576, etc).
 * **`limit`** *(uint64, REQUIRED)* - limit in bytes of *hugepagesize* HugeTLB usage
 
 #### Example


### PR DESCRIPTION
This fixes some escaping for the `<` and `>` characters in markdown:

master:
![Screenshot from 2019-06-18 19-37-42](https://user-images.githubusercontent.com/1467188/59706398-af499080-9200-11e9-93f0-0090ed73cae3.png)


With this PR:
![Screenshot from 2019-06-18 19-37-20](https://user-images.githubusercontent.com/1467188/59706391-ace73680-9200-11e9-827a-45d9acfe62d0.png)
