### PR TITLE
Add type alias for ContainerState for compatibility

### DIFF
--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -1,7 +1,7 @@
 package specs
 
 // ContainerState represents the state of a container.
-type ContainerState string
+type ContainerState = string
 
 const (
 	// StateCreating indicates that the container is being created


### PR DESCRIPTION
Not sure the original purpose of this breaking change.
Others still can assign State.Status with `ContainerState("whatever")`.
Actually Go doesn't have a proper Enum type.

So I propose we keep the compatibility with less effort.