### PR TITLE
config-linux: update type of LinuxCPU.Idle  to *int64

### DIFF
--- a/config.md
+++ b/config.md
@@ -840,6 +840,7 @@ Here is a full example `config.json` for reference.
                 "realtimeRuntime": 950000,
                 "realtimePeriod": 1000000,
                 "cpus": "2-3",
+                "idle": 1,
                 "mems": "0-7"
             },
             "devices": [

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -331,7 +331,7 @@ type LinuxCPU struct {
 	// List of memory nodes in the cpuset. Default is to use any available memory node.
 	Mems string `json:"mems,omitempty"`
 	// cgroups are configured with minimum weight, 0: default behavior, 1: SCHED_IDLE.
-	Idle int64 `json:"idle"`
+	Idle *int64 `json:"idle,omitempty"`
 }
 
 // LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3)


### PR DESCRIPTION
the config values should contain a value that means "do not modify it" within its range of values. for `int64` in other cases, we usually use `0` to express this meaning, but in `cpu.idle`, `0` can not be regarded as this meaning.

by changing the type from `int64`to `*int64`, we can use `nil` solve this problem