### PR TITLE
[RFC]: IMA Namespace support

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -218,6 +218,8 @@ const (
 	UTSNamespace LinuxNamespaceType = "uts"
 	// UserNamespace for isolating user and group IDs
 	UserNamespace LinuxNamespaceType = "user"
+	// ImaNamespace for isolating PCR values
+	ImaNamespace LinuxNamespaceType = "ima"
 	// CgroupNamespace for isolating cgroup hierarchies
 	CgroupNamespace LinuxNamespaceType = "cgroup"
 )


### PR DESCRIPTION
The Linux kernel community is now working on supporting [IMA namespaces](https://lore.kernel.org/linux-integrity/20220302134703.1273041-1-stefanb@linux.ibm.com/T/)
and it is almost done. It is a new kernel feature that allows isolation of  Platform Configuration Register (PCR) values, Measurement Logs (ML), etc. The related issue is #1163.

Signed-off-by: Ilya Hanov <ilya.hanov@huawei-partners.com>

Advanced Software Technology Lab
Huawei