### PR TITLE
Add Go 1.20 support

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,22 +11,32 @@ jobs:
     steps:
       - name: checkout source code
         uses: actions/checkout@master
+
       - name: setup go environment
         uses: actions/setup-go@v1
         with:
           go-version: '1.17.2'
+      
+      - name: create go.mod
+        run: |
+          # Fix for "cannot find main module" issue
+          go mod init github.com/opencontainers/runtime-spec
+
+          go get -d ./schema/...
+
+      - name: run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.51.2
+          args: --verbose
+
       - name: run tests
         run: |
           export PATH="$(go env GOPATH)/bin:${PATH}"
           set -x
           make install.tools
 
-          # Fix for "cannot find main module" issue
-          go mod init github.com/opencontainers/runtime-spec
-
-          go get -d ./schema/...
           make .govet
-          make .golint
 
           make .gitvalidation
           make docs

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,14 +8,19 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go: [1.19.x, 1.20.x]
+
     steps:
       - name: checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: setup go environment
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.17.2'
+          go-version: ${{ matrix.go }}
       
       - name: create go.mod
         run: |
@@ -32,7 +37,6 @@ jobs:
 
       - name: run tests
         run: |
-          export PATH="$(go env GOPATH)/bin:${PATH}"
           set -x
           make install.tools
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,22 +11,32 @@ jobs:
     steps:
       - name: checkout source code
         uses: actions/checkout@master
+
       - name: setup go environment
         uses: actions/setup-go@v1
         with:
           go-version: '1.17.2'
+
+      - name: create go.mod
+        run: |
+          # Fix for "cannot find main module" issue
+          go mod init github.com/opencontainers/runtime-spec
+
+          go get -d ./schema/...
+
+      - name: run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.51.2
+          args: --verbose
+
       - name: run tests
         run: |
           export PATH="$(go env GOPATH)/bin:${PATH}"
           set -x
           make install.tools
 
-          # Fix for "cannot find main module" issue
-          go mod init github.com/opencontainers/runtime-spec
-
-          go get -d ./schema/...
           make .govet
-          make .golint
 
           make .gitvalidation
           make docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,19 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go: [1.19.x, 1.20.x]
+
     steps:
       - name: checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: setup go environment
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.17.2'
+          go-version: ${{ matrix.go }}
 
       - name: create go.mod
         run: |
@@ -32,7 +37,6 @@ jobs:
 
       - name: run tests
         run: |
-          export PATH="$(go env GOPATH)/bin:${PATH}"
           set -x
           make install.tools
 

--- a/.tool/version-doc.go
+++ b/.tool/version-doc.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 install.tools: .install.gitvalidation
 
 .install.gitvalidation:
-	go get -u github.com/vbatts/git-validation
+	go install github.com/vbatts/git-validation@v1.2.0
 
 clean:
 	rm -rf $(OUTPUT_DIRNAME) *~

--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,6 @@ test: .govet .golint .gitvalidation
 .govet:
 	go vet -x ./...
 
-# `go get github.com/golang/lint/golint`
-.golint:
-ifeq ($(call ALLOWED_GO_VERSION,1.7,$(HOST_GOLANG_VERSION)),true)
-	@which golint > /dev/null 2>/dev/null || (echo "ERROR: golint not found. Consider 'make install.tools' target" && false)
-	golint ./...
-endif
-
-
 # When this is running in GitHub, it will only check the GitHub commit range
 .gitvalidation:
 	@which git-validation > /dev/null 2>/dev/null || (echo "ERROR: git-validation not found. Consider 'make install.tools' target" && false)
@@ -78,13 +70,7 @@ else
 	git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
 endif
 
-install.tools: .install.golint .install.gitvalidation
-
-# golint does not even build for <go1.7
-.install.golint:
-ifeq ($(call ALLOWED_GO_VERSION,1.7,$(HOST_GOLANG_VERSION)),true)
-	go get -u golang.org/x/lint/golint
-endif
+install.tools: .install.gitvalidation
 
 .install.gitvalidation:
 	go get -u github.com/vbatts/git-validation

--- a/schema/validate.go
+++ b/schema/validate.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,7 +61,7 @@ func main() {
 		}
 		documentLoader = gojsonschema.NewReferenceLoader("file://" + documentPath)
 	} else {
-		documentBytes, err := ioutil.ReadAll(os.Stdin)
+		documentBytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)


### PR DESCRIPTION
* Add Go 1.20 to GitHub actions matrix
* Updates actions/setup-go from v1 to v3. (Resolves deprecation warnings in GitHub actions around Node 12. Reference [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)) 

Signed-off-by: Austin Vazquez <macedonv@amazon.com>