### PR TITLE
Add the specification of seccomp userspace notification

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -624,6 +624,9 @@ The following parameters can be specified to set up seccomp:
     * `SECCOMP_FILTER_FLAG_TSYNC`
     * `SECCOMP_FILTER_FLAG_LOG`
     * `SECCOMP_FILTER_FLAG_SPEC_ALLOW`
+    * `SECCOMP_FILTER_FLAG_NEW_LISTENER`
+
+* **`listenerPath`** *(string, OPTIONAL)* - specifies the path of UNIX domain socket which the runtime will pass the file descriptor of seccomp notification using SCM_RIGHT to.
 
 * **`syscalls`** *(array of objects, OPTIONAL)* - match a syscall in seccomp.
     While this property is OPTIONAL, some values of `defaultAction` are not useful without `syscalls` entries.
@@ -633,7 +636,7 @@ The following parameters can be specified to set up seccomp:
     * **`names`** *(array of strings, REQUIRED)* - the names of the syscalls.
         `names` MUST contain at least one entry.
     * **`action`** *(string, REQUIRED)* - the action for seccomp rules.
-        A valid list of constants as of libseccomp v2.4.0 is shown below.
+        A valid list of constants is shown below.
 
         * `SCMP_ACT_KILL`
         * `SCMP_ACT_KILL_PROCESS`
@@ -642,6 +645,7 @@ The following parameters can be specified to set up seccomp:
         * `SCMP_ACT_TRACE`
         * `SCMP_ACT_ALLOW`
         * `SCMP_ACT_LOG`
+        * `SCMP_ACT_NOTIFY`
 
     * **`errnoRet`** *(uint, OPTIONAL)* - the errno return code to use.
         Some actions like `SCMP_ACT_ERRNO` and `SCMP_ACT_TRACE` allow to specify the errno

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -209,6 +209,9 @@
                             "$ref": "defs-linux.json#/definitions/SeccompFlag"
                         }
                     },
+                    "listenerPath": {
+                        "type": "string"
+                    },
                     "architectures": {
                         "type": "array",
                         "items": {

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -60,7 +60,8 @@
                 "SCMP_ACT_ERRNO",
                 "SCMP_ACT_TRACE",
                 "SCMP_ACT_ALLOW",
-                "SCMP_ACT_LOG"
+                "SCMP_ACT_LOG",
+                "SCMP_ACT_NOTIFY"
             ]
         },
         "SeccompFlag": {
@@ -68,7 +69,8 @@
             "enum": [
                 "SECCOMP_FILTER_FLAG_TSYNC",
                 "SECCOMP_FILTER_FLAG_LOG",
-                "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
+                "SECCOMP_FILTER_FLAG_SPEC_ALLOW",
+                "SECCOMP_FILTER_FLAG_NEW_LISTENER"
             ]
         },
         "SeccompOperators": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -601,6 +601,7 @@ type LinuxSeccomp struct {
 	DefaultAction LinuxSeccompAction `json:"defaultAction"`
 	Architectures []Arch             `json:"architectures,omitempty"`
 	Flags         []LinuxSeccompFlag `json:"flags,omitempty"`
+	ListenerPath  string             `json:"listenerPath,omitempty"`
 	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
 }
 
@@ -646,6 +647,7 @@ const (
 	ActTrace       LinuxSeccompAction = "SCMP_ACT_TRACE"
 	ActAllow       LinuxSeccompAction = "SCMP_ACT_ALLOW"
 	ActLog         LinuxSeccompAction = "SCMP_ACT_LOG"
+	ActNotify      LinuxSeccompAction = "SCMP_ACT_NOTIFY"
 )
 
 // LinuxSeccompOperator used to match syscall arguments in Seccomp


### PR DESCRIPTION
This commit adds the specification of seccomp userspace notification.

The runtime will pass the file descriptor of seccomp notification via the UNIX domain socket using SCM_RIGHT to **"listenerPath"**.
The reference link is below.
https://www.kernel.org/doc/html/v5.0/userspace-api/seccomp_filter.html#userspace-notification

I want to share our background. As Sony, we are building our rootless embedded container system. We need to hook some syscalls like mount(2) or mknod(2) inside our container and handle those syscalls in userspace in accordance with our use case.
I think this specification is useful for all container users, especially rootless container users.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>