### PR TITLE
config-linux: Add Intel RDT CMT and MBM Linux support

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -549,6 +549,13 @@ The following parameters can be specified for the container:
 
     * If `closID` is set, and neither of `l3CacheSchema` and `memBwSchema` are set, runtime MUST check if corresponding pre-configured directory `closID` is present in mounted `resctrl`. If such pre-configured directory `closID` exists, runtime MUST assign container to this `closID` and [generate an error](runtime.md#errors) if directory does not exist.
 
+* **`enableCMT`** *(boolean, OPTIONAL)* - specifies if Intel RDT CMT should be enabled:
+    * CMT (Cache Monitoring Technology) supports monitoring of the last-level cache (LLC) occupancy
+      for the container.
+
+* **`enableMBM`** *(boolean, OPTIONAL)* - specifies if Intel RDT MBM should be enabled:
+    * MBM (Memory Bandwidth Monitoring) supports monitoring of total and local memory bandwidth
+      for the container.
 
 ### Example
 

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -250,6 +250,12 @@
                     "memBwSchema": {
                         "type": "string",
                         "pattern": "^MB:[^\\n]*$"
+                    },
+                    "enableCMT": {
+                        "type": "boolean"
+                    },
+                    "enableMBM": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -178,7 +178,7 @@ type Linux struct {
 	// MountLabel specifies the selinux context for the mounts in the container.
 	MountLabel string `json:"mountLabel,omitempty"`
 	// IntelRdt contains Intel Resource Director Technology (RDT) information for
-	// handling resource constraints (e.g., L3 cache, memory bandwidth) for the container
+	// handling resource constraints and monitoring metrics (e.g., L3 cache, memory bandwidth) for the container
 	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
 	// Personality contains configuration for the Linux personality syscall
 	Personality *LinuxPersonality `json:"personality,omitempty"`
@@ -678,8 +678,9 @@ type LinuxSyscall struct {
 	Args     []LinuxSeccompArg  `json:"args,omitempty"`
 }
 
-// LinuxIntelRdt has container runtime resource constraints for Intel RDT
-// CAT and MBA features which introduced in Linux 4.10 and 4.12 kernel
+// LinuxIntelRdt has container runtime resource constraints for Intel RDT CAT and MBA
+// features and flags enabling Intel RDT CMT and MBM features.
+// Intel RDT features are available in Linux 4.14 and newer kernel versions.
 type LinuxIntelRdt struct {
 	// The identity for RDT Class of Service
 	ClosID string `json:"closID,omitempty"`
@@ -692,4 +693,12 @@ type LinuxIntelRdt struct {
 	// The unit of memory bandwidth is specified in "percentages" by
 	// default, and in "MBps" if MBA Software Controller is enabled.
 	MemBwSchema string `json:"memBwSchema,omitempty"`
+
+	// EnableCMT is the flag to indicate if the Intel RDT CMT is enabled. CMT (Cache Monitoring Technology) supports monitoring of
+	// the last-level cache (LLC) occupancy for the container.
+	EnableCMT bool `json:"enableCMT,omitempty"`
+
+	// EnableMBM is the flag to indicate if the Intel RDT MBM is enabled. MBM (Memory Bandwidth Monitoring) supports monitoring of
+	// total and local memory bandwidth for the container.
+	EnableMBM bool `json:"enableMBM,omitempty"`
 }


### PR DESCRIPTION
Add support for Intel Resource Director Technology (RDT) /
Cache Monitoring Technology (CMT) and Memory Bandwidth Monitoring (MBM).

Example:
```
"linux": {
    "intelRdt": {
        "enableCMT": true,
        "enableMBM": true
    }
}
```
This is the prerequisite of this runc proposal:
https://github.com/opencontainers/runc/issues/2519

For more information about Intel RDT CMT and MBM, please refer to:
https://github.com/opencontainers/runc/issues/2519

Signed-off-by: Paweł Szulik <pawel.szulik@intel.com>