### PR TITLE
defs-zos: [Fix] prevent schema parsers from hitting recursion-loop while resolving types.

### DIFF
--- a/schema/defs-zos.json
+++ b/schema/defs-zos.json
@@ -32,16 +32,16 @@
                   "$ref": "defs.json#/definitions/FilePath"
                 },
                 "type": {
-                  "$ref": "defs-zos.json#/definitions/FileType"
+                  "$ref": "#/definitions/FileType"
                 },
                 "major": {
-                  "$ref": "defs-zos.json#/definitions/Major"
+                  "$ref": "#/definitions/Major"
                 },
                 "minor": {
-                  "$ref": "defs-zos.json#/definitions/Minor"
+                  "$ref": "#/definitions/Minor"
                 },
                 "fileMode": {
-                    "$ref": "defs-zos.json#/definitions/FileMode"
+                    "$ref": "#/definitions/FileMode"
                 },
                 "uid": {
                     "$ref": "defs.json#/definitions/UID"


### PR DESCRIPTION
Hi Team, 

Following PR makes sure that `des-zos.json` is consistent with schema definition w.r.t to entire spec.  

I think following PR ( https://github.com/opencontainers/runtime-spec/pull/1095 )  has introduced type-resolution issues on downstream parsers. 
Specifying definition-files for types present in existing `.json` would result in infinite type resolution loop. However existing convention is just using `#` instead of specifying def-file for example  https://github.com/opencontainers/runtime-spec/blob/master/schema/defs-linux.json

Thanks