### PR TITLE
Add the all option to kill operation

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -129,11 +129,13 @@ This operation MUST run the user-specified program as specified by [`process`](c
 This operation MUST generate an error if `process` was not set.
 
 ### <a name="runtimeKill" />Kill
-`kill <container-id> <signal>`
+`kill <container-id> <signal> <all>`
 
 This operation MUST [generate an error](#errors) if it is not provided the container ID.
 Attempting to send a signal to a container that is neither [`created` nor `running`](#state) MUST have no effect on the container and MUST [generate an error](#errors).
 This operation MUST send the specified signal to the container process.
+
+`<all>` is a boolean. If it is true, all the processes in the container are be killed.
 
 ### <a name="runtimeDelete" />Delete
 `delete <container-id>`


### PR DESCRIPTION
Since the `--all` option is already used a lot, why not include it in the specification?
* contained
    https://github.com/containerd/go-runc/blob/f5d58d02d6c8d10b17786c1da74e72aed01d4dfb/runc.go#L375-L378
* cri-o
    https://github.com/cri-o/cri-o/blob/488d8823f507fe7fb7c9041ed55ae957762b874c/internal/oci/runtime_oci.go#L1133-L1138

All of runc/crun/youki supported this option.