### PR TITLE
config-linux: add memory.checkBeforeUpdate

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -336,6 +336,11 @@ The following properties do not specify memory limits, but are covered by the `m
     To disable it, specify a value of `true`.
 * **`useHierarchy`** *(bool, OPTIONAL)* - enables or disables hierarchical memory accounting.
     If enabled (`true`), child cgroups will share the memory limits of this cgroup.
+* **`checkBeforeUpdate`** *(bool, OPTIONAL)* - enables container memory usage check before setting a new limit.
+    If enabled (`true`), runtime MAY check if a new memory limit is lower than the current usage, and MUST
+    reject the new limit. Practically, when cgroup v1 is used, the kernel rejects the limit lower than the
+    current usage, and when cgroup v2 is used, an OOM killer is invoked. This setting can be used on
+    cgroup v2 to mimic the cgroup v1 behavior.
 
 #### Example
 

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -169,6 +169,9 @@
                             },
                             "useHierarchy": {
                                 "type": "boolean"
+                            },
+                            "checkBeforeUpdate": {
+                                "type": "boolean"
                             }
                         }
                     },

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -270,7 +270,8 @@
                 "kernelTCP": -1,
                 "swappiness": 0,
                 "disableOOMKiller": false,
-                "useHierarchy": false
+                "useHierarchy": false,
+                "checkBeforeUpdate": false
             },
             "cpu": {
                 "shares": 1024,

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -319,6 +319,10 @@ type LinuxMemory struct {
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Enables hierarchical memory accounting
 	UseHierarchy *bool `json:"useHierarchy,omitempty"`
+	// CheckBeforeUpdate enables checking if a new memory limit is lower
+	// than the current usage during update, and if so, rejecting the new
+	// limit.
+	CheckBeforeUpdate *bool `json:"checkBeforeUpdate,omitempty"`
 }
 
 // LinuxCPU for Linux cgroup 'cpu' resource management


### PR DESCRIPTION
This setting can be used to mimic cgroup v1 behavior on cgroup v2,
when setting the new memory limit during update operation.

In cgroup v1, a limit which is lower than the current usage is rejected.

In cgroup v2, such a low limit is causing an OOM kill.

Ref: https://github.com/opencontainers/runc/issues/3509