### PR TITLE
Add GitHub Labeler for platform-specific labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,19 @@
+platform/linux:
+- '**/*-linux*'
+- '**/linux-*'
+
+platform/vm:
+- '**/*-vm*'
+- '**/vm-*'
+
+platform/windows:
+- '**/*-windows*'
+- '**/windows-*'
+
+platform/solaris:
+- '**/*-solaris*'
+- '**/solaris-*'
+
+platform/zos:
+- '**/*-zos*'
+- '**/zos-*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/labeler@v4


### PR DESCRIPTION
This change adds a GitHub Labeler configuration and workflow to label pull requests based on the platform they affect automatically. This will help streamline the review process and facilitate generating release notes.

Test PR: https://github.com/utam0k/runtime-spec/pull/3