### PR TITLE
Hook: add type attribute to spec

### DIFF
--- a/config.md
+++ b/config.md
@@ -390,6 +390,8 @@ For POSIX platforms, the configuration structure supports `hooks` for configurin
             * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008's `environ`][ieee-1003.1-2008-xbd-c8.1].
             * **`timeout`** (int, OPTIONAL) is the number of seconds before aborting the hook.
                 If set, `timeout` MUST be greater than zero.
+            * **`type`** *(string, OPTIONAL)* - hook type, which defines where should the hooks run.
+                Valid values are `host` or `guest`, defaults to `host`.
         * The value of `path` MUST resolve in the [runtime namespace](glossary.md#runtime-namespace).
         * The `prestart` hooks MUST be executed in the [runtime namespace](glossary.md#runtime-namespace).
     * **`createRuntime`** (array of objects, OPTIONAL) is an array of [`createRuntime` hooks](#createRuntime-hooks).
@@ -400,6 +402,8 @@ For POSIX platforms, the configuration structure supports `hooks` for configurin
             * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008's `environ`][ieee-1003.1-2008-xbd-c8.1].
             * **`timeout`** (int, OPTIONAL) is the number of seconds before aborting the hook.
                 If set, `timeout` MUST be greater than zero.
+            * **`type`** *(string, OPTIONAL)* - hook type, which defines where should the hooks run.
+                Valid values are `host` or `guest`, defaults to `host`.
         * The value of `path` MUST resolve in the [runtime namespace](glossary.md#runtime-namespace).
         * The `createRuntime` hooks MUST be executed in the [runtime namespace](glossary.md#runtime-namespace).
     * **`createContainer`** (array of objects, OPTIONAL) is an array of [`createContainer` hooks](#createContainer-hooks).
@@ -539,8 +543,13 @@ See the below table for a summary of hooks and when they are called:
     ],
     "poststop": [
         {
-            "path": "/usr/sbin/cleanup.sh",
-            "args": ["cleanup.sh", "-f"]
+            "path": "/usr/sbin/cleanup-host.sh",
+            "args": ["cleanup-host.sh", "-f"]
+        },
+        {
+            "path": "/usr/sbin/cleanup-guest.sh",
+            "args": ["cleanup-guest.sh", "-f"],
+            "type": "guest",
         }
     ]
 }

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -81,6 +81,13 @@
         "Env": {
             "$ref": "#/definitions/ArrayOfStrings"
         },
+        "HookType": {
+            "type": "string",
+            "enum": [
+                "host",
+                "guest"
+            ]
+        },
         "Hook": {
             "type": "object",
             "properties": {
@@ -96,6 +103,9 @@
                 "timeout": {
                     "type": "integer",
                     "minimum": 1
+                },
+                "type": {
+                    "$ref": "#/definitions/HookType"
                 }
             },
             "required": [

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -152,7 +152,8 @@
                 ]
             },
             {
-                "path": "/usr/bin/setup-network"
+                "path": "/usr/bin/setup-network",
+                "type": "host"
             }
         ],
         "createRuntime": [
@@ -170,6 +171,10 @@
                 "path": "/usr/bin/mount-hook",
                 "args": ["-mount", "arg1", "arg2"],
                 "env":  [ "key1=value1"]
+            },
+            {
+                "path": "/usr/bin/download-data",
+                "type": "guest"
             }
         ],
         "startContainer": [

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -125,7 +125,18 @@ type Hook struct {
 	Args    []string `json:"args,omitempty"`
 	Env     []string `json:"env,omitempty"`
 	Timeout *int     `json:"timeout,omitempty"`
+	Type    HookType `json:"type,omitempty"`
 }
+
+// HookType is the type of hooks
+type HookType string
+
+const (
+	// HostHook for hooks run on the host side
+	HostHook HookType = "host"
+	// GuestHook for hooks run on the guest side
+	GuestHook HookType = "guest"
+)
 
 // Hooks specifies a command that is run in the container at a particular event in the lifecycle of a container
 // Hooks for container setup and teardown


### PR DESCRIPTION
For vm-based runtimes, like Kata Containers, the hooks become
confused, some hooks may need run on the host side, but others
may need to run on the guest side.

Add type attribute identity where the hooks should run, the
host side or guest side, and let runtime treat them separately.

Signed-off-by: bin liu <liubin0329@gmail.com>