### PR TITLE
Clarify case with pre-configured Intel RDT closID

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -522,6 +522,9 @@ The following parameters can be specified for the container:
 
     * If `closID` is set, `l3CacheSchema` and/or `memBwSchema` is set, runtimes MUST compare `l3CacheSchema` and/or `memBwSchema` value with `schemata` file, and [generate an error](runtime.md#errors) if doesn't match.
 
+    * If `closID` is set, and neither of `l3CacheSchema` and `memBwSchema` are set, runtime MUST check if corresponding pre-configured directory `closID` is present in mounted `resctrl`. If such pre-configured directory `closID` exists, runtime MUST assign container to this `closID` and [generate an error](runtime.md#errors) if directory does not exist.
+
+
 ### Example
 
 Consider a two-socket machine with two L3 caches where the default CBM is 0x7ff and the max CBM length is 11 bits,


### PR DESCRIPTION
System administrators can pre-configure set of closIDs that can
be assigned to containers. If closID is specified and present,
runtime can just assign container to it.