### PR TITLE
features: add potentiallyUnsafeConfigAnnotations

### DIFF
--- a/features.md
+++ b/features.md
@@ -140,6 +140,24 @@ The current version of the spec do not provide a way to enumerate the possible v
 }
 ```
 
+## <a name="featuresPotentiallyUnsafeConfigAnnotations" />Unsafe annotations in `config.json`
+
+**`potentiallyUnsafeConfigAnnotations`** (array of strings, OPTIONAL) contains values of [`annotations` property of `config.json`](config.md#annotations)
+that may potentially change the behavior of the runtime.
+
+A value that ends with "." is interpreted as a prefix of annotations.
+
+### Example
+```json
+"potentiallyUnsafeConfigAnnotations": [
+  "com.example.foo.bar",
+  "org.systemd.property."
+]
+```
+
+The example above matches `com.example.foo.bar`, `org.systemd.property.ExecStartPre`, etc.
+The example does not match `com.example.foo.bar.baz`.
+
 # Example
 
 Here is a full example for reference.

--- a/schema/features-schema.json
+++ b/schema/features-schema.json
@@ -18,6 +18,9 @@
         "annotations": {
             "$ref": "defs.json#/definitions/annotations"
         },
+        "potentiallyUnsafeConfigAnnotations": {
+            "$ref": "defs.json#/definitions/ArrayOfStrings"
+        },
          "linux": {
             "$ref": "features-linux.json#/linux"
         }

--- a/specs-go/features/features.go
+++ b/specs-go/features/features.go
@@ -24,6 +24,12 @@ type Features struct {
 	// Annotations contains implementation-specific annotation strings,
 	// such as the implementation version, and third-party extensions.
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// PotentiallyUnsafeConfigAnnotations the list of the potential unsafe annotations
+	// that may appear in `config.json`.
+	//
+	// A value that ends with "." is interpreted as a prefix of annotations.
+	PotentiallyUnsafeConfigAnnotations []string `json:"potentiallyUnsafeConfigAnnotations,omitempty"`
 }
 
 // Linux is specific to Linux.


### PR DESCRIPTION
Fix #1202 , for prohibiting propagation of insecure annotations from remote images into OCI runtime `config.json`

https://github.com/opencontainers/image-spec/pull/1061/files#r1194531089