### PR TITLE
config-linux: support seccomp flags

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -586,6 +586,14 @@ The following parameters can be specified to set up seccomp:
     * `SCMP_ARCH_PARISC`
     * `SCMP_ARCH_PARISC64`
 
+* **`flags`** *(array of strings, OPTIONAL)* - list of flags to use with seccomp(2).
+
+    A valid list of constants is shown below.
+
+    * `SECCOMP_FILTER_FLAG_TSYNC`
+    * `SECCOMP_FILTER_FLAG_LOG`
+    * `SECCOMP_FILTER_FLAG_SPEC_ALLOW`
+
 * **`syscalls`** *(array of objects, OPTIONAL)* - match a syscall in seccomp.
 
     While this property is OPTIONAL, some values of `defaultAction` are not useful without `syscalls` entries.

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -197,6 +197,12 @@
                     "defaultAction": {
                         "$ref": "defs-linux.json#/definitions/SeccompAction"
                     },
+                    "flags": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "defs-linux.json#/definitions/SeccompFlag"
+                        }
+                    },
                     "architectures": {
                         "type": "array",
                         "items": {

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -42,6 +42,14 @@
                 "SCMP_ACT_ALLOW"
             ]
         },
+        "SeccompFlag": {
+            "type": "string",
+            "enum": [
+                "SECCOMP_FILTER_FLAG_TSYNC",
+                "SECCOMP_FILTER_FLAG_LOG",
+                "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
+            ]
+        },
         "SeccompOperators": {
             "type": "string",
             "enum": [

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -556,11 +556,15 @@ type VMImage struct {
 type LinuxSeccomp struct {
 	DefaultAction LinuxSeccompAction `json:"defaultAction"`
 	Architectures []Arch             `json:"architectures,omitempty"`
+	Flags         []LinuxSeccompFlag `json:"flags,omitempty"`
 	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
 }
 
 // Arch used for additional architectures
 type Arch string
+
+// LinuxSeccompFlag is a flag to pass to seccomp(2).
+type LinuxSeccompFlag string
 
 // Additional architectures permitted to be used for system calls
 // By default only the native architecture of the kernel is permitted


### PR DESCRIPTION
allow to specify what flags must be passed to seccomp(2) when
installing the filter.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>