### PR TITLE
Add Seccomp Notify support

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -633,7 +633,7 @@ The following parameters can be specified to set up seccomp:
     * **`names`** *(array of strings, REQUIRED)* - the names of the syscalls.
         `names` MUST contain at least one entry.
     * **`action`** *(string, REQUIRED)* - the action for seccomp rules.
-        A valid list of constants as of libseccomp v2.4.0 is shown below.
+        A valid list of constants as of libseccomp v2.5.0 is shown below.
 
         * `SCMP_ACT_KILL`
         * `SCMP_ACT_KILL_PROCESS`
@@ -642,6 +642,7 @@ The following parameters can be specified to set up seccomp:
         * `SCMP_ACT_TRACE`
         * `SCMP_ACT_ALLOW`
         * `SCMP_ACT_LOG`
+        * `SCMP_ACT_NOTIFY`
 
     * **`errnoRet`** *(uint, OPTIONAL)* - the errno return code to use.
         Some actions like `SCMP_ACT_ERRNO` and `SCMP_ACT_TRACE` allow to specify the errno

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -18,6 +18,9 @@
                 "createContainer": {
                     "$ref": "defs.json#/definitions/ArrayOfHooks"
                 },
+                "sendSeccompFd": {
+                    "$ref": "defs.json#/definitions/ArrayOfHooks"
+                },
                 "startContainer": {
                     "$ref": "defs.json#/definitions/ArrayOfHooks"
                 },

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -60,7 +60,8 @@
                 "SCMP_ACT_ERRNO",
                 "SCMP_ACT_TRACE",
                 "SCMP_ACT_ALLOW",
-                "SCMP_ACT_LOG"
+                "SCMP_ACT_LOG",
+                "SCMP_ACT_NOTIFY"
             ]
         },
         "SeccompFlag": {

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -172,6 +172,13 @@
                 "env":  [ "key1=value1"]
             }
         ],
+        "sendSeccompFd": [
+            {
+                "path": "/usr/bin/seccomp-agent",
+                "args": ["seccomp-agent", "--allow-mknods=/dev/null,/dev/net/tun"],
+                "env":  [ "key1=value1"]
+            }
+        ],
         "startContainer": [
             {
                 "path": "/usr/bin/refresh-ldcache"

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -137,6 +137,9 @@ type Hooks struct {
 	// CreateContainer is a list of hooks to be run after the container has been created but before pivot_root or any equivalent operation has been called
 	// It is called in the Container Namespace
 	CreateContainer []Hook `json:"createContainer,omitempty"`
+	// SendSeccompFd is a list of hooks to be run after a new seccomp fd is created
+	// It is called in the Runtime Namespace
+	SendSeccompFd []Hook `json:"sendSeccompFd,omitempty"`
 	// StartContainer is a list of hooks to be run after the start operation is called but before the container process is started
 	// It is called in the Container Namespace
 	StartContainer []Hook `json:"startContainer,omitempty"`
@@ -646,6 +649,7 @@ const (
 	ActTrace       LinuxSeccompAction = "SCMP_ACT_TRACE"
 	ActAllow       LinuxSeccompAction = "SCMP_ACT_ALLOW"
 	ActLog         LinuxSeccompAction = "SCMP_ACT_LOG"
+	ActNotify      LinuxSeccompAction = "SCMP_ACT_NOTIFY"
 )
 
 // LinuxSeccompOperator used to match syscall arguments in Seccomp

--- a/specs-go/state.go
+++ b/specs-go/state.go
@@ -5,20 +5,22 @@ type ContainerState string
 
 const (
 	// StateCreating indicates that the container is being created
-	StateCreating ContainerState  = "creating"
+	StateCreating ContainerState = "creating"
 
 	// StateCreated indicates that the runtime has finished the create operation
-	StateCreated ContainerState  = "created"
+	StateCreated ContainerState = "created"
 
 	// StateRunning indicates that the container process has executed the
 	// user-specified program but has not exited
-	StateRunning ContainerState  = "running"
+	StateRunning ContainerState = "running"
 
 	// StateStopped indicates that the container process has exited
-	StateStopped ContainerState  = "stopped"
+	StateStopped ContainerState = "stopped"
 )
 
-// State holds information about the runtime state of the container.
+// State holds information about the runtime state of the container. The State
+// can be displayed when requested (query state operation); it is also passed
+// via stdin to many hooks.
 type State struct {
 	// Version is the version of the specification that is supported.
 	Version string `json:"ociVersion"`
@@ -32,4 +34,18 @@ type State struct {
 	Bundle string `json:"bundle"`
 	// Annotations are key values associated with the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type SeccompState struct {
+	// Version is the version of the specification that is supported.
+	Version string `json:"ociVersion"`
+	// SeccompFd is the file descriptor for Seccomp User Notification
+	SeccompFd int `json:"seccompFd"`
+	// Pid is the process ID on which the seccomp filter is applied
+	Pid int `json:"pid"`
+	// PidFd is a pidfd for the process on which the seccomp filter is
+	// applied
+	PidFd int `json:"pidFd,omitempty"`
+	// State of the container
+	State State `json:"state"`
 }


### PR DESCRIPTION
This adds the specification for Seccomp Userspace Notification and the Golang bindings. This contains:
- A new OCI hook "sendSeccompFd" used to pass the seccompfd to an external seccomp agent via the hook.
- Additional SeccompState struct containing the container state and file descriptors passed for seccomp.

This was discussed in the OCI Weekly Discussion on September 16th, 2020, see:
- https://hackmd.io/El8Dd2xrTlCaCG59ns5cwg#September-16-2020
- https://docs.google.com/document/d/1xHw5GQjMj6ZKR-40aKmTWZRkvlPuzMGQRu-YpOFQc30/edit

Documentation for this feature:
- https://www.kernel.org/doc/html/v5.0/userspace-api/seccomp_filter.html#userspace-notification
- man pages: seccomp_user_notif.2 at https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/log/?h=seccomp_user_notif
- brauner's blog: https://brauner.github.io/2020/07/23/seccomp-notify.html

This PR is an alternative proposal to PR #1038.

Signed-off-by: Alban Crequy <alban@kinvolk.io>

-----

We will make a PR for runc implementing this shortly.

cc @KentaTada @giuseppe @AkihiroSuda @brauner @rata @mauriciovasquezbernal