### PR TITLE
specs-go/config: add Landlock LSM support

### DIFF
--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -144,6 +144,20 @@
                 "selinuxLabel": {
                     "type": "string"
                 },
+                "landlock": {
+                    "type": "object",
+                    "properties": {
+                        "ruleset": {
+                            "$ref": "defs.json#/definitions/LandlockRuleset"
+                        },
+                        "rules": {
+                            "$ref": "defs.json#/definitions/LandlockRules"
+                        },
+                        "disableBestEffort": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "noNewPrivileges": {
                     "type": "boolean"
                 },

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -165,6 +165,63 @@
         },
         "annotations": {
             "$ref": "#/definitions/mapStringString"
+        },
+        "LandlockFSAction": {
+            "type": "string",
+            "enum": [
+                "execute",
+                "write_file",
+                "read_file",
+                "read_dir",
+                "remove_dir",
+                "remove_file",
+                "make_char",
+                "make_dir",
+                "make_reg",
+                "make_sock",
+                "make_fifo",
+                "make_block",
+                "make_sym"
+            ]
+        },
+        "ArrayOfLandlockFSActions": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/LandlockFSAction"
+            }
+        },
+        "LandlockRuleset": {
+            "type": "object",
+             "properties": {
+                 "handledAccessFS": {
+                     "$ref": "#/definitions/ArrayOfLandlockFSActions"
+                 }
+             }
+        },
+        "LandlockRulePathBeneath": {
+            "type": "object",
+            "properties": {
+                "allowedAccess": {
+                    "$ref": "#/definitions/ArrayOfLandlockFSActions"
+                },
+                "paths": {
+                    "$ref": "#/definitions/ArrayOfStrings"
+                }
+            }
+        },
+        "ArrayOfLandlockRulePathBeneaths": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/LandlockRulePathBeneath"
+            }
+        },
+        "LandlockRules": {
+            "type": "object",
+            "properties": {
+                "pathBeneath": {
+                    "$ref": "#/definitions/ArrayOfLandlockRulePathBeneaths"
+                }
+            }
         }
     }
 }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -62,7 +62,65 @@ type Process struct {
 	OOMScoreAdj *int `json:"oomScoreAdj,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
+	// Landlock specifies the Landlock unprivileged access control settings for the container process.
+	// `noNewPrivileges` must be enabled to use Landlock.
+	Landlock *Landlock `json:"landlock,omitempty" platform:"linux"`
 }
+
+// Landlock specifies the Landlock unprivileged access control settings for the container process.
+type Landlock struct {
+	// Ruleset identifies a set of rules (i.e., actions on objects) that need to be handled.
+	Ruleset *LandlockRuleset `json:"ruleset,omitempty" platform:"linux"`
+	// Rules are the security policies (i.e., actions allowed on objects) to be added to an existing ruleset.
+	Rules *LandlockRules `json:"rules,omitempty" platform:"linux"`
+	// DisableBestEffort disables the best-effort security approach for Landlock access rights.
+	// This is for conditions when the Landlock access rights explicitly configured by the container are not
+	// supported or available in the running kernel.
+	// Default is false, i.e., following a best-effort security approach.
+	DisableBestEffort bool `json:"disableBestEffort,omitempty" platform:"linux"`
+}
+
+// LandlockRuleset identifies a set of rules (i.e., actions on objects) that need to be handled.
+type LandlockRuleset struct {
+	// HandledAccessFS is a list of actions that is handled by this ruleset and should then be
+	// forbidden if no rule explicitly allow them.
+	HandledAccessFS []LandlockFSAction `json:"handledAccessFS,omitempty" platform:"linux"`
+}
+
+// LandlockRules represents the security policies (i.e., actions allowed on objects).
+type LandlockRules struct {
+	// PathBeneath specifies the file-hierarchy typed rules.
+	PathBeneath []LandlockRulePathBeneath `json:"pathBeneath,omitempty" platform:"linux"`
+}
+
+// LandlockRulePathBeneath defines the file-hierarchy typed rule that grants the access rights specified by
+// `AllowedAccess` to the file hierarchies under the given `Paths`.
+type LandlockRulePathBeneath struct {
+	// AllowedAccess contains a list of allowed filesystem actions for the file hierarchies.
+	AllowedAccess []LandlockFSAction `json:"allowedAccess,omitempty" platform:"linux"`
+	// Paths are the files or parent directories of the file hierarchies to restrict.
+	Paths []string `json:"paths,omitempty" platform:"linux"`
+}
+
+// LandlockFSAction used to specify the FS actions that are handled by a ruleset or allowed by a rule.
+type LandlockFSAction string
+
+// Define actions on files and directories that Landlock can restrict a sandboxed process to.
+const (
+	LLFSActExecute    LandlockFSAction = "execute"
+	LLFSActWriteFile  LandlockFSAction = "write_file"
+	LLFSActReadFile   LandlockFSAction = "read_file"
+	LLFSActReadDir    LandlockFSAction = "read_dir"
+	LLFSActRemoveDir  LandlockFSAction = "remove_dir"
+	LLFSActRemoveFile LandlockFSAction = "remove_file"
+	LLFSActMakeChar   LandlockFSAction = "make_char"
+	LLFSActMakeDir    LandlockFSAction = "make_dir"
+	LLFSActMakeReg    LandlockFSAction = "make_reg"
+	LLFSActMakeSock   LandlockFSAction = "make_sock"
+	LLFSActMakeFifo   LandlockFSAction = "make_fifo"
+	LLFSActMakeBlock  LandlockFSAction = "make_block"
+	LLFSActMakeSym    LandlockFSAction = "make_sym"
+)
 
 // LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
 // http://man7.org/linux/man-pages/man7/capabilities.7.html


### PR DESCRIPTION
Linux kernel 5.13 adds support for Landlock Linux Security Module (LSM).
This allows unprivileged processes to create safe security sandboxes
that can securely restrict the ambient rights (e.g. global filesystem
access) for themselves.

https://github.com/opencontainers/runtime-spec/issues/1110

Signed-off-by: Kailun Qin <kailun.qin@intel.com>