### PR TITLE
seccomp: Add flag SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -701,6 +701,7 @@ The following parameters can be specified to set up seccomp:
     * `SECCOMP_FILTER_FLAG_TSYNC`
     * `SECCOMP_FILTER_FLAG_LOG`
     * `SECCOMP_FILTER_FLAG_SPEC_ALLOW`
+    * `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV`
 
 * **`listenerPath`** *(string, OPTIONAL)* - specifies the path of UNIX domain socket over which the runtime will send the [container process state](#containerprocessstate) data structure when the `SCMP_ACT_NOTIFY` action is used.
     This socket MUST use `AF_UNIX` domain and `SOCK_STREAM` type.

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -70,7 +70,8 @@
             "enum": [
                 "SECCOMP_FILTER_FLAG_TSYNC",
                 "SECCOMP_FILTER_FLAG_LOG",
-                "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
+                "SECCOMP_FILTER_FLAG_SPEC_ALLOW",
+                "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV"
             ]
         },
         "SeccompOperators": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -645,6 +645,10 @@ const (
 	// LinuxSeccompFlagSpecAllow can be used to disable Speculative Store
 	// Bypass mitigation. (since Linux 4.17)
 	LinuxSeccompFlagSpecAllow LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
+
+	// LinuxSeccompFlagWaitKillableRecv can be used to switch to the wait
+	// killable semantics. (since Linux 5.19)
+	LinuxSeccompFlagWaitKillableRecv LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV"
 )
 
 // Additional architectures permitted to be used for system calls


### PR DESCRIPTION
Linux 5.19 (https://github.com/torvalds/linux/commit/c2aa2dfef243) introduced a new seccomp flag: SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV


It is useful for seccomp notify when handling notification from Golang programs which are often preempted by the runtime with SIGURG.