### PR TITLE
Change all references from whitelist to allowlist

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -120,7 +120,7 @@ Each entry has the following structure:
     If a [file][] already exists at `path` that does not match the requested device, the runtime MUST generate an error.
 * **`major, minor`** *(int64, REQUIRED unless `type` is `p`)* - [major, minor numbers][devices] for the device.
 * **`fileMode`** *(uint32, OPTIONAL)* - file mode for the device.
-    You can also control access to devices [with cgroups](#device-whitelist).
+    You can also control access to devices [with cgroups](#configLinuxDeviceAllowedlist).
 * **`uid`** *(uint32, OPTIONAL)* - id of device owner in the [container namespace](glossary.md#container-namespace).
 * **`gid`** *(uint32, OPTIONAL)* - id of device group in the [container namespace](glossary.md#container-namespace).
 
@@ -161,7 +161,7 @@ In addition to any devices configured with this setting, the runtime MUST also s
 * [`/dev/random`][random.4]
 * [`/dev/urandom`][random.4]
 * [`/dev/tty`][tty.4]
-* `/dev/console` is set up if [`terminal`](config.md#process) is enabled in the config by bind mounting the pseudoterminal slave to `/dev/console`.
+* `/dev/console` is set up if [`terminal`](config.md#process) is enabled in the config by bind mounting the pseudoterminal pty to `/dev/console`.
 * [`/dev/ptmx`][pts.4].
   A [bind-mount or symlink of the container's `/dev/pts/ptmx`][devpts].
 
@@ -214,9 +214,9 @@ Runtimes MAY attach the container process to additional cgroup controllers beyon
 }
 ```
 
-### <a name="configLinuxDeviceWhitelist" />Device whitelist
+### <a name="configLinuxDeviceAllowedlist" />Allowed Device list
 
-**`devices`** (array of objects, OPTIONAL) configures the [device whitelist][cgroup-v1-devices].
+**`devices`** (array of objects, OPTIONAL) configures the [allowed device list][cgroup-v1-devices].
 The runtime MUST apply entries in the listed order.
 
 Each entry has the following structure:

--- a/config.md
+++ b/config.md
@@ -145,7 +145,7 @@ For POSIX platforms the `mounts` structure has the following fields:
 This property is REQUIRED when [`start`](runtime.md#start) is called.
 
 * **`terminal`** (bool, OPTIONAL) specifies whether a terminal is attached to the process, defaults to false.
-    As an example, if set to true on Linux a pseudoterminal pair is allocated for the process and the pseudoterminal slave is duplicated on the process's [standard streams][stdin.3].
+    As an example, if set to true on Linux a pseudoterminal pair is allocated for the process and the pseudoterminal pty is duplicated on the process's [standard streams][stdin.3].
 * **`consoleSize`** (object, OPTIONAL) specifies the console size in characters of the terminal.
     Runtimes MUST ignore `consoleSize` if `terminal` is `false` or unset.
     * **`height`** (uint, REQUIRED)

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -60,7 +60,7 @@ type Process struct {
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// LinuxCapabilities specifies the whitelist of capabilities that are kept for a process.
+// LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
 // http://man7.org/linux/man-pages/man7/capabilities.7.html
 type LinuxCapabilities struct {
 	// Bounding is the set of capabilities checked by the kernel.
@@ -354,7 +354,7 @@ type LinuxRdma struct {
 
 // LinuxResources has container runtime resource constraints
 type LinuxResources struct {
-	// Devices configures the device whitelist.
+	// Devices configures the device allowlist.
 	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
 	// Memory restriction configuration
 	Memory *LinuxMemory `json:"memory,omitempty"`
@@ -392,7 +392,8 @@ type LinuxDevice struct {
 	GID *uint32 `json:"gid,omitempty"`
 }
 
-// LinuxDeviceCgroup represents a device rule for the whitelist controller
+// LinuxDeviceCgroup represents a device rule for the devices specified to
+// the device controller
 type LinuxDeviceCgroup struct {
 	// Allow or deny
 	Allow bool `json:"allow"`


### PR DESCRIPTION
We want to move to more enclusive names/terms in our code, and remove problematic language
from code and comments.

We want to change reference for whitelist/blacklist to allowlist/denylist.

https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>