### PR TITLE
Support mount_setattr(2) attributes (mostly for recursively-readonly mounts)

### DIFF
--- a/config.md
+++ b/config.md
@@ -139,6 +139,41 @@ For POSIX platforms the `mounts` structure has the following fields:
 ]
 ```
 
+### <a name="configLinuxMounts" />Linux Mounts
+
+For Linux, the `mounts` structure mounts MAY have the following additional fields:
+
+* **`attr`** (object, OPTIONAL) specifies `mount_setattr(2)` attributes. Requires kernel 5.12 or later.
+  The runtime MUST [generate an error](runtime.md#errors) for any values which cannot be mapped to a relevant kernel interface.
+    * **`flags`** (array of strings, OPTIONAL) specifies the `flags` argument of `mount_setattr(2)` syscall.
+       e.g.,  "AT_RECURSIVE"
+    * **`attr_set`** (array of strings, OPTIONAL) specifies the `attr_set` field of `mount_attr` struct.
+       e.g., "MOUNT_ATTR_RDONLY"
+    * **`attr_clr`** (array of strings, OPTIONAL) specifies the `attr_clr` field of `mount_attr` struct.
+    * **`propagation`** (string, OPTIONAL) specifies the `propagation` field of `mount_attr` struct.
+       See [Rootfs Mount Propagation](./config-linux.md#configLinuxRootfsMountPropagation) for the string format.
+
+<!-- TODO: consider supporting mount_attr.userns_fd -->
+
+### Example
+
+```json
+"mounts": [
+    {
+        "destination": "/ro",
+        "type": "none",
+        "source": "/volumes/ro",
+        "options": ["rbind"],
+        "attr": {
+          "flags": ["AT_RECURSIVE"],
+          "attr_set": ["MOUNT_ATTR_RDONLY"],
+          "attr_clr": ["MOUNT_ATTR_NOEXEC"],
+          "propagation": "private"
+        }
+    }
+]
+```
+
 ## <a name="configProcess" />Process
 
 **`process`** (object, OPTIONAL) specifies the container process.

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -141,11 +141,31 @@
                 },
                 "type": {
                     "type": "string"
+                },
+                "attr": {
+                    "$ref": "#/definitions/LinuxMountAttr"
                 }
             },
             "required": [
                 "destination"
             ]
+        },
+        "LinuxMountAttr": {
+          "type": "object",
+          "properties": {
+                "flags": {
+                    "$ref": "#/definitions/ArrayOfStrings"
+                },
+                "attr_set": {
+                    "$ref": "#/definitions/ArrayOfStrings"
+                },
+                "attr_clr": {
+                    "$ref": "#/definitions/ArrayOfStrings"
+                },
+                "propagation": {
+                    "type": "string"
+                }
+            }
         },
         "ociVersion": {
             "description": "The version of Open Container Initiative Runtime Specification that the document complies with",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -117,6 +117,22 @@ type Mount struct {
 	Source string `json:"source,omitempty"`
 	// Options are fstab style mount options.
 	Options []string `json:"options,omitempty"`
+	// Attr specifies mount_setattr(2) attributes.
+	Attr *LinuxMountAttr `json:"attr,omitempty"`
+}
+
+// LinuxMountAttr specifies mount_setattr(2) attributes.
+// Requires Linux kernel 5.12 or later.
+type LinuxMountAttr struct {
+	// Flags specifies the flags argument of mount_setattr(2) syscall. e.g., "AT_RECURSIVE"
+	Flags []string `json:"flags,omitempty"`
+	// AttrSet specifies the attr_set field of mount_attr struct. e.g., "MOUNT_ATTR_RDONLY"
+	AttrSet []string `json:"attr_set,omitempty"`
+	// AttrClr specifies the attr_clr field of mount_attr struct.
+	AttrClr []string `json:"attr_clr,omitempty"`
+	// Propagation specifies the propagation field of mount_attr struct.
+	// Format corresponds to Linux.RootfsPropagation .
+	Propagation string `json:"propagation,omitempty"`
 }
 
 // Hook specifies a command that is run at a particular event in the lifecycle of a container


### PR DESCRIPTION
`mount_setattr(2)` introduced in [kernel 5.12](https://github.com/torvalds/linux/commit/2a1867219c7b27f928e2545782b86daaf9ad50bd) is especially useful for creating recursively-readonly bind mounts:
```c
struct mount_attr {
	__u64 attr_set;
	__u64 attr_clr;
	__u64 propagation;
	__u64 userns_fd;
};

int mount_setattr(int dfd, const char *path, unsigned flags,
                  struct mount_attr *uattr, size_t usize);

```

e.g.,
```c
struct mount_attr attr = {
  .attr_set   = MOUNT_ATTR_RDONLY,
};
rc = mount_setattr(-1, "/mnt/ro", AT_RECURSIVE, &attr, sizeof(attr));
```

This commit updates `config.md` to add OCI support for `mount_setattr(2)`.

e.g.,
```json
"mounts": [
    {
        "destination": "/mnt/ro",
        "type": "none",
        "source": "/src",
        "options": ["rbind"],
        "attr": {
          "flags": ["AT_RECURSIVE"],
          "attr_set": ["MOUNT_ATTR_RDONLY"],
        }
    }
]
```
