### PR TITLE
runtime: remove `When serialized in JSON, the format MUST adhere to the following pattern`

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -32,7 +32,11 @@ The state of a container includes the following properties:
 
 The state MAY include additional properties.
 
-When serialized in JSON, the format MUST adhere to the following pattern:
+When serialized in JSON, the format MUST adhere to the JSON Schema [`schema/state-schema.json`](schema/state-schema.json).
+
+See [Query State](#query-state) for information on retrieving the state of a container.
+
+### Example
 
 ```json
 {
@@ -46,8 +50,6 @@ When serialized in JSON, the format MUST adhere to the following pattern:
     }
 }
 ```
-
-See [Query State](#query-state) for information on retrieving the state of a container.
 
 ## <a name="runtimeLifecycle" />Lifecycle
 The lifecycle describes the timeline of events that happen from when a container is created to when it ceases to exist.


### PR DESCRIPTION
The sentence looked like as if it required a specific indentation pattern.

Fix #1177
