### PR TITLE
config-linux: mark memory.kernel[TCP] as NOT RECOMMENDED

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -264,8 +264,8 @@ Values for memory specify the limit in bytes, or `-1` for unlimited memory.
 * **`limit`** *(int64, OPTIONAL)* - sets limit of memory usage
 * **`reservation`** *(int64, OPTIONAL)* - sets soft limit of memory usage
 * **`swap`** *(int64, OPTIONAL)* - sets limit of memory+Swap usage
-* **`kernel`** *(int64, OPTIONAL)* - sets hard limit for kernel memory
-* **`kernelTCP`** *(int64, OPTIONAL)* - sets hard limit for kernel TCP buffer memory
+* **`kernel`** *(int64, OPTIONAL, NOT RECOMMENDED)* - sets hard limit for kernel memory
+* **`kernelTCP`** *(int64, OPTIONAL, NOT RECOMMENDED)* - sets hard limit for kernel TCP buffer memory
 
 The following properties do not specify memory limits, but are covered by the `memory` controller:
 


### PR DESCRIPTION
Per-cgroup kernel memory accounting (and explicit limiting) is
problematic in the Linux kernel for too many reasons to quote here.
Besides, cgroup v2 does not even have a kernel memory limit knob,
and the one in cgroup v1 is made obsoleted in kernel v5.4 [1].

Mark memory.kernel and memory.kernelTCP as NOT RECOMMENDED, in additon
to OPTIONAL. This is a way to say "we do not anyone (runtimes or users)
to set those limits, unless they have good understanding and strong
reasons to do so".

[1]https://github.com/torvalds/linux/commit/0158115f702b0ba208ab0