### PR TITLE
seccomp: allow to override errno return code

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -616,6 +616,10 @@ The following parameters can be specified to set up seccomp:
         * `SCMP_ACT_ALLOW`
         * `SCMP_ACT_LOG`
 
+    * **`errnoRet`** *(uint, OPTIONAL)* - the errno return code to use.
+        Some actions like `SCMP_ACT_ERRNO` and `SCMP_ACT_TRACE` allow to specify the errno
+        code to return. If not specified its default value is `EPERM`.
+
     * **`args`** *(array of objects, OPTIONAL)* - the specific syscall in seccomp.
         Each entry has the following structure:
 

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -116,6 +116,9 @@
                 "action": {
                     "$ref": "#/definitions/SeccompAction"
                 },
+                "errnoRet": {
+                    "$ref": "defs.json#/definitions/uint32"
+                },
                 "args": {
                     "type": "array",
                     "items": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -667,9 +667,10 @@ type LinuxSeccompArg struct {
 
 // LinuxSyscall is used to match a syscall in Seccomp
 type LinuxSyscall struct {
-	Names  []string           `json:"names"`
-	Action LinuxSeccompAction `json:"action"`
-	Args   []LinuxSeccompArg  `json:"args,omitempty"`
+	Names    []string           `json:"names"`
+	Action   LinuxSeccompAction `json:"action"`
+	ErrnoRet uint               `json:"errno"`
+	Args     []LinuxSeccompArg  `json:"args,omitempty"`
 }
 
 // LinuxIntelRdt has container runtime resource constraints for Intel RDT


### PR DESCRIPTION
some seccomp actions allow to specify the errno code returned for the
syscall.

Add a new attribute to the seccomp syscall so the default EPERM can be
overriden.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>