### PR TITLE
Makefile: Fix golint URL used in go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ install.tools: .install.golint .install.gitvalidation
 # golint does not even build for <go1.7
 .install.golint:
 ifeq ($(call ALLOWED_GO_VERSION,1.7,$(HOST_GOLANG_VERSION)),true)
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 endif
 
 .install.gitvalidation:


### PR DESCRIPTION
Otherwise, commands like "make install.tools" fail with:

	$ make install.tools
	go get -u github.com/golang/lint/golint
	code in directory /<path>/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"

The github repository says this URL should be used for go get. After
this patch, make install.tools works just fine.

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>