### PR TITLE
Fix int64 and uint64 type value ranges

### DIFF
--- a/schema/defs.json
+++ b/schema/defs.json
@@ -18,8 +18,8 @@
         },
         "int64": {
             "type": "integer",
-            "minimum": -9223372036854776000,
-            "maximum": 9223372036854776000
+            "minimum": -9223372036854775808,
+            "maximum": 9223372036854775807
         },
         "uint8": {
             "type": "integer",
@@ -39,7 +39,7 @@
         "uint64": {
             "type": "integer",
             "minimum": 0,
-            "maximum": 18446744073709552000
+            "maximum": 18446744073709551615
         },
         "percent": {
             "type": "integer",


### PR DESCRIPTION
Fixes #1051, making the schema definition for 'int64' and 'uint64' types have the expected ranges:
* `int64` minimum is -2^63
* `int64` maximum is 2^63-1
* `uint64` maximum is 2^64-1

Signed-off-by: John Bartholomew <jpa.bartholomew@gmail.com>