### PR TITLE
seccomp: Allow specification of syscalls as numbers

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -649,7 +649,7 @@ The following parameters can be specified to set up seccomp:
     For example, if `defaultAction` is `SCMP_ACT_KILL` and `syscalls` is empty or unset, the kernel will kill the container process on its first syscall.
     Each entry has the following structure:
 
-    * **`names`** *(array of strings, REQUIRED)* - the names of the syscalls.
+    * **`names`** *(array of strings, REQUIRED)* - the names (or decimal strings of the number) of the syscalls.
         `names` MUST contain at least one entry.
     * **`action`** *(string, REQUIRED)* - the action for seccomp rules.
         A valid list of constants as of libseccomp v2.5.0 is shown below.


### PR DESCRIPTION
The motivation here is the same as https://github.com/moby/moby/issues/41671, which was closed
as requiring a spec change (hence this PR). In short, certain applications use high syscall numbers
(e.g. 1000+) for private communication with an associated ptracer. Since these are not real syscalls,
there is no corresponding string mapping for them in the runtime. Currently users simply run such
applications in privileged containers, which is of course the absolute worst option. I would like to be
able to provide these users a seccomp profile that works, but without being able to specify these
pseudo-syscalls by number, this is not possible.

cc @thaJeztah @staticfloat