### PR TITLE
seccomp: allow to override default errno return code

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -645,8 +645,9 @@ The following parameters can be specified to set up seccomp:
         * `SCMP_ACT_LOG`
 
     * **`errnoRet`** *(uint, OPTIONAL)* - the errno return code to use.
-        Some actions like `SCMP_ACT_ERRNO` and `SCMP_ACT_TRACE` allow to specify the errno
-        code to return. If not specified its default value is `EPERM`.
+        Some actions like `SCMP_ACT_ERRNO` and `SCMP_ACT_TRACE` allow to specify the errno code to return.
+        When the action doesn't support an errno, the runtime MUST print and error and fail.
+        If not specified its default value is `EPERM`.
 
     * **`args`** *(array of objects, OPTIONAL)* - the specific syscall in seccomp.
         Each entry has the following structure:

--- a/config-linux.md
+++ b/config-linux.md
@@ -594,6 +594,10 @@ The actions, architectures, and operators are strings that match the definitions
 The following parameters can be specified to set up seccomp:
 
 * **`defaultAction`** *(string, REQUIRED)* - the default action for seccomp. Allowed values are the same as `syscalls[].action`.
+* **`defaultErrnoRet`** *(uint, OPTIONAL)* - the errno return code to use.
+    Some actions like `SCMP_ACT_ERRNO` and `SCMP_ACT_TRACE` allow to specify the errno code to return.
+    When the action doesn't support an errno, the runtime MUST print and error and fail.
+    If not specified then its default value is `EPERM`.
 * **`architectures`** *(array of strings, OPTIONAL)* - the architecture used for system calls.
     A valid list of constants as of libseccomp v2.5.0 is shown below.
 

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -203,6 +203,9 @@
                     "defaultAction": {
                         "$ref": "defs-linux.json#/definitions/SeccompAction"
                     },
+                    "defaultErrnoRet": {
+                        "$ref": "defs.json#/definitions/uint32"
+                    },
                     "flags": {
                         "type": "array",
                         "items": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -598,10 +598,11 @@ type VMImage struct {
 
 // LinuxSeccomp represents syscall restrictions
 type LinuxSeccomp struct {
-	DefaultAction LinuxSeccompAction `json:"defaultAction"`
-	Architectures []Arch             `json:"architectures,omitempty"`
-	Flags         []LinuxSeccompFlag `json:"flags,omitempty"`
-	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
+	DefaultAction   LinuxSeccompAction `json:"defaultAction"`
+	DefaultErrnoRet *uint              `json:"defaultErrnoRet,omitempty"`
+	Architectures   []Arch             `json:"architectures,omitempty"`
+	Flags           []LinuxSeccompFlag `json:"flags,omitempty"`
+	Syscalls        []LinuxSyscall     `json:"syscalls,omitempty"`
 }
 
 // Arch used for additional architectures


### PR DESCRIPTION
the specs already support overriding the errno code for the syscalls
but the default value is hardcoded to EPERM.

Add a new attribute to override the default value.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>