### PR TITLE
config-linux: add CFS bandwidth burst

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -360,6 +360,9 @@ The following parameters can be specified to set up the controller:
 
 * **`shares`** *(uint64, OPTIONAL)* - specifies a relative share of CPU time available to the tasks in a cgroup
 * **`quota`** *(int64, OPTIONAL)* - specifies the total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by **`period`** below)
+    If specified with any (valid) positive value, it MUST be no smaller than `burst` (runtimes MAY generate an error).
+* **`burst`** *(uint64, OPTIONAL)* - specifies the maximum amount of accumulated time in microseconds for which all tasks in a cgroup can run additionally for burst during one period (as defined by **`period`** below)
+    If specified, this value MUST be no larger than any positive `quota` (runtimes MAY generate an error).
 * **`period`** *(uint64, OPTIONAL)* - specifies a period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated (CFS scheduler only)
 * **`realtimeRuntime`** *(int64, OPTIONAL)* - specifies a period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources
 * **`realtimePeriod`** *(uint64, OPTIONAL)* - same as **`period`** but applies to realtime scheduler only
@@ -373,6 +376,7 @@ The following parameters can be specified to set up the controller:
 "cpu": {
     "shares": 1024,
     "quota": 1000000,
+    "burst": 1000000,
     "period": 500000,
     "realtimeRuntime": 950000,
     "realtimePeriod": 1000000,

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -110,6 +110,9 @@
                             "quota": {
                                 "$ref": "defs.json#/definitions/int64"
                             },
+                            "burst": {
+                                "$ref": "defs.json#/definitions/uint64"
+                            },
                             "realtimePeriod": {
                                 "$ref": "defs.json#/definitions/uint64"
                             },

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -275,6 +275,7 @@
             "cpu": {
                 "shares": 1024,
                 "quota": 1000000,
+                "burst": 1000000,
                 "period": 500000,
                 "realtimeRuntime": 950000,
                 "realtimePeriod": 1000000,

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -327,6 +327,9 @@ type LinuxCPU struct {
 	Shares *uint64 `json:"shares,omitempty"`
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
 	Quota *int64 `json:"quota,omitempty"`
+	// CPU hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst in a
+	// given period.
+	Burst *uint64 `json:"burst,omitempty"`
 	// CPU period to be used for hardcapping (in usecs).
 	Period *uint64 `json:"period,omitempty"`
 	// How much time realtime scheduling may use (in usecs).


### PR DESCRIPTION
Burstable CFS controller is introduced in Linux 5.14. This helps with
parallel workloads that might be bursty. They can get throttled even
when their average utilization is under quota. And they may be latency
sensitive at the same time so that throttling them is undesired.

This feature borrows time now against the future underrun, at the cost
of increased interference against the other system users, by introducing
`cfs_burst_us` into CFS bandwidth control to enact the cap on unused
bandwidth accumulation, which will then used additionally for burst.

The patch adds the support/control for CFS bandwidth burst.

Fixes https://github.com/opencontainers/runtime-spec/issues/1119

Signed-off-by: Kailun Qin <kailun.qin@intel.com>