### PR TITLE
Add support for time namespace

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -34,6 +34,7 @@ The following parameters can be specified to set up namespaces:
     * **`uts`** the container will be able to have its own hostname and domain name.
     * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container.
     * **`cgroup`** the container will have an isolated view of the cgroup hierarchy.
+    * **`time`** the container will be able to have its own clocks.
 * **`path`** *(string, OPTIONAL)* - namespace file.
     This value MUST be an absolute path in the [runtime mount namespace](glossary.md#runtime-namespace).
     The runtime MUST place the container process in the namespace associated with that `path`.
@@ -70,6 +71,9 @@ If a `namespaces` field contains duplicated namespaces with same `type`, the run
     },
     {
         "type": "cgroup"
+    },
+    {
+        "type": "time"
     }
 ]
 ```
@@ -106,6 +110,17 @@ Note that the number of mapping entries MAY be limited by the [kernel][user-name
     }
 ]
 ```
+
+## <a name="configLinuxTimeOffset" />Offset for Time Namespace
+
+**`timeOffsets`** (object, OPTIONAL) sets the offset for Time Namespace. For more information
+see the [time_namespaces](time_namespaces.7).
+
+The name of the clock is the entry key.
+Entry values are objects with the following properties:
+
+* **`secs`** *(int64, OPTIONAL)* - is the offset of clock (in seconds) in the container.
+* **`nanosecs`** *(uint32, OPTIONAL)* - is the offset of clock (in nanoseconds) in the container.
 
 ## <a name="configLinuxDevices" />Devices
 
@@ -770,3 +785,4 @@ subset of the available options.
 [zero.4]: http://man7.org/linux/man-pages/man4/zero.4.html
 [user-namespaces]: http://man7.org/linux/man-pages/man7/user_namespaces.7.html
 [intel-rdt-cat-kernel-interface]: https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt
+[time_namespaces.7]: https://man7.org/linux/man-pages/man7/time_namespaces.7.html

--- a/config.md
+++ b/config.md
@@ -905,6 +905,16 @@ Here is a full example `config.json` for reference.
                 }
             ]
         },
+        "timeOffsets": {
+            "monotonic": {
+                "secs": 172800,
+                "nanosecs": 0
+            },
+            "boottime": {
+                "secs": 604800,
+                "nanosecs": 0
+            }
+        },
         "namespaces": [
             {
                 "type": "pid"
@@ -926,6 +936,9 @@ Here is a full example `config.json` for reference.
             },
             {
                 "type": "cgroup"
+            },
+            {
+                "type": "time"
             }
         ],
         "maskedPaths": [

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -253,6 +253,12 @@
             "personality": {
                 "type": "object",
                 "$ref": "defs-linux.json#/definitions/Personality"
+            },
+            "timeOffsets": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "defs-linux.json#/definitions/TimeOffsets"
+                }
             }
         }
     }

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -292,7 +292,8 @@
                 "uts",
                 "ipc",
                 "user",
-                "cgroup"
+                "cgroup",
+                "time"
             ]
         },
         "NamespaceReference": {
@@ -308,6 +309,17 @@
             "required": [
                 "type"
             ]
+        },
+        "TimeOffsets": {
+            "type": "object",
+            "properties": {
+                "secs": {
+                    "$ref": "defs.json#/definitions/int64"
+                },
+                "nanosecs": {
+                    "$ref": "defs.json#/definitions/uint32"
+                }
+            }
         }
     }
 }

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -349,6 +349,16 @@
                 }
             ]
         },
+        "timeOffsets": {
+            "monotonic": {
+                "secs": 172800,
+                "nanosecs": 0
+            },
+            "boottime": {
+                "secs": 604800,
+                "nanosecs": 0
+            }
+        },
         "namespaces": [
             {
                 "type": "pid"
@@ -370,6 +380,9 @@
             },
             {
                 "type": "cgroup"
+            },
+            {
+                "type": "time"
             }
         ],
         "maskedPaths": [

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -182,6 +182,8 @@ type Linux struct {
 	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
 	// Personality contains configuration for the Linux personality syscall
 	Personality *LinuxPersonality `json:"personality,omitempty"`
+	// TimeOffsets specifies the offset for supporting time namespaces.
+	TimeOffsets map[string]LinuxTimeOffset `json:"timeOffsets,omitempty"`
 }
 
 // LinuxNamespace is the configuration for a Linux namespace
@@ -211,6 +213,8 @@ const (
 	UserNamespace LinuxNamespaceType = "user"
 	// CgroupNamespace for isolating cgroup hierarchies
 	CgroupNamespace LinuxNamespaceType = "cgroup"
+	// TimeNamespace for isolating the clocks
+	TimeNamespace LinuxNamespaceType = "time"
 )
 
 // LinuxIDMapping specifies UID/GID mappings
@@ -221,6 +225,14 @@ type LinuxIDMapping struct {
 	HostID uint32 `json:"hostID"`
 	// Size is the number of IDs to be mapped
 	Size uint32 `json:"size"`
+}
+
+// LinuxTimeOffset specifies the offset for Time Namespace
+type LinuxTimeOffset struct {
+	// Secs is the offset of clock (in secs) in the container
+	Secs int64 `json:"secs,omitempty"`
+	// Nanosecs is the additional offset for Secs (in nanosecs)
+	Nanosecs uint32 `json:"nanosecs,omitempty"`
 }
 
 // POSIXRlimit type and restrictions


### PR DESCRIPTION
The time namespace is a new kernel feature available in 5.6+ to
isolate the system monotonic and boot-time clocks.

I'm sorry I mistook and closed the existing request https://github.com/opencontainers/runtime-spec/pull/1062

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>