### PR TITLE
Add support for SCMP_ACT_KILL_THREAD

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -637,6 +637,7 @@ The following parameters can be specified to set up seccomp:
 
         * `SCMP_ACT_KILL`
         * `SCMP_ACT_KILL_PROCESS`
+        * `SCMP_ACT_KILL_THREAD`
         * `SCMP_ACT_TRAP`
         * `SCMP_ACT_ERRNO`
         * `SCMP_ACT_TRACE`

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -56,6 +56,7 @@
             "enum": [
                 "SCMP_ACT_KILL",
                 "SCMP_ACT_KILL_PROCESS",
+                "SCMP_ACT_KILL_THREAD",
                 "SCMP_ACT_TRAP",
                 "SCMP_ACT_ERRNO",
                 "SCMP_ACT_TRACE",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -641,6 +641,7 @@ type LinuxSeccompAction string
 const (
 	ActKill        LinuxSeccompAction = "SCMP_ACT_KILL"
 	ActKillProcess LinuxSeccompAction = "SCMP_ACT_KILL_PROCESS"
+	ActKillThread  LinuxSeccompAction = "SCMP_ACT_KILL_THREAD"
 	ActTrap        LinuxSeccompAction = "SCMP_ACT_TRAP"
 	ActErrno       LinuxSeccompAction = "SCMP_ACT_ERRNO"
 	ActTrace       LinuxSeccompAction = "SCMP_ACT_TRACE"


### PR DESCRIPTION
The seccomp action has been added to libseccomp a while ago, so I guess
the runtime spec should support it as well:

https://github.com/seccomp/libseccomp/commit/b2f15f3d02f302b12b9d1a37d83521e6f9e08841
