### PR TITLE
Update State structure to use the new ContainerState type

### DIFF
--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -25,7 +25,7 @@ type State struct {
 	// ID is the container ID
 	ID string `json:"id"`
 	// Status is the runtime status of the container.
-	Status string `json:"status"`
+	Status ContainerState `json:"status"`
 	// Pid is the process ID for the container process.
 	Pid int `json:"pid,omitempty"`
 	// Bundle is the path to the container's bundle directory.


### PR DESCRIPTION
Following up on @kolyshkin 's [comment](https://github.com/opencontainers/runtime-spec/pull/1046#discussion_r457674394), we realized I should have updated the `State` structure to use that new type.

Thanks for picking up on this mistake!

/cc @kolyshkin @titanous 
Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>