### PR TITLE
Define State for container and runtime namespace

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -22,7 +22,9 @@ The state of a container includes the following properties:
     * `stopped`: the container process has exited (step 7 in the [lifecycle](#lifecycle))
 
     Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
-* **`pid`** (int, REQUIRED when `status` is `created` or `running` on Linux, OPTIONAL on other platforms) is the ID of the container process, as seen by the host.
+* **`pid`** (int, REQUIRED when `status` is `created` or `running` on Linux, OPTIONAL on other platforms) is the ID of the container process.
+  For hooks executed in the runtime namespace, it is the pid as seen by the runtime.
+  For hooks executed in the container namespace, it is the pid as seen by the container.
 * **`bundle`** (string, REQUIRED) is the absolute path to the container's bundle directory.
     This is provided so that consumers can find the container's configuration and root filesystem on the host.
 * **`annotations`** (map, OPTIONAL) contains the list of annotations associated with the container.


### PR DESCRIPTION
Hello!

As a followup of the OCI Weekly Discussion on 5/20/2020, as well as discussions on the runc [hooks Pull Request](https://github.com/opencontainers/runc/pull/2229#discussion_r426957106), I've updated the definition of the PID field for the state structure.

We are updating it with the following definition in mind:
- Runtime namespace hooks get runtime/absolute information
- Container Namespace hooks get container/relative information

/cc @cyphar @mrunalp @mikebrow 

Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>