### PR TITLE
seccomp: Add support for SCMP_ACT_KILL_PROCESS

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -610,6 +610,7 @@ The following parameters can be specified to set up seccomp:
         A valid list of constants as of libseccomp v2.4.0 is shown below.
 
         * `SCMP_ACT_KILL`
+        * `SCMP_ACT_KILL_PROCESS`
         * `SCMP_ACT_TRAP`
         * `SCMP_ACT_ERRNO`
         * `SCMP_ACT_TRACE`

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -54,6 +54,7 @@
             "type": "string",
             "enum": [
                 "SCMP_ACT_KILL",
+                "SCMP_ACT_KILL_PROCESS",
                 "SCMP_ACT_TRAP",
                 "SCMP_ACT_ERRNO",
                 "SCMP_ACT_TRACE",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -635,12 +635,13 @@ type LinuxSeccompAction string
 
 // Define actions for Seccomp rules
 const (
-	ActKill  LinuxSeccompAction = "SCMP_ACT_KILL"
-	ActTrap  LinuxSeccompAction = "SCMP_ACT_TRAP"
-	ActErrno LinuxSeccompAction = "SCMP_ACT_ERRNO"
-	ActTrace LinuxSeccompAction = "SCMP_ACT_TRACE"
-	ActAllow LinuxSeccompAction = "SCMP_ACT_ALLOW"
-	ActLog   LinuxSeccompAction = "SCMP_ACT_LOG"
+	ActKill        LinuxSeccompAction = "SCMP_ACT_KILL"
+	ActKillProcess LinuxSeccompAction = "SCMP_ACT_KILL_PROCESS"
+	ActTrap        LinuxSeccompAction = "SCMP_ACT_TRAP"
+	ActErrno       LinuxSeccompAction = "SCMP_ACT_ERRNO"
+	ActTrace       LinuxSeccompAction = "SCMP_ACT_TRACE"
+	ActAllow       LinuxSeccompAction = "SCMP_ACT_ALLOW"
+	ActLog         LinuxSeccompAction = "SCMP_ACT_LOG"
 )
 
 // LinuxSeccompOperator used to match syscall arguments in Seccomp


### PR DESCRIPTION
Adds support for SCMP_ACT_KILL_PROCESS, which allows users to kill the entire process when a syscall blocked by seccomp is called.

Signed-off-by: Paulo Gomes <pjbgf@linux.com>