### PR TITLE
config-linux: Fix example of cpu quota

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -371,8 +371,8 @@ The following parameters can be specified to set up the controller:
 ```json
 "cpu": {
     "shares": 1024,
-    "quota": 1000000,
-    "period": 500000,
+    "quota": 500000,
+    "period": 1000000,
     "realtimeRuntime": 950000,
     "realtimePeriod": 1000000,
     "cpus": "2-3",


### PR DESCRIPTION
Quota should be smaller than period length.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>