### PR TITLE
Release v1.1.0-rc.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,23 @@
 OpenContainers Specifications
 
+Changes with v1.1.0-rc.3:
+
+	Additions:
+
+	* config: add scheduler entity (#1188)
+	* config: Add I/O Priority Configuration for process group in Linux Containers (#1191)
+
+	Minor fixes and documentation:
+
+	* config-linux: clarify I/O throttling differences between cgroup v1 and v2 (#1194)
+	* config-linux: chore: Update `ociVersion` in example (#1199)
+	* releases: use +dev as in-development suffix (#1198)
+	* MAINTAINERS: add Toru Komatsu (utam0k) (#1201)
+	* glossary: `s/features document/Features structure/g` (#1203)
+	* features: update Example (#1204)
+	* schema: fix definition for ioPriority (#1206)
+	* CODEOWNER: Add Toru Komatsu(@utam0k) to sync with MAINTAINERS (#1207)
+
 Changes with v1.1.0-rc.2:
 
 	Additions:

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.3"
+	VersionDev = "-rc.3+dev"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.2-dev"
+	VersionDev = "-rc.3"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
## Changes (v1.0.2→v1.1.0-rc.1)
See https://github.com/opencontainers/runtime-spec/pull/1175

## Changes (v1.1.0-rc.1→v1.1.0-rc.2)
See https://github.com/opencontainers/runtime-spec/pull/1192

## Changes (v1.1.0-rc.2→v1.1.0-rc.3)
### Additions:

* config: add scheduler entity (#1188)
* config: Add I/O Priority Configuration for process group in Linux Containers (#1191)

### Minor fixes and documentation:

* config-linux: clarify I/O throttling differences between cgroup v1 and v2 (#1194)
* config-linux: chore: Update `ociVersion` in example (#1199)
* releases: use +dev as in-development suffix (#1198)
* MAINTAINERS: add Toru Komatsu (utam0k) (#1201)
* glossary: `s/features document/Features structure/g` (#1203)
* features: update Example (#1204)
* schema: fix definition for ioPriority (#1206)
* CODEOWNER: Add Toru Komatsu(@utam0k) to sync with MAINTAINERS (#1207)

- - -


[[runtime-spec VOTE] tag ae35e39 as v1.1.0-rc3 (closes Mon May 29 02:08:08 PM UTC 2023)](https://groups.google.com/a/opencontainers.org/g/dev/c/VoNKGQpXh70) (at least **8** of 12 maintainers needed for this resolution to pass):
- [ ] @crosbymichael
- [ ] @mrunalp
- [x] @vbatts
- [ ] @dqminh
- [ ] @tianon
- [x] @hqhq
- [x] @cyphar
- [x] @giuseppe
- [X] @AkihiroSuda
- [x] @kolyshkin
- [x] @thaJeztah
- [x] @utam0k
