### PR TITLE
Proposal: Flatten Rdma to array instead of using additionalProperties. [Breaking-change]

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -184,8 +184,8 @@
                         }
                     },
                     "rdma": {
-                        "type": "object",
-                        "additionalProperties": {
+                        "type": "array",
+                        "items": {
                             "$ref": "defs-linux.json#/definitions/Rdma"
                         }
                     }

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -277,6 +277,9 @@
         "Rdma": {
             "type": "object",
             "properties": {
+                "device": {
+                    "type": "string"
+                },
                 "hcaHandles": {
                     "$ref": "defs.json#/definitions/uint32"
                 },

--- a/schema/test/config/bad/linux-rdma.json
+++ b/schema/test/config/bad/linux-rdma.json
@@ -5,11 +5,12 @@
     },
     "linux": {
         "resources": {
-            "rdma": {
-                "mlx5_1": {
+            "rdma": [
+                {
+                    "device": "mlx5_1",
                     "hcaHandles": "not a uint32"
                 }
-            }
+            ]
         }
     }
 }

--- a/schema/test/config/good/linux-rdma.json
+++ b/schema/test/config/good/linux-rdma.json
@@ -5,18 +5,21 @@
     },
     "linux": {
         "resources": {
-            "rdma": {
-                "mlx5_1": {
+            "rdma": [
+                {
+                    "device": "mlx5_1",
                     "hcaHandles": 3,
                     "hcaObjects": 10000
                 },
-                "mlx4_0": {
+                {
+                    "device": "mlx4_0",
                     "hcaObjects": 1000
                 },
-                "rxe3": {
+                {
+                    "device": "rxe3",
                     "hcaObjects": 10000
                 }
-            }
+            ]
         }
     }
 }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -346,6 +346,8 @@ type LinuxNetwork struct {
 
 // LinuxRdma for Linux cgroup 'rdma' resource management (Linux 4.11)
 type LinuxRdma struct {
+	// Device name
+	Device string `json:"device,omitempty"`
 	// Maximum number of HCA handles that can be opened. Default is "no limit".
 	HcaHandles *uint32 `json:"hcaHandles,omitempty"`
 	// Maximum number of HCA objects that can be created. Default is "no limit".
@@ -369,9 +371,7 @@ type LinuxResources struct {
 	// Network restriction configuration
 	Network *LinuxNetwork `json:"network,omitempty"`
 	// Rdma resource restriction configuration.
-	// Limits are a set of key value pairs that define RDMA resource limits,
-	// where the key is device name and value is resource limits.
-	Rdma map[string]LinuxRdma `json:"rdma,omitempty"`
+	Rdma []LinuxRdma `json:"rdma,omitempty"`
 	// Unified resources.
 	Unified map[string]string `json:"unified,omitempty"`
 }


### PR DESCRIPTION
Following PR aims to reduce unnecessary complications of type `mapStringObject` around Rdma by moving it to simpler array based structure.

Reasons:
1) Number of devices is limited, cant really understand use case of a `additonalProperties` here, I feel current `additonalProperties` here is anomaly and  forces parsers to implement `mapStringObject` which is not strongly typed and is not helpful.