### PR TITLE
config-linux: Clarify where device nodes can be created

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -118,6 +118,7 @@ Each entry has the following structure:
     More info in [mknod(1)][mknod.1].
 * **`path`** *(string, REQUIRED)* - full path to device inside container.
     If a [file][] already exists at `path` that does not match the requested device, the runtime MUST generate an error.
+    The path MAY be anywhere in the container filesystem, notably outside of `/dev`.
 * **`major, minor`** *(int64, REQUIRED unless `type` is `p`)* - [major, minor numbers][devices] for the device.
 * **`fileMode`** *(uint32, OPTIONAL)* - file mode for the device.
     You can also control access to devices [with cgroups](#configLinuxDeviceAllowedlist).
@@ -125,6 +126,14 @@ Each entry has the following structure:
 * **`gid`** *(uint32, OPTIONAL)* - id of device group in the [container namespace](glossary.md#container-namespace).
 
 The same `type`, `major` and `minor` SHOULD NOT be used for multiple devices.
+
+Containers MAY NOT access any device node that is not either explicitly
+referenced in the **`devices`** array or listed as being part of the
+[default devices](#configLinuxDefaultDevices).
+Rationale: runtimes based on virtual machines need to be able to adjust the node
+devices, and accessing device nodes that were not adjusted could have undefined
+behaviour.
+
 
 ### Example
 


### PR DESCRIPTION
Clarify that device nodes need not be under `/dev`, but that the runtime need to
be informed of all the device nodes that are used by the
container.

Virtual-machine based runtimes such as Kata Containers need to be able to
perform adjustment on device nodes, and cannot be required to deep-scan
file-systems to do so.

The proposed wording was chosen to avoid any regression for any workload
mounding nodes elsewhere, while at the same time clarifying that correct
behaviour cannot be guaranteed if a device node is created on the host and used
by the container without being passed in the devices list.

This fixes issue #1147.

Signed-off-by: Christophe de Dinechin <christophe@dinechin.org>