### PR TITLE
Release v1.1.0-rc.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,24 @@
 OpenContainers Specifications
 
+Changes with v1.1.0-rc.2:
+
+	Additions:
+
+	* config-linux: add support for rsvd hugetlb cgroup (#1116)
+	* features: add `features.md` to formalize the `runc features` JSON (#1130)
+	* config-linux: add support for time namespace (#1151)
+
+	Minor fixes and documentation:
+
+	* config-linux: clarify where device nodes can be created (#1148)
+	* runtime: remove `When serialized in JSON, the format MUST adhere to the
+	  following pattern` (#1178)
+	* Update CI to Go 1.20 (#1179)
+	* config: clarify Linux mount options (#1181)
+	* config-linux: fix url error (#1184)
+	* schema: fix schema for timeOffsets (#1193)
+	* schema: remove duplicate keys (#1195)
+
 Changes with v1.1.0-rc.1:
 
 	Breaking changes (but rather conforms to the existing runc implementation):

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.1-dev"
+	VersionDev = "-rc.2"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.2"
+	VersionDev = "-rc.2-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Call for vote: https://groups.google.com/a/opencontainers.org/g/dev/c/fnCiFoXBsiI/m/fbbmbs19EQAJ
Closes Tue Apr 4 03:33:57 AM UTC 2023

- - -
After releasing v1.1.0-rc.2, I propose feature-freezing the main branch until releasing v1.1.0 GA, with an exception for PRs that were opened before proposing v1.1.0-rc.2. (e.g., #1188 #1190 #1191)

- - -
## Changes (v1.0.2→v1.1.0-rc.1)
See https://github.com/opencontainers/runtime-spec/pull/1175

## Changes (v1.1.0-rc.1→v1.1.0-rc.2)
### Additions

* config-linux: add support for rsvd hugetlb cgroup (#1116)
* features: add `features.md` to formalize the `runc features` JSON (#1130)
* config-linux: add support for time namespace (#1151)

###  Minor fixes and documentation

* config-linux: clarify where device nodes can be created (#1148)
* runtime: remove `When serialized in JSON, the format MUST adhere to the following pattern` (#1178)
* Update CI to Go 1.20 (#1179)
* config: clarify Linux mount options (#1181)
* config-linux: fix url error (#1184)
* schema: fix schema for timeOffsets (#1193)
* schema: remove duplicate keys (#1195)