### PR TITLE
Fix seccomp notify inconsistencies

### DIFF
--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -70,8 +70,7 @@
             "enum": [
                 "SECCOMP_FILTER_FLAG_TSYNC",
                 "SECCOMP_FILTER_FLAG_LOG",
-                "SECCOMP_FILTER_FLAG_SPEC_ALLOW",
-                "SECCOMP_FILTER_FLAG_NEW_LISTENER"
+                "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
             ]
         },
         "SeccompOperators": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -650,6 +650,7 @@ const (
 	ActTrace       LinuxSeccompAction = "SCMP_ACT_TRACE"
 	ActAllow       LinuxSeccompAction = "SCMP_ACT_ALLOW"
 	ActLog         LinuxSeccompAction = "SCMP_ACT_LOG"
+	ActNotify      LinuxSeccompAction = "SCMP_ACT_NOTIFY"
 )
 
 // LinuxSeccompOperator used to match syscall arguments in Seccomp


### PR DESCRIPTION
In PR https://github.com/opencontainers/runtime-spec/pull/1074 I missed some consts, sorry!

Funny thing is we didn't catch them even when we used this in runc and containerd patches because containerd just passes a string (see commit for a detailed explanation) and runc doesn't use these constants (again, full explanation in the commit msg).

cc @vbatts @giuseppe as you LGTM to #1074.