### PR TITLE
Add State status constants to spec-go

### DIFF
--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -1,18 +1,21 @@
 package specs
 
+// ContainerState represents the state of a container.
+type ContainerState string
+
 const (
 	// StateCreating indicates that the container is being created
-	StateCreating = "creating"
+	StateCreating ContainerState  = "creating"
 
 	// StateCreated indicates that the runtime has finished the create operation
-	StateCreated = "created"
+	StateCreated ContainerState  = "created"
 
 	// StateRunning indicates that the container process has executed the
 	// user-specified program but has not exited
-	StateRunning = "running"
+	StateRunning ContainerState  = "running"
 
 	// StateStopped indicates that the container process has exited
-	StateStopped = "stopped"
+	StateStopped ContainerState  = "stopped"
 )
 
 // State holds information about the runtime state of the container.

--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -1,5 +1,20 @@
 package specs
 
+const (
+	// StateCreating indicates that the container is being created
+	StateCreating = "creating"
+
+	// StateCreated indicates that the runtime has finished the create operation
+	StateCreated = "created"
+
+	// StateRunning indicates that the container process has executed the
+	// user-specified program but has not exited
+	StateRunning = "running"
+
+	// StateStopped indicates that the container process has exited
+	StateStopped = "stopped"
+)
+
 // State holds information about the runtime state of the container.
 type State struct {
 	// Version is the version of the specification that is supported.


### PR DESCRIPTION
Hello!

The [State definition ](https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#state) defines 4 constants for the status field that are not present in the specs-go

This PR adds them to the state.go file to make it available to runc.
/cc @cyphar @mrunalp @mikebrow


Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>