### PR TITLE
config-linux: add sysDevBlock

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -894,6 +894,20 @@ subset of the available options.
 * **`flags`** *(array of strings, OPTIONAL)* - the additional flags to apply.
     Currently no flag values are supported.
 
+## <a name="configLinuxSysDevBlock" />SysDevBlock
+
+**`sysDevBlock`** (boolean, OPTIONAL), if true, will expose /sys/dev/block symlinks for the mounts
+and devices in the container. This allows containers to navigate via these symlinks to the
+/sys/device hierarachy exposing information about the storage attributes that the container may
+use.
+
+If false, or missing, the default exposure of /sys/dev/block from the container runtime occurs.
+
+### Example
+
+```json
+"sysDevBlock": true
+```
 
 [cgroup-v1]: https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
 [cgroup-v1-blkio]: https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -189,6 +189,8 @@ type Linux struct {
 	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
 	// Personality contains configuration for the Linux personality syscall
 	Personality *LinuxPersonality `json:"personality,omitempty"`
+	// Expose /sys/dev/block entries for mounts and devices in the container.
+	SysDevBlock bool `json:"sysdevblock,omitempty"`
 }
 
 // LinuxNamespace is the configuration for a Linux namespace


### PR DESCRIPTION
This is to expose the /sys/dev/block hierarchy to the container for devices of mounted filesystems and block devices of the containers.

In [rhbz#1772993](https://bugzilla.redhat.com/show_bug.cgi?id=1772993) the OCP decided to block the system storage information from unprivileged containers. As a move to re-expose this information back to the unprivileged containers, this add the option back, leaving the default behaviour to what the container runtime previously did.

The population and use of this option has a implementation under review https://github.com/containers/podman/pull/13708.