### PR TITLE
Add new seccomp action

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -604,13 +604,14 @@ The following parameters can be specified to set up seccomp:
     * **`names`** *(array of strings, REQUIRED)* - the names of the syscalls.
         `names` MUST contain at least one entry.
     * **`action`** *(string, REQUIRED)* - the action for seccomp rules.
-        A valid list of constants as of libseccomp v2.3.2 is shown below.
+        A valid list of constants as of libseccomp v2.4.0 is shown below.
 
         * `SCMP_ACT_KILL`
         * `SCMP_ACT_TRAP`
         * `SCMP_ACT_ERRNO`
         * `SCMP_ACT_TRACE`
         * `SCMP_ACT_ALLOW`
+        * `SCMP_ACT_LOG`
 
     * **`args`** *(array of objects, OPTIONAL)* - the specific syscall in seccomp.
 

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -39,7 +39,8 @@
                 "SCMP_ACT_TRAP",
                 "SCMP_ACT_ERRNO",
                 "SCMP_ACT_TRACE",
-                "SCMP_ACT_ALLOW"
+                "SCMP_ACT_ALLOW",
+                "SCMP_ACT_LOG"
             ]
         },
         "SeccompFlag": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -599,6 +599,7 @@ const (
 	ActErrno LinuxSeccompAction = "SCMP_ACT_ERRNO"
 	ActTrace LinuxSeccompAction = "SCMP_ACT_TRACE"
 	ActAllow LinuxSeccompAction = "SCMP_ACT_ALLOW"
+	ActLog   LinuxSeccompAction = "SCMP_ACT_LOG"
 )
 
 // LinuxSeccompOperator used to match syscall arguments in Seccomp


### PR DESCRIPTION
Updating documentation with a new seccomp action made available on libseccomp v2.4.0.

PR to implement this on runC:
https://github.com/opencontainers/runc/pull/1951

Libseccomp release:
https://github.com/seccomp/libseccomp/releases/tag/v2.4.0

Signed-off-by: Paulo Gomes <paulo.gomes.uk@gmail.com>