### PR TITLE
config-linux.md: formalize the order of `seccomp.syscalls`

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -759,6 +759,11 @@ The following parameters can be specified to set up seccomp:
             * `SCMP_CMP_GT`
             * `SCMP_CMP_MASKED_EQ`
 
+    Syscalls in this list are not guaranteed to be unique, and MAY appear multiple
+    times. If a syscall appears multiple times, runtimes MUST use the first match,
+    and MUST ignore further occurrences. Runtimes MAY log a warning if duplicate entries
+    are present.
+
 ### Example
 
 ```json


### PR DESCRIPTION
When the syscall matches multiple entries, only the first entry is effective.

Corresponds to the behavior of existing implementations such as runc.

