### PR TITLE
cgroup ownership: clarify that some files may not exist

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -236,10 +236,14 @@ SHOULD NOT change the cgroup ownership.
 
 A runtime that changes the cgroup ownership SHOULD only change the
 ownership of the container's cgroup directory and files within that
-directory that are listed in `/sys/kernel/cgroup/delegate` (see
-`cgroups(7)` for details about this file).  If the
-`/sys/kernel/cgroup/delegate` file does not exist, the runtime MUST
-fall back to using the following list of files:
+directory that are listed in `/sys/kernel/cgroup/delegate`.  See
+`cgroups(7)` for details about this file.  Note that not all files
+listed in `/sys/kernel/cgroup/delegate` necessarily exist in every
+cgroup.  Runtimes MUST NOT fail in this scenario, and SHOULD change
+the ownership of the listed files that do exist in the cgroup.
+
+If the `/sys/kernel/cgroup/delegate` file does not exist, the
+runtime MUST fall back to using the following list of files:
 
 ```
 cgroup.procs


### PR DESCRIPTION
Not all files listed in /sys/kernel/cgroup/delegate necessarily
exist in all cgroups.  For example, see this issue and PR:

- https://github.com/opencontainers/runc/issues/3387
- https://github.com/opencontainers/runc/pull/3389

Expand the cgroup ownership semantics to ensure that runtime authors
are aware of this possibility and implementations handle it
gracefully.