### PR TITLE
Rebase #937

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -46,7 +46,7 @@ Specifications have a variety of different timelines in their lifecycle.
     This means a major release like a v1.0.0 or v2.0.0 release will take 1 month at minimum: one week for rc1, one week for rc2, one week for rc3, and one week for the major release itself.
     Maintainers SHOULD strive to make zero breaking changes during this cycle of release candidates and SHOULD restart the three-candidate count when a breaking change is introduced.
     For example if a breaking change is introduced in v1.0.0-rc2 then the series would end with v1.0.0-rc4 and v1.0.0.
-- Minor and patch releases SHOULD be made on an as-needed basis.
+* Minor and patch releases SHOULD be made on an as-needed basis.
 
 [charter]: https://www.opencontainers.org/about/governance
 

--- a/config-linux.md
+++ b/config-linux.md
@@ -34,7 +34,6 @@ The following parameters can be specified to set up namespaces:
     * **`uts`** the container will be able to have its own hostname and domain name.
     * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container.
     * **`cgroup`** the container will have an isolated view of the cgroup hierarchy.
-
 * **`path`** *(string, OPTIONAL)* - namespace file.
     This value MUST be an absolute path in the [runtime mount namespace](glossary.md#runtime-namespace).
     The runtime MUST place the container process in the namespace associated with that `path`.
@@ -48,31 +47,31 @@ If a `namespaces` field contains duplicated namespaces with same `type`, the run
 ### Example
 
 ```json
-    "namespaces": [
-        {
-            "type": "pid",
-            "path": "/proc/1234/ns/pid"
-        },
-        {
-            "type": "network",
-            "path": "/var/run/netns/neta"
-        },
-        {
-            "type": "mount"
-        },
-        {
-            "type": "ipc"
-        },
-        {
-            "type": "uts"
-        },
-        {
-            "type": "user"
-        },
-        {
-            "type": "cgroup"
-        }
-    ]
+"namespaces": [
+    {
+        "type": "pid",
+        "path": "/proc/1234/ns/pid"
+    },
+    {
+        "type": "network",
+        "path": "/var/run/netns/neta"
+    },
+    {
+        "type": "mount"
+    },
+    {
+        "type": "ipc"
+    },
+    {
+        "type": "uts"
+    },
+    {
+        "type": "user"
+    },
+    {
+        "type": "cgroup"
+    }
+]
 ```
 
 ## <a name="configLinuxUserNamespaceMappings" />User namespace mappings
@@ -92,20 +91,20 @@ Note that the number of mapping entries MAY be limited by the [kernel][user-name
 ### Example
 
 ```json
-    "uidMappings": [
-        {
-            "containerID": 0,
-            "hostID": 1000,
-            "size": 32000
-        }
-    ],
-    "gidMappings": [
-        {
-            "containerID": 0,
-            "hostID": 1000,
-            "size": 32000
-        }
-    ]
+"uidMappings": [
+    {
+        "containerID": 0,
+        "hostID": 1000,
+        "size": 32000
+    }
+],
+"gidMappings": [
+    {
+        "containerID": 0,
+        "hostID": 1000,
+        "size": 32000
+    }
+]
 ```
 
 ## <a name="configLinuxDevices" />Devices
@@ -130,26 +129,26 @@ The same `type`, `major` and `minor` SHOULD NOT be used for multiple devices.
 ### Example
 
 ```json
-    "devices": [
-        {
-            "path": "/dev/fuse",
-            "type": "c",
-            "major": 10,
-            "minor": 229,
-            "fileMode": 438,
-            "uid": 0,
-            "gid": 0
-        },
-        {
-            "path": "/dev/sda",
-            "type": "b",
-            "major": 8,
-            "minor": 0,
-            "fileMode": 432,
-            "uid": 0,
-            "gid": 0
-        }
-    ]
+"devices": [
+    {
+        "path": "/dev/fuse",
+        "type": "c",
+        "major": 10,
+        "minor": 229,
+        "fileMode": 438,
+        "uid": 0,
+        "gid": 0
+    },
+    {
+        "path": "/dev/sda",
+        "type": "b",
+        "major": 8,
+        "minor": 0,
+        "fileMode": 432,
+        "uid": 0,
+        "gid": 0
+    }
+]
 ```
 
 ### <a name="configLinuxDefaultDevices" />Default Devices
@@ -178,6 +177,7 @@ For more information, see the [kernel cgroups documentation][cgroup-v1].
 It can be used to either control the cgroups hierarchy for containers or to run a new process in an existing container.
 
 The value of `cgroupsPath` MUST be either an absolute path or a relative path.
+
 * In the case of an absolute path (starting with `/`), the runtime MUST take the path to be relative to the cgroups mount point.
 * In the case of a relative path (not starting with `/`), the runtime MAY interpret the path relative to a runtime-determined location in the cgroups hierarchy.
 
@@ -199,19 +199,19 @@ Runtimes MAY attach the container process to additional cgroup controllers beyon
 ### Example
 
 ```json
-    "cgroupsPath": "/myRuntime/myContainer",
-    "resources": {
-        "memory": {
-        "limit": 100000,
-        "reservation": 200000
-        },
-        "devices": [
-            {
-                "allow": false,
-                "access": "rwm"
-            }
-        ]
-   }
+"cgroupsPath": "/myRuntime/myContainer",
+"resources": {
+    "memory": {
+    "limit": 100000,
+    "reservation": 200000
+    },
+    "devices": [
+        {
+            "allow": false,
+            "access": "rwm"
+        }
+    ]
+}
 ```
 
 ### <a name="configLinuxDeviceWhitelist" />Device whitelist
@@ -232,26 +232,26 @@ Each entry has the following structure:
 #### Example
 
 ```json
-    "devices": [
-        {
-            "allow": false,
-            "access": "rwm"
-        },
-        {
-            "allow": true,
-            "type": "c",
-            "major": 10,
-            "minor": 229,
-            "access": "rw"
-        },
-        {
-            "allow": true,
-            "type": "b",
-            "major": 8,
-            "minor": 0,
-            "access": "r"
-        }
-    ]
+"devices": [
+    {
+        "allow": false,
+        "access": "rwm"
+    },
+    {
+        "allow": true,
+        "type": "c",
+        "major": 10,
+        "minor": 229,
+        "access": "rw"
+    },
+    {
+        "allow": true,
+        "type": "b",
+        "major": 8,
+        "minor": 0,
+        "access": "r"
+    }
+]
 ```
 
 ### <a name="configLinuxMemory" />Memory
@@ -281,15 +281,15 @@ The following properties do not specify memory limits, but are covered by the `m
 #### Example
 
 ```json
-    "memory": {
-        "limit": 536870912,
-        "reservation": 536870912,
-        "swap": 536870912,
-        "kernel": -1,
-        "kernelTCP": -1,
-        "swappiness": 0,
-        "disableOOMKiller": false
-    }
+"memory": {
+    "limit": 536870912,
+    "reservation": 536870912,
+    "swap": 536870912,
+    "kernel": -1,
+    "kernelTCP": -1,
+    "swappiness": 0,
+    "disableOOMKiller": false
+}
 ```
 
 ### <a name="configLinuxCPU" />CPU
@@ -310,15 +310,15 @@ The following parameters can be specified to set up the controller:
 #### Example
 
 ```json
-    "cpu": {
-        "shares": 1024,
-        "quota": 1000000,
-        "period": 500000,
-        "realtimeRuntime": 950000,
-        "realtimePeriod": 1000000,
-        "cpus": "2-3",
-        "mems": "0-7"
-    }
+"cpu": {
+    "shares": 1024,
+    "quota": 1000000,
+    "period": 500000,
+    "realtimeRuntime": 950000,
+    "realtimePeriod": 1000000,
+    "cpus": "2-3",
+    "mems": "0-7"
+}
 ```
 
 ### <a name="configLinuxBlockIO" />Block IO
@@ -354,37 +354,37 @@ The following parameters can be specified to set up the controller:
 #### Example
 
 ```json
-    "blockIO": {
-        "weight": 10,
-        "leafWeight": 10,
-        "weightDevice": [
-            {
-                "major": 8,
-                "minor": 0,
-                "weight": 500,
-                "leafWeight": 300
-            },
-            {
-                "major": 8,
-                "minor": 16,
-                "weight": 500
-            }
-        ],
-        "throttleReadBpsDevice": [
-            {
-                "major": 8,
-                "minor": 0,
-                "rate": 600
-            }
-        ],
-        "throttleWriteIOPSDevice": [
-            {
-                "major": 8,
-                "minor": 16,
-                "rate": 300
-            }
-        ]
-    }
+"blockIO": {
+    "weight": 10,
+    "leafWeight": 10,
+    "weightDevice": [
+        {
+            "major": 8,
+            "minor": 0,
+            "weight": 500,
+            "leafWeight": 300
+        },
+        {
+            "major": 8,
+            "minor": 16,
+            "weight": 500
+        }
+    ],
+    "throttleReadBpsDevice": [
+        {
+            "major": 8,
+            "minor": 0,
+            "rate": 600
+        }
+    ],
+    "throttleWriteIOPSDevice": [
+        {
+            "major": 8,
+            "minor": 16,
+            "rate": 300
+        }
+    ]
+}
 ```
 
 ### <a name="configLinuxHugePageLimits" />Huge page limits
@@ -404,16 +404,16 @@ Each entry has the following structure:
 #### Example
 
 ```json
-    "hugepageLimits": [
-        {
-            "pageSize": "2MB",
-            "limit": 209715200
-        },
-        {
-            "pageSize": "64KB",
-            "limit": 1000000
-        }
-   ]
+"hugepageLimits": [
+    {
+        "pageSize": "2MB",
+        "limit": 209715200
+    },
+    {
+        "pageSize": "64KB",
+        "limit": 1000000
+    }
+]
 ```
 
 ### <a name="configLinuxNetwork" />Network
@@ -432,19 +432,19 @@ The following parameters can be specified to set up the controller:
 #### Example
 
 ```json
-    "network": {
-        "classID": 1048577,
-        "priorities": [
-            {
-                "name": "eth0",
-                "priority": 500
-            },
-            {
-                "name": "eth1",
-                "priority": 1000
-            }
-        ]
-   }
+"network": {
+    "classID": 1048577,
+    "priorities": [
+        {
+            "name": "eth0",
+            "priority": 500
+        },
+        {
+            "name": "eth1",
+            "priority": 1000
+        }
+    ]
+}
 ```
 
 ### <a name="configLinuxPIDS" />PIDs
@@ -459,9 +459,9 @@ The following parameters can be specified to set up the controller:
 #### Example
 
 ```json
-    "pids": {
-        "limit": 32771
-   }
+"pids": {
+    "limit": 32771
+}
 ```
 
 ### <a name="configLinuxRDMA" />RDMA
@@ -497,8 +497,8 @@ You MUST specify at least one of the `hcaHandles` or `hcaObjects` in a given ent
 ## <a name="configLinuxIntelRdt" />IntelRdt
 
 **`intelRdt`** (object, OPTIONAL) represents the [Intel Resource Director Technology][intel-rdt-cat-kernel-interface].
-    If `intelRdt` is set, the runtime MUST write the container process ID to the `tasks` file in a proper sub-directory in a mounted `resctrl` pseudo-filesystem. That sub-directory name is specified by `closID` parameter.
-    If no mounted `resctrl` pseudo-filesystem is available in the [runtime mount namespace](glossary.md#runtime-namespace), the runtime MUST [generate an error](runtime.md#errors).
+If `intelRdt` is set, the runtime MUST write the container process ID to the `tasks` file in a proper sub-directory in a mounted `resctrl` pseudo-filesystem. That sub-directory name is specified by `closID` parameter.
+If no mounted `resctrl` pseudo-filesystem is available in the [runtime mount namespace](glossary.md#runtime-namespace), the runtime MUST [generate an error](runtime.md#errors).
 
 If `intelRdt` is not set, the runtime MUST NOT manipulate any `resctrl` pseudo-filesystems.
 
@@ -510,16 +510,17 @@ The following parameters can be specified for the container:
 * **`l3CacheSchema`** *(string, OPTIONAL)* - specifies the schema for L3 cache id and capacity bitmask (CBM).
     The value SHOULD start with `L3:` and SHOULD NOT contain newlines.
 * **`memBwSchema`** *(string, OPTIONAL)* - specifies the schema of memory bandwidth per L3 cache id.
-    The value MUST start with `MB:` and MUST NOT contain newlines.
+    * The value MUST start with `MB:` and MUST NOT contain newlines.
 
-    If both `l3CacheSchema` and `memBwSchema` are set, runtimes MUST write the combined value to the `schemata` file in that sub-directory discussed in `closID`.
-    If `l3CacheSchema` contains a line beginning with `MB:`, the value written to `schemata` file MUST be the non-`MB:` line(s) from `l3CacheSchema` and the line from `memBWSchema`.
+    * If both `l3CacheSchema` and `memBwSchema` are set, runtimes MUST write the combined value to the `schemata` file in that sub-directory discussed in `closID`.
 
-    If either `l3CacheSchema` or `memBwSchema` is set, runtimes MUST write the value to the `schemata` file in the that sub-directory discussed in `closID`.
+    * If `l3CacheSchema` contains a line beginning with `MB:`, the value written to `schemata` file MUST be the non-`MB:` line(s) from `l3CacheSchema` and the line from `memBWSchema`.
 
-    If neither `l3CacheSchema` nor `memBwSchema` is set, runtimes MUST NOT write to `schemata` files in any `resctrl` pseudo-filesystems.
+    * If either `l3CacheSchema` or `memBwSchema` is set, runtimes MUST write the value to the `schemata` file in the that sub-directory discussed in `closID`.
 
-    If `closID` is set, `l3CacheSchema` and/or `memBwSchema` is set, runtimes MUST compare `l3CacheSchema` and/or `memBwSchema` value with `schemata` file, and [generate an error](runtime.md#errors) if doesn't match.
+    * If neither `l3CacheSchema` nor `memBwSchema` is set, runtimes MUST NOT write to `schemata` files in any `resctrl` pseudo-filesystems.
+
+    * If `closID` is set, `l3CacheSchema` and/or `memBwSchema` is set, runtimes MUST compare `l3CacheSchema` and/or `memBwSchema` value with `schemata` file, and [generate an error](runtime.md#errors) if doesn't match.
 
 ### Example
 
@@ -547,10 +548,10 @@ For more information, see the [sysctl(8)][sysctl.8] man page.
 ### Example
 
 ```json
-    "sysctl": {
-        "net.ipv4.ip_forward": "1",
-        "net.core.somaxconn": "256"
-   }
+"sysctl": {
+    "net.ipv4.ip_forward": "1",
+    "net.core.somaxconn": "256"
+}
 ```
 
 ## <a name="configLinuxSeccomp" />Seccomp
@@ -565,7 +566,6 @@ The actions, architectures, and operators are strings that match the definitions
 The following parameters can be specified to set up seccomp:
 
 * **`defaultAction`** *(string, REQUIRED)* - the default action for seccomp. Allowed values are the same as `syscalls[].action`.
-
 * **`architectures`** *(array of strings, OPTIONAL)* - the architecture used for system calls.
     A valid list of constants as of libseccomp v2.3.2 is shown below.
 
@@ -597,10 +597,8 @@ The following parameters can be specified to set up seccomp:
     * `SECCOMP_FILTER_FLAG_SPEC_ALLOW`
 
 * **`syscalls`** *(array of objects, OPTIONAL)* - match a syscall in seccomp.
-
     While this property is OPTIONAL, some values of `defaultAction` are not useful without `syscalls` entries.
     For example, if `defaultAction` is `SCMP_ACT_KILL` and `syscalls` is empty or unset, the kernel will kill the container process on its first syscall.
-
     Each entry has the following structure:
 
     * **`names`** *(array of strings, REQUIRED)* - the names of the syscalls.
@@ -616,7 +614,6 @@ The following parameters can be specified to set up seccomp:
         * `SCMP_ACT_LOG`
 
     * **`args`** *(array of objects, OPTIONAL)* - the specific syscall in seccomp.
-
         Each entry has the following structure:
 
         * **`index`** *(uint, REQUIRED)* - the index for syscall arguments in seccomp.
@@ -636,60 +633,60 @@ The following parameters can be specified to set up seccomp:
 ### Example
 
 ```json
-    "seccomp": {
-        "defaultAction": "SCMP_ACT_ALLOW",
-        "architectures": [
-            "SCMP_ARCH_X86",
-            "SCMP_ARCH_X32"
-        ],
-        "syscalls": [
-            {
-                "names": [
-                    "getcwd",
-                    "chmod"
-                ],
-                "action": "SCMP_ACT_ERRNO"
-            }
-        ]
-    }
+"seccomp": {
+    "defaultAction": "SCMP_ACT_ALLOW",
+    "architectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+    ],
+    "syscalls": [
+        {
+            "names": [
+                "getcwd",
+                "chmod"
+            ],
+            "action": "SCMP_ACT_ERRNO"
+        }
+    ]
+}
 ```
 
 ## <a name="configLinuxRootfsMountPropagation" />Rootfs Mount Propagation
 
 **`rootfsPropagation`** (string, OPTIONAL) sets the rootfs's mount propagation.
-    Its value is either slave, private, shared or unbindable.
-    The [Shared Subtrees][sharedsubtree] article in the kernel documentation has more information about mount propagation.
+Its value is either slave, private, shared or unbindable.
+The [Shared Subtrees][sharedsubtree] article in the kernel documentation has more information about mount propagation.
 
 ### Example
 
 ```json
-    "rootfsPropagation": "slave",
+"rootfsPropagation": "slave",
 ```
 
 ## <a name="configLinuxMaskedPaths" />Masked Paths
 
 **`maskedPaths`** (array of strings, OPTIONAL) will mask over the provided paths inside the container so that they cannot be read.
-    The values MUST be absolute paths in the [container namespace](glossary.md#container_namespace).
+The values MUST be absolute paths in the [container namespace](glossary.md#container_namespace).
 
 ### Example
 
 ```json
-    "maskedPaths": [
-        "/proc/kcore"
-    ]
+"maskedPaths": [
+    "/proc/kcore"
+]
 ```
 
 ## <a name="configLinuxReadonlyPaths" />Readonly Paths
 
 **`readonlyPaths`** (array of strings, OPTIONAL) will set the provided paths as readonly inside the container.
-    The values MUST be absolute paths in the [container namespace](glossary.md#container-namespace).
+The values MUST be absolute paths in the [container namespace](glossary.md#container-namespace).
 
 ### Example
 
 ```json
-    "readonlyPaths": [
-        "/proc/sys"
-    ]
+"readonlyPaths": [
+    "/proc/sys"
+]
 ```
 
 ## <a name="configLinuxMountLabel" />Mount Label
@@ -699,7 +696,7 @@ The following parameters can be specified to set up seccomp:
 ### Example
 
 ```json
-    "mountLabel": "system_u:object_r:svirt_sandbox_file_t:s0:c715,c811"
+"mountLabel": "system_u:object_r:svirt_sandbox_file_t:s0:c715,c811"
 ```
 
 ## <a name="configLinuxPersonality" />Personality

--- a/config-solaris.md
+++ b/config-solaris.md
@@ -47,7 +47,7 @@ cappedCPU is mapped to `capped-cpu` in [zonecfg(1M)][zonecfg.1m_2] man page.
 ### Example
 ```json
 "cappedCPU": {
-        "ncpus": "8"
+    "ncpus": "8"
 }
 ```
 
@@ -62,8 +62,8 @@ cappedMemory is mapped to `capped-memory` in [zonecfg(1M)][zonecfg.1m_2] man pag
 ### Example
 ```json
 "cappedMemory": {
-        "physical": "512m",
-        "swap": "512m"
+    "physical": "512m",
+    "swap": "512m"
 }
 ```
 

--- a/config-windows.md
+++ b/config-windows.md
@@ -6,19 +6,19 @@ The Windows container specification uses APIs provided by the Windows Host Compu
 ## <a name="configWindowsLayerFolders" />LayerFolders
 
 **`layerFolders`** (array of strings, REQUIRED) specifies a list of layer folders the container image relies on. The list is ordered from topmost layer to base layer with the last entry being the scratch.
-  `layerFolders` MUST contain at least one entry.
+`layerFolders` MUST contain at least one entry.
 
 ### Example
 
 ```json
-    "windows": {
-        "layerFolders": [
-            "C:\\Layers\\layer2",
-            "C:\\Layers\\layer1",
-            "C:\\Layers\\layer-base",
-            "C:\\scratch",
-        ]
-    }
+"windows": {
+    "layerFolders": [
+        "C:\\Layers\\layer2",
+        "C:\\Layers\\layer1",
+        "C:\\Layers\\layer-base",
+        "C:\\scratch",
+    ]
+}
 ```
 
 ## <a name="configWindowsDevices" />Devices
@@ -35,18 +35,18 @@ Each entry has the following structure:
 ### Example
 
 ```json
-    "windows": {
-        "devices": [
-            {
-                "id": "24E552D7-6523-47F7-A647-D3465BF1F5CA",
-                "idType": "class"
-            },
-            {
-                "id": "5175d334-c371-4806-b3ba-71fd53c9258d",
-                "idType": "class"
-            }
-        ]
-    }
+"windows": {
+    "devices": [
+        {
+            "id": "24E552D7-6523-47F7-A647-D3465BF1F5CA",
+            "idType": "class"
+        },
+        {
+            "id": "5175d334-c371-4806-b3ba-71fd53c9258d",
+            "idType": "class"
+        }
+    ]
+}
 ```
 
 ## <a name="configWindowsResources" />Resources
@@ -64,13 +64,13 @@ The following parameters can be specified:
 #### Example
 
 ```json
-    "windows": {
-        "resources": {
-            "memory": {
-                "limit": 2097152
-            }
+"windows": {
+    "resources": {
+        "memory": {
+            "limit": 2097152
         }
     }
+}
 ```
 
 ### <a name="configWindowsCpu" />CPU
@@ -86,13 +86,13 @@ The following parameters can be specified:
 #### Example
 
 ```json
-    "windows": {
-        "resources": {
-            "cpu": {
-                "maximum": 5000
-            }
+"windows": {
+    "resources": {
+        "cpu": {
+            "maximum": 5000
         }
     }
+}
 ```
 
 ### <a name="configWindowsStorage" />Storage
@@ -108,13 +108,13 @@ The following parameters can be specified:
 #### Example
 
 ```json
-    "windows": {
-        "resources": {
-            "storage": {
-                "iops": 50
-            }
+"windows": {
+    "resources": {
+        "storage": {
+            "iops": 50
         }
     }
+}
 ```
 
 ## <a name="configWindowsNetwork" />Network
@@ -132,20 +132,20 @@ The following parameters can be specified:
 ### Example
 
 ```json
-    "windows": {
-        "network": {
-            "endpointList": [
-                "7a010682-17e0-4455-a838-02e5d9655fe6"
-            ],
-            "allowUnqualifiedDNSQuery": true,
-            "DNSSearchList": [
-                "a.com",
-                "b.com"
-            ],
-            "networkSharedContainerName": "containerName",
-            "networkNamespace": "168f3daf-efc6-4377-b20a-2c86764ba892"
-        }
-   }
+"windows": {
+    "network": {
+        "endpointList": [
+            "7a010682-17e0-4455-a838-02e5d9655fe6"
+        ],
+        "allowUnqualifiedDNSQuery": true,
+        "DNSSearchList": [
+            "a.com",
+            "b.com"
+        ],
+        "networkSharedContainerName": "containerName",
+        "networkNamespace": "168f3daf-efc6-4377-b20a-2c86764ba892"
+    }
+}
 ```
 
 ## <a name="configWindowsCredentialSpec" />Credential Spec
@@ -167,9 +167,9 @@ You can indicate that a container should be started in a mode to apply pending s
 ### Example
 
 ```json
-    "windows": {
-        "servicing": true
-    }
+"windows": {
+    "servicing": true
+}
 ```
 
 ## <a name="configWindowsIgnoreFlushesDuringBoot" />IgnoreFlushesDuringBoot
@@ -179,9 +179,9 @@ You can indicate that a container should be started in an a mode where disk flus
 ### Example
 
 ```json
-    "windows": {
-        "ignoreFlushesDuringBoot": true
-    }
+"windows": {
+    "ignoreFlushesDuringBoot": true
+}
 ```
 
 ## <a name="configWindowsHyperV" />HyperV
@@ -199,9 +199,9 @@ The following parameters can be specified:
 ### Example
 
 ```json
-    "windows": {
-        "hyperv": {
-            "utilityVMPath": "C:\\path\\to\\utilityvm"
-        }
+"windows": {
+    "hyperv": {
+        "utilityVMPath": "C:\\path\\to\\utilityvm"
     }
+}
 ```

--- a/config.md
+++ b/config.md
@@ -21,7 +21,7 @@ For all platform-specific configuration values, the scope defined below in the [
 ### Example
 
 ```json
-    "ociVersion": "0.1.0"
+"ociVersion": "0.1.0"
 ```
 
 ## <a name="configRoot" />Root
@@ -33,9 +33,7 @@ For [Hyper-V Containers](config-windows.md#hyperv), this field MUST NOT be set.
 On all other platforms, this field is REQUIRED.
 
 * **`path`** (string, REQUIRED) Specifies the path to the root filesystem for the container.
-
     * On Windows, `path` MUST be a [volume GUID path][naming-a-volume].
-
     * On POSIX platforms, `path` is either an absolute path or a relative path to the bundle.
         For example, with a bundle at `/to/bundle` and a root filesystem at `/to/bundle/rootfs`, the `path` value can be either `/to/bundle/rootfs` or `rootfs`.
         The value SHOULD be the conventional `rootfs`.
@@ -65,9 +63,9 @@ On all other platforms, this field is REQUIRED.
 ## <a name="configMounts" />Mounts
 
 **`mounts`** (array of objects, OPTIONAL) specifies additional mounts beyond [`root`](#root).
-    The runtime MUST mount entries in the listed order.
-    For Linux, the parameters are as documented in [mount(2)][mount.2] system call man page.
-    For Solaris, the mount entry corresponds to the 'fs' resource in the [zonecfg(1M)][zonecfg.1m] man page.
+The runtime MUST mount entries in the listed order.
+For Linux, the parameters are as documented in [mount(2)][mount.2] system call man page.
+For Solaris, the mount entry corresponds to the 'fs' resource in the [zonecfg(1M)][zonecfg.1m] man page.
 
 * **`destination`** (string, REQUIRED) Destination of mount point: path inside container.
     This value MUST be an absolute path.
@@ -101,8 +99,8 @@ On all other platforms, this field is REQUIRED.
 For POSIX platforms the `mounts` structure has the following fields:
 
 * **`type`** (string, OPTIONAL) The type of the filesystem to be mounted.
-  * Linux: filesystem types supported by the kernel as listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). For bind mounts (when `options` include either `bind` or `rbind`), the type is a dummy, often "none" (not listed in */proc/filesystems*).
-  * Solaris: corresponds to "type" of the fs resource in [zonecfg(1M)][zonecfg.1m].
+    * Linux: filesystem types supported by the kernel as listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). For bind mounts (when `options` include either `bind` or `rbind`), the type is a dummy, often "none" (not listed in */proc/filesystems*).
+    * Solaris: corresponds to "type" of the fs resource in [zonecfg(1M)][zonecfg.1m].
 
 ### Example (Linux)
 
@@ -144,7 +142,7 @@ For POSIX platforms the `mounts` structure has the following fields:
 ## <a name="configProcess" />Process
 
 **`process`** (object, OPTIONAL) specifies the container process.
-    This property is REQUIRED when [`start`](runtime.md#start) is called.
+This property is REQUIRED when [`start`](runtime.md#start) is called.
 
 * **`terminal`** (bool, OPTIONAL) specifies whether a terminal is attached to the process, defaults to false.
     As an example, if set to true on Linux a pseudoterminal pair is allocated for the process and the pseudoterminal slave is duplicated on the process's [standard streams][stdin.3].
@@ -494,69 +492,69 @@ See the below table for a summary of hooks and when they are called:
 ### Example
 
 ```json
-    "hooks": {
-        "prestart": [
-            {
-                "path": "/usr/bin/fix-mounts",
-                "args": ["fix-mounts", "arg1", "arg2"],
-                "env":  [ "key1=value1"]
-            },
-            {
-                "path": "/usr/bin/setup-network"
-            }
-        ],
-        "createRuntime": [
-            {
-                "path": "/usr/bin/fix-mounts",
-                "args": ["fix-mounts", "arg1", "arg2"],
-                "env":  [ "key1=value1"]
-            },
-            {
-                "path": "/usr/bin/setup-network"
-            }
-        ],
-        "createContainer": [
-            {
-                "path": "/usr/bin/mount-hook",
-                "args": ["-mount", "arg1", "arg2"],
-                "env":  [ "key1=value1"]
-            }
-        ],
-        "startContainer": [
-            {
-                "path": "/usr/bin/refresh-ldcache"
-            }
-        ],
-        "poststart": [
-            {
-                "path": "/usr/bin/notify-start",
-                "timeout": 5
-            }
-        ],
-        "poststop": [
-            {
-                "path": "/usr/sbin/cleanup.sh",
-                "args": ["cleanup.sh", "-f"]
-            }
-        ]
-    }
+"hooks": {
+    "prestart": [
+        {
+            "path": "/usr/bin/fix-mounts",
+            "args": ["fix-mounts", "arg1", "arg2"],
+            "env":  [ "key1=value1"]
+        },
+        {
+            "path": "/usr/bin/setup-network"
+        }
+    ],
+    "createRuntime": [
+        {
+            "path": "/usr/bin/fix-mounts",
+            "args": ["fix-mounts", "arg1", "arg2"],
+            "env":  [ "key1=value1"]
+        },
+        {
+            "path": "/usr/bin/setup-network"
+        }
+    ],
+    "createContainer": [
+        {
+            "path": "/usr/bin/mount-hook",
+            "args": ["-mount", "arg1", "arg2"],
+            "env":  [ "key1=value1"]
+        }
+    ],
+    "startContainer": [
+        {
+            "path": "/usr/bin/refresh-ldcache"
+        }
+    ],
+    "poststart": [
+        {
+            "path": "/usr/bin/notify-start",
+            "timeout": 5
+        }
+    ],
+    "poststop": [
+        {
+            "path": "/usr/sbin/cleanup.sh",
+            "args": ["cleanup.sh", "-f"]
+        }
+    ]
+}
 ```
 
 ## <a name="configAnnotations" />Annotations
 
 **`annotations`** (object, OPTIONAL) contains arbitrary metadata for the container.
-    This information MAY be structured or unstructured.
-    Annotations MUST be a key-value map.
-    If there are no annotations then this property MAY either be absent or an empty map.
+This information MAY be structured or unstructured.
+Annotations MUST be a key-value map.
+If there are no annotations then this property MAY either be absent or an empty map.
 
-    Keys MUST be strings.
-    Keys MUST NOT be an empty string.
-    Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
-    Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
-    Runtimes MUST handle unknown annotation keys like any other [unknown property](#extensibility).
+Keys MUST be strings.
+Keys MUST NOT be an empty string.
+Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
+Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
+Runtimes MUST handle unknown annotation keys like any other [unknown property](#extensibility).
 
-    Values MUST be strings.
-    Values MAY be an empty string.
+Values MUST be strings.
+Values MAY be an empty string.
 
 ```json
 "annotations": {


### PR DESCRIPTION
@vbatts [asked](https://github.com/opencontainers/runtime-spec/issues/1010#issuecomment-582040551) if I could rebase #937 by @Mashimiao, which I did here.

There were some trivial conflicts in `config.md`, `config-linux.md` & `config-windows.md`. The only question was whether to add asterisks around `l3cacheSchema`, compare the original [here](https://github.com/opencontainers/runtime-spec/pull/937/files#r375104291). I went and added them here as well, but those can easily be removed.