### PR TITLE
Introduce zos as platform

### DIFF
--- a/config-zos.md
+++ b/config-zos.md
@@ -1,0 +1,20 @@
+_This document is a work in progress._
+
+# <a name="ZOSContainerConfiguration" />z/OS Container Configuration
+
+This document describes the schema for the [z/OS-specific section](config.md#platform-specific-configuration) of the [container configuration](config.md).
+
+## <a name="configZOSDevices" />Devices
+
+**`devices`** (array of objects, OPTIONAL) lists devices that MUST be available in the container.
+The runtime MAY supply them however it likes.
+
+Each entry has the following structure:
+
+* **`type`** *(string, REQUIRED)* - type of device: `c`, `b`, `u` or `p`.
+* **`path`** *(string, REQUIRED)* - full path to device inside container.
+    If a file already exists at `path` that does not match the requested device, the runtime MUST generate an error.
+* **`major, minor`** *(int64, REQUIRED unless `type` is `p`)* - major, minor numbers for the device.
+* **`fileMode`** *(uint32, OPTIONAL)* - file mode for the device.
+
+The same `type`, `major` and `minor` SHOULD NOT be used for multiple devices.

--- a/config.md
+++ b/config.md
@@ -360,6 +360,8 @@ For Windows based systems the user structure has the following fields:
     This MAY be set if the target platform of this spec is `solaris`.
 * **`vm`** (object, OPTIONAL) [Virtual-machine-specific configuration](config-vm.md).
     This MAY be set if the target platform and architecture of this spec support hardware virtualization.
+* **`zos`** (object, OPTIONAL) [z/OS-specific configuration](config-zos.md).
+    This MAY be set if the target platform of this spec is `zos`.
 
 ### Example (Linux)
 

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -180,6 +180,9 @@
         },
         "vm": {
             "$ref": "config-vm.json#/vm"
+        },
+        "zos": {
+            "$ref": "config-zos.json#/zos"
         }
     },
     "required": [

--- a/schema/config-zos.json
+++ b/schema/config-zos.json
@@ -1,0 +1,14 @@
+{
+    "zos": {
+        "description": "z/OS platform-specific configurations",
+        "type": "object",
+        "properties": {
+            "devices": {
+                "type": "array",
+                "items": {
+                    "$ref": "defs-zos.json#/definitions/Device"
+                }
+            }
+        }
+    }
+}

--- a/schema/defs-zos.json
+++ b/schema/defs-zos.json
@@ -1,0 +1,55 @@
+{
+    "definitions": {
+        "Major": {
+            "description": "major device number",
+            "$ref": "defs.json#/definitions/int64"
+        },
+        "Minor": {
+            "description": "minor device number",
+            "$ref": "defs.json#/definitions/int64"
+        },
+        "FileMode": {
+            "description": "File permissions mode (typically an octal value)",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 512
+        },
+        "FileType": {
+            "description": "Type of a block or special character device",
+            "type": "string",
+            "pattern": "^[cbup]$"
+        },
+        "Device": {
+            "type": "object",
+            "required": [
+                "type",
+                "path",
+                "major",
+                "minor"
+            ],
+            "properties": {
+                "path": {
+                  "$ref": "defs.json#/definitions/FilePath"
+                },
+                "type": {
+                  "$ref": "defs-zos.json#/definitions/FileType"
+                },
+                "major": {
+                  "$ref": "defs-zos.json#/definitions/Major"
+                },
+                "minor": {
+                  "$ref": "defs-zos.json#/definitions/Minor"
+                },
+                "fileMode": {
+                    "$ref": "defs-zos.json#/definitions/FileMode"
+                },
+                "uid": {
+                    "$ref": "defs.json#/definitions/UID"
+                },
+                "gid": {
+                    "$ref": "defs.json#/definitions/GID"
+                }
+            }
+        }
+    }
+}

--- a/schema/test/config/good/zos-minimal.json
+++ b/schema/test/config/good/zos-minimal.json
@@ -1,0 +1,8 @@
+{
+    "ociVersion": "1.0.0",
+    "root": {
+        "path": "rootfs"
+    },
+    "zos": {
+    }
+}

--- a/spec.md
+++ b/spec.md
@@ -17,6 +17,7 @@ Platforms defined by this specification are:
 * `solaris`: [runtime.md](runtime.md), [config.md](config.md), and [config-solaris.md](config-solaris.md).
 * `windows`: [runtime.md](runtime.md), [config.md](config.md), and [config-windows.md](config-windows.md).
 * `vm`: [runtime.md](runtime.md), [config.md](config.md), and [config-vm.md](config-vm.md).
+* `zos`: [runtime.md](runtime.md), [config.md](config.md), and [config-zos.md](config-zos.md).
 
 # <a name="ociRuntimeSpecTOC" />Table of Contents
 
@@ -31,6 +32,7 @@ Platforms defined by this specification are:
     - [Solaris-specific Configuration](config-solaris.md)
     - [Windows-specific Configuration](config-windows.md)
     - [Virtual-Machine-specific Configuration](config-vm.md)
+    - [z/OS-specific Configuration](config-zos.md)
 - [Glossary](glossary.md)
 
 # <a name="ociRuntimeSpecNotationalConventions" />Notational Conventions

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -15,7 +15,7 @@ type Spec struct {
 	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
 	// Hooks configures callbacks for container lifecycle events.
-	Hooks *Hooks `json:"hooks,omitempty" platform:"linux,solaris"`
+	Hooks *Hooks `json:"hooks,omitempty" platform:"linux,solaris,zos"`
 	// Annotations contains arbitrary metadata for the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
@@ -27,6 +27,8 @@ type Spec struct {
 	Windows *Windows `json:"windows,omitempty" platform:"windows"`
 	// VM specifies configuration for virtual-machine-based containers.
 	VM *VM `json:"vm,omitempty" platform:"vm"`
+	// ZOS is platform-specific configuration for z/OS based containers.
+	ZOS *ZOS `json:"zos,omitempty" platform:"zos"`
 }
 
 // Process contains information to start a specific application inside the container.
@@ -49,7 +51,7 @@ type Process struct {
 	// Capabilities are Linux capabilities that are kept for the process.
 	Capabilities *LinuxCapabilities `json:"capabilities,omitempty" platform:"linux"`
 	// Rlimits specifies rlimit options to apply to the process.
-	Rlimits []POSIXRlimit `json:"rlimits,omitempty" platform:"linux,solaris"`
+	Rlimits []POSIXRlimit `json:"rlimits,omitempty" platform:"linux,solaris,zos"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
 	// ApparmorProfile specifies the apparmor profile for the container.
@@ -86,11 +88,11 @@ type Box struct {
 // User specifies specific user (and group) information for the container process.
 type User struct {
 	// UID is the user id.
-	UID uint32 `json:"uid" platform:"linux,solaris"`
+	UID uint32 `json:"uid" platform:"linux,solaris,zos"`
 	// GID is the group id.
-	GID uint32 `json:"gid" platform:"linux,solaris"`
+	GID uint32 `json:"gid" platform:"linux,solaris,zos"`
 	// Umask is the umask for the init process.
-	Umask *uint32 `json:"umask,omitempty" platform:"linux,solaris"`
+	Umask *uint32 `json:"umask,omitempty" platform:"linux,solaris,zos"`
 	// AdditionalGids are additional group ids set for the container's process.
 	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
 	// Username is the user name.
@@ -110,7 +112,7 @@ type Mount struct {
 	// Destination is the absolute path where the mount will be placed in the container.
 	Destination string `json:"destination"`
 	// Type specifies the mount kind.
-	Type string `json:"type,omitempty" platform:"linux,solaris"`
+	Type string `json:"type,omitempty" platform:"linux,solaris,zos"`
 	// Source specifies the source path of the mount.
 	Source string `json:"source,omitempty"`
 	// Options are fstab style mount options.
@@ -697,4 +699,28 @@ type LinuxIntelRdt struct {
 	// The unit of memory bandwidth is specified in "percentages" by
 	// default, and in "MBps" if MBA Software Controller is enabled.
 	MemBwSchema string `json:"memBwSchema,omitempty"`
+}
+
+// ZOS contains platform-specific configuration for z/OS based containers.
+type ZOS struct {
+	// Devices are a list of device nodes that are created for the container
+	Devices []ZOSDevice `json:"devices,omitempty"`
+}
+
+// ZOSDevice represents the mknod information for a z/OS special device file
+type ZOSDevice struct {
+	// Path to the device.
+	Path string `json:"path"`
+	// Device type, block, char, etc.
+	Type string `json:"type"`
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+	// FileMode permission bits for the device.
+	FileMode *os.FileMode `json:"fileMode,omitempty"`
+	// UID of the device.
+	UID *uint32 `json:"uid,omitempty"`
+	// Gid of the device.
+	GID *uint32 `json:"gid,omitempty"`
 }


### PR DESCRIPTION
As discussed in the 1/27/2021 OCI developer meeting, these changes introduce IBM z/OS as a Native Platform for OCI. Changes to code, JSON schema, and markdown documentation is included.

Other than `zos` being added a _platform_ and having its own platform-specific configuration, nothing new is really added with this. The expectation is that additional pull requests (preceded by development discussions, if needed) will be used to request any z/OS-unique configuration properties as the IBM initiative to support OCI containers on z/OS progresses.

*Note on z/OS devices:* it is the only property in the z/OS-specific configuration object. This was copied from how devices can be specified for Linux. Specifying devices like this would be a perfectly valid way to define/create devices in a container on z/OS. However, its usefulness on z/OS is questionable. It is being included in this PR so that _something_ is defined in the z/OS-specific configuration object. It very well may turn out that the ability to specify devices to be created in a z/OS container may be unnecessary and that the definition should be replaced with more useful properties.

Signed-off-by: Neil Johnson <najohnsn@us.ibm.com>
Contributors: @SteeleDesmond and @najohnsn