### PR TITLE
Add loong64 support for seccomp

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -726,6 +726,7 @@ The following parameters can be specified to set up seccomp:
     * `SCMP_ARCH_PARISC`
     * `SCMP_ARCH_PARISC64`
     * `SCMP_ARCH_RISCV64`
+    * `SCMP_ARCH_LOONGARCH64`
 
 * **`flags`** *(array of strings, OPTIONAL)* - list of flags to use with seccomp(2).
 

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -48,7 +48,8 @@
                 "SCMP_ARCH_S390X",
                 "SCMP_ARCH_PARISC",
                 "SCMP_ARCH_PARISC64",
-                "SCMP_ARCH_RISCV64"
+                "SCMP_ARCH_RISCV64",
+                "SCMP_ARCH_LOONGARCH64"
             ]
         },
         "SeccompAction": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -692,6 +692,7 @@ const (
 	ArchPARISC      Arch = "SCMP_ARCH_PARISC"
 	ArchPARISC64    Arch = "SCMP_ARCH_PARISC64"
 	ArchRISCV64     Arch = "SCMP_ARCH_RISCV64"
+	ArchLOONGARCH64 Arch = "SCMP_ARCH_LOONGARCH64"
 )
 
 // LinuxSeccompAction taken upon Seccomp rule match


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html