### PR TITLE
specs-go/config: add keyring support

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -182,6 +182,8 @@ type Linux struct {
 	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
 	// Personality contains configuration for the Linux personality syscall
 	Personality *LinuxPersonality `json:"personality,omitempty"`
+	// Keyrings specifies the kernel keyrings that are created and/or joined by the container.
+	Keyrings *LinuxKeyrings `json:"keyrings,omitempty"`
 }
 
 // LinuxNamespace is the configuration for a Linux namespace
@@ -429,6 +431,38 @@ type LinuxPersonality struct {
 	Domain LinuxPersonalityDomain `json:"domain"`
 	// Additional flags
 	Flags []LinuxPersonalityFlag `json:"flags,omitempty"`
+}
+
+// LinuxKeyrings specifies the list of keyrings used to anchor keys on behalf of a process.
+// https://man7.org/linux/man-pages/man7/keyrings.7.html
+type LinuxKeyrings struct {
+	// Session is the session shared process keyring.
+	// It is inherited and shared by all child processes.
+	Session LinuxSessionKeyring `json:"session,omitempty"`
+	// Process is the per-process shared keyring.
+	// It is shared by all threads in a process.
+	Process LinuxProcessKeyring `json:"process,omitempty"`
+	// Session is the per-thread keyring.
+	// It is specific to a particular thread.
+	Thread LinuxThreadKeyring `json:"thread,omitempty"`
+}
+
+// LinuxSessionKeyring defines the session shared process keyring.
+type LinuxSessionKeyring struct {
+	// Name is the name of the session-specific keyring.
+	Name string `json:"name,omitempty"`
+}
+
+// LinuxProcessKeyring defines the per-process shared keyring.
+type LinuxProcessKeyring struct {
+	// Name is the name of the process-specific keyring.
+	Name string `json:"name,omitempty"`
+}
+
+// LinuxThreadKeyring defines the per-thread keyring.
+type LinuxThreadKeyring struct {
+	// Name is the name of the thread-specific keyring.
+	Name string `json:"name,omitempty"`
 }
 
 // Solaris contains platform-specific configuration for Solaris application containers.


### PR DESCRIPTION
Currently, with `runc` we have a special cmdline flag `--no-new-keyring`
for `runc run` that enables/disables the creation of a new kernel
keyring. The main reason we have the option is that older kernels had
issues with allocating a lot of keyrings (so in order to run containers
on old kernels you need to disable the creation of a new keyring).

This patch adds keyring support into part of the OCI spec which allows
managers to drive this behavior in a runtime-agnostic way and helps make
swapping in other runtimes easier.

Fixes https://github.com/opencontainers/runtime-spec/issues/754
Fixes https://github.com/opencontainers/runtime-spec/issues/950

Signed-off-by: Kailun Qin <kailun.qin@intel.com>