### PR TITLE
config-linux: add idle option for container cgroup

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -361,6 +361,7 @@ The following parameters can be specified to set up the controller:
 * **`realtimePeriod`** *(uint64, OPTIONAL)* - same as **`period`** but applies to realtime scheduler only
 * **`cpus`** *(string, OPTIONAL)* - list of CPUs the container will run in
 * **`mems`** *(string, OPTIONAL)* - list of Memory Nodes the container will run in
+* **`idle`** *(int64, OPTIONAL)* - cgroups are configured with minimum weight, 0: default behavior, 1: SCHED_IDLE.
 
 #### Example
 
@@ -372,7 +373,8 @@ The following parameters can be specified to set up the controller:
     "realtimeRuntime": 950000,
     "realtimePeriod": 1000000,
     "cpus": "2-3",
-    "mems": "0-7"
+    "mems": "0-7",
+    "idle": 0
 }
 ```
 

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -330,6 +330,8 @@ type LinuxCPU struct {
 	Cpus string `json:"cpus,omitempty"`
 	// List of memory nodes in the cpuset. Default is to use any available memory node.
 	Mems string `json:"mems,omitempty"`
+	// cgroups are configured with minimum weight, 0: default behavior, 1: SCHED_IDLE. Default 0
+	Idle *int64 `json:"idle,omitempty"`
 }
 
 // LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3)

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -330,8 +330,8 @@ type LinuxCPU struct {
 	Cpus string `json:"cpus,omitempty"`
 	// List of memory nodes in the cpuset. Default is to use any available memory node.
 	Mems string `json:"mems,omitempty"`
-	// cgroups are configured with minimum weight, 0: default behavior, 1: SCHED_IDLE. Default 0
-	Idle *int64 `json:"idle,omitempty"`
+	// cgroups are configured with minimum weight, 0: default behavior, 1: SCHED_IDLE.
+	Idle int64 `json:"idle"`
 }
 
 // LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3)


### PR DESCRIPTION
[sched: Cgroup SCHED_IDLE support](https://lore.kernel.org/lkml/162971078674.25758.15464079371945307825.tip-bot2@tip-bot2/#r) is introduced in Linux 5.15

we can mark a container SCHED_IDLE with this feature which means its sched weight are configured to the minimum

see also #1135 