### PR TITLE
fix the lifecycle reference in the states listing

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -18,8 +18,8 @@ The state of a container includes the following properties:
 
     * `creating`: the container is being created (step 2 in the [lifecycle](#lifecycle))
     * `created`: the runtime has finished the [create operation](#create) (after step 2 in the [lifecycle](#lifecycle)), and the container process has neither exited nor executed the user-specified program
-    * `running`: the container process has executed the user-specified program but has not exited (after step 5 in the [lifecycle](#lifecycle))
-    * `stopped`: the container process has exited (step 7 in the [lifecycle](#lifecycle))
+    * `running`: the container process has executed the user-specified program but has not exited (after step 8 in the [lifecycle](#lifecycle))
+    * `stopped`: the container process has exited (step 10 in the [lifecycle](#lifecycle))
 
     Additional values MAY be defined by the runtime, however, they MUST be used to represent new runtime states not defined above.
 * **`pid`** (int, REQUIRED when `status` is `created` or `running` on Linux, OPTIONAL on other platforms) is the ID of the container process.


### PR DESCRIPTION
In PR #1008 three new steps in the lifecycle were added(4./5./7.) and the referencing of the states to the corresponding lifecycle step was not adjusted. Based on Tag v1.0.0-rc6, the references to the lifecycle steps were corrected.