### PR TITLE
add domainname spec entity

### DIFF
--- a/config.md
+++ b/config.md
@@ -355,6 +355,18 @@ For Windows based systems the user structure has the following fields:
 "hostname": "mrsdalloway"
 ```
 
+## <a name="configDomainname" />Domainname
+
+* **`domainname`** (string, OPTIONAL) specifies the container's domainname as seen by processes running inside the container.
+    On Linux, for example, this will change the domainname in the [container](glossary.md#container-namespace) [UTS namespace][uts-namespace.7].
+    Depending on your [namespace configuration](config-linux.md#namespaces), the container UTS namespace may be the [runtime](glossary.md#runtime-namespace) [UTS namespace][uts-namespace.7].
+
+### Example
+
+```json
+"domainname": "foobarbaz.test"
+```
+
 ## <a name="configPlatformSpecificConfiguration" />Platform-specific configuration
 
 * **`linux`** (object, OPTIONAL) [Linux-specific configuration](config-linux.md).

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -35,6 +35,9 @@
         "hostname": {
             "type": "string"
         },
+        "domainname": {
+            "type": "string"
+        },
         "mounts": {
             "type": "array",
             "items": {

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -63,6 +63,7 @@
         "readonly": true
     },
     "hostname": "slartibartfast",
+    "domainname": "foobarbaz.test",
     "mounts": [
         {
             "destination": "/proc",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -12,6 +12,8 @@ type Spec struct {
 	Root *Root `json:"root,omitempty"`
 	// Hostname configures the container's hostname.
 	Hostname string `json:"hostname,omitempty"`
+	// Domainname configures the container's domainname.
+	Domainname string `json:"domainname,omitempty"`
 	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
 	// Hooks configures callbacks for container lifecycle events.


### PR DESCRIPTION
add the domainname entity so that container runtimes can add special handling similar to hostname. The current workaround of adding a sysctl for kernel.domainname only works with rootful execution in most cases. This will allow for rootless execution.

container runtimes will be able to add special handling as they do for hostname, using setdomainname to add the entry to /proc/sys/kernel/domainname.

Signed-off-by: Charlie Doern <cdoern@redhat.com>