### PR TITLE
seccomp: fix go-specs for errnoRet

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -669,7 +669,7 @@ type LinuxSeccompArg struct {
 type LinuxSyscall struct {
 	Names    []string           `json:"names"`
 	Action   LinuxSeccompAction `json:"action"`
-	ErrnoRet uint               `json:"errno"`
+	ErrnoRet *uint              `json:"errnoRet,omitempty"`
 	Args     []LinuxSeccompArg  `json:"args,omitempty"`
 }
 


### PR DESCRIPTION
commit 3bfcde28eab5d7e107ddd3771fc92399332932a8 introduced errnoRet
for seccomp syscalls but the Go specs were not implemented correctly.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>