### PR TITLE
specs-go: add consts for seccomp flags

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -613,6 +613,13 @@ type Arch string
 // LinuxSeccompFlag is a flag to pass to seccomp(2).
 type LinuxSeccompFlag string
 
+// LinuxSeccompFlag options
+const (
+	FlagTSync LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_TSYNC"
+	FlagLog   LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_LOG"
+	FlagAllow LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
+)
+
 // Additional architectures permitted to be used for system calls
 // By default only the native architecture of the kernel is permitted
 const (


### PR DESCRIPTION
Relates to https://github.com/moby/moby/issues/42619

Commit d1ef109cd0b39239ff82c267df314f7ed2da576b (https://github.com/opencontainers/runtime-spec/pull/1018) added the ability to specify
flags that must be passed to seccomp(2) when installing the filter, and
defined an enum in the specification.

This patch adds corresponding consts for the Go implementation of the Spec.

