### PR TITLE
config: change prestart hook spec to match reality

### DIFF
--- a/config.md
+++ b/config.md
@@ -442,8 +442,9 @@ The [state](runtime.md#state) of the container MUST be passed to hooks over stdi
 
 ### <a name="configHooksPrestart" />Prestart
 
-The `prestart` hooks MUST be called after the [`start`](runtime.md#start) operation is called but [before the user-specified program command is executed](runtime.md#lifecycle).
+The `prestart` hooks MUST be called as part of the [`create`](runtime.md#create) operation after the runtime environment has been created (according to the configuration in config.json) but before the `pivot_root` or any equivalent operation has been executed.
 On Linux, for example, they are called after the container namespaces are created, so they provide an opportunity to customize the container (e.g. the network namespace could be specified in this hook).
+The `prestart` hooks MUST be called before the `createRuntime` hooks.
 
 Note: `prestart` hooks were deprecated in favor of `createRuntime`, `createContainer` and `startContainer` hooks, which allow more granular hook control during the create and start phase.
 
@@ -460,8 +461,6 @@ The `createRuntime` hooks MUST be executed in the [runtime namespace](glossary.m
 On Linux, for example, they are called after the container namespaces are created, so they provide an opportunity to customize the container (e.g. the network namespace could be specified in this hook).
 
 The definition of `createRuntime` hooks is currently underspecified and hooks authors, should only expect from the runtime that the mount namespace have been created and the mount operations performed. Other operations such as cgroups and SELinux/AppArmor labels might not have been performed by the runtime.
-
-Note: `runc` originally implemented `prestart` hooks contrary to the spec, namely as part of the `create` operation (instead of during the `start` operation). This incorrect implementation actually corresponds to `createRuntime` hooks. For runtimes that implement the deprecated `prestart` hooks as `createRuntime` hooks, `createRuntime` hooks MUST be called after the `prestart` hooks.
 
 ### <a name="configHooksCreateContainer" />CreateContainer Hooks
 


### PR DESCRIPTION
runC originally implemented prestart hooks contrary to the spec. [And it still implements them the same way today](https://github.com/opencontainers/runc/blob/8da0a0b5675764feaaaaad466f6567a9983fcd08/libcontainer/process_linux.go#L525-L530), as it would break a lot of projects which have come to rely on the existing behaviour. Any OCI runtime implementations which want to be compatible with projects that have come to rely on the existing runC behaviour must also implement them contrary to the spec. Furthermore, the Lifecycle section of the spec requires the existing runC behaviour for the prestart hook, _directly contradicting the section of the spec which defines the prestart hook in config.md!_

https://github.com/opencontainers/runtime-spec/blob/494a5a6aca782455c0fbfc35af8e12f04e98a55e/runtime.md?plain=1#L52-L77
https://github.com/opencontainers/runtime-spec/blob/494a5a6aca782455c0fbfc35af8e12f04e98a55e/config.md?plain=1#L445

Given that existing implementations cannot be changed, the spec contradicts existing implementations, and the spec contradicts _itself_, amending the spec to align with the existing runC behaviour is the only viable way to resolve the contradiction.

- Alternative to #1167 for resolving the conflict within the spec