### PR TITLE
travis: fix go_import_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ go:
 
 sudo: required
 
+go_import_path: github.com/opencontainers/runtime-spec
+
 services:
   - docker
 


### PR DESCRIPTION
Without this, Travis CI only works on the main repository (github.com/opencontainers/runtime-spec) but not on forks. It is useful
to make Travis CI work on forks for contributors to be able to test their work before submitting a PR upstream.

See:
https://docs.travis-ci.com/user/languages/go#go-import-path

Symptoms:
```
$ make docs
go run ./.tool/version-doc.go > version.md
.tool/version-doc.go:10:2: cannot find package "github.com/opencontainers/runtime-spec/specs-go" in any of:
	/home/travis/.gimme/versions/go1.11.13.linux.amd64/src/github.com/opencontainers/runtime-spec/specs-go (from $GOROOT)
	/home/travis/gopath/src/github.com/opencontainers/runtime-spec/specs-go (from $GOPATH)
Makefile:53: recipe for target 'version.md' failed
make: *** [version.md] Error 1
The command "make docs" exited with 2.
```

Signed-off-by: Alban Crequy <alban@kinvolk.io>

-----

cc @mauriciovasquezbernal