### PR TITLE
Release v1.1.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 OpenContainers Specifications
 
+Changes with v1.1.0:
+
+	Minor fixes and documentation:
+
+	* README.md: update chat information (#1210)
+	* Remove outdated meeting.ics (#1211)
+	* features: add a note to avoid confusion about annotations (#1212)
+
 Changes with v1.1.0-rc.3:
 
 	Additions:

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,51 +2,6 @@ OpenContainers Specifications
 
 Changes with v1.1.0:
 
-	Minor fixes and documentation:
-
-	* README.md: update chat information (#1210)
-	* Remove outdated meeting.ics (#1211)
-	* features: add a note to avoid confusion about annotations (#1212)
-
-Changes with v1.1.0-rc.3:
-
-	Additions:
-
-	* config: add scheduler entity (#1188)
-	* config: Add I/O Priority Configuration for process group in Linux Containers (#1191)
-
-	Minor fixes and documentation:
-
-	* config-linux: clarify I/O throttling differences between cgroup v1 and v2 (#1194)
-	* config-linux: chore: Update `ociVersion` in example (#1199)
-	* releases: use +dev as in-development suffix (#1198)
-	* MAINTAINERS: add Toru Komatsu (utam0k) (#1201)
-	* glossary: `s/features document/Features structure/g` (#1203)
-	* features: update Example (#1204)
-	* schema: fix definition for ioPriority (#1206)
-	* CODEOWNER: Add Toru Komatsu(@utam0k) to sync with MAINTAINERS (#1207)
-
-Changes with v1.1.0-rc.2:
-
-	Additions:
-
-	* config-linux: add support for rsvd hugetlb cgroup (#1116)
-	* features: add `features.md` to formalize the `runc features` JSON (#1130)
-	* config-linux: add support for time namespace (#1151)
-
-	Minor fixes and documentation:
-
-	* config-linux: clarify where device nodes can be created (#1148)
-	* runtime: remove `When serialized in JSON, the format MUST adhere to the
-	  following pattern` (#1178)
-	* Update CI to Go 1.20 (#1179)
-	* config: clarify Linux mount options (#1181)
-	* config-linux: fix url error (#1184)
-	* schema: fix schema for timeOffsets (#1193)
-	* schema: remove duplicate keys (#1195)
-
-Changes with v1.1.0-rc.1:
-
 	Breaking changes (but rather conforms to the existing runc implementation):
 
 	* config: change prestart hook spec to match reality (#1169)
@@ -73,46 +28,72 @@ Changes with v1.1.0-rc.1:
 	* add domainname spec entity (#1156)
 	* config-linux: add memory.checkBeforeUpdate (#1158)
 	* seccomp: Add flag SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV (#1161)
+	* config-linux: add support for rsvd hugetlb cgroup (#1116)
+	* features: add `features.md` to formalize the `runc features` JSON (#1130)
+	* config-linux: add support for time namespace (#1151)
+	* config: add scheduler entity (#1188)
+	* config: Add I/O Priority Configuration for process group in Linux Containers (#1191)
 
-	Minor fixes and documentation:
+	Minor fixes:
 
 	* seccomp: fix go-specs for errnoRet (#1042)
-	* MAINTAINERS: Add @cyphar as maintainer (#1043)
 	* Define State for container and runtime namespace (#1045)
-	* Add Giuseppe Scrivano as a runtime spec maintainer (#1048)
-	* Remove superfluous 'an' (#1049)
 	* Add State status constants to spec-go (#1046)
 	* config.go: make umask a pointer (#1058)
 	* Update State structure to use the new ContainerState type (#1056)
-	* docs: Added enclave OCI runtime rune to implementations (#1055)
-	* Change all references from whitelist to allowlist (#1054)
 	* Fix int64 and uint64 type value ranges (#1060)
-	* MAINTAINERS: update vbatts email (#1065)
-	* travis: fix go_import_path (#1072)
-	* Makefile: Fix golint URL used in go get (#1075)
-	* config-linux: fix personality link (#1086)
-	* README: Fix broken link for charter (#1091)
 	* Fix seccomp notify inconsistencies (#1096)
 	* runtime should WARN / ignore capabilities that cannot be granted (#1094)
 	* config-linux: clarify the handling of ClosID RDT parameter (#1104)
 	* defs-zos: [Fix] prevent schema parsers from hitting recursion-loop while resolving types. (#1117)
 	* fix the lifecycle reference in the states listing (#1118)
-	* add youki to implementations.md (#1126)
-	* Switch to GitHub Actions, CODEOWNERS, etc. (#1128)
 	* specify cgroup ownership semantics (#1123)
 	* config-linux: MAY reject an unfit cgroup (#1125)
 	* cgroup ownership: clarify that some files may not exist (#1137)
-	* typo: seccompFD -> seccompFd (#1133)
 	* schema: update README.md (#1083)
 	* schema: make with golang 1.16 (#1084)
 	* Update Windows CPU comments (#1144)
 	* specs-go: export LinuxBlockIODevice (#1103)
 	* config-linux: update type of LinuxCPU.Idle to *int64 (#1146)
-	* fix RFC link (#1153)
 	* Add available LinuxSeccompFlags (#1138)
-	* maintainer updates as per (#1101 (#1150)
+	* config-linux: clarify where device nodes can be created (#1148)
+	* runtime: remove `When serialized in JSON, the format MUST adhere to the following pattern` (#1178)
+	* config: clarify Linux mount options (#1181)
+	* schema: fix schema for timeOffsets (#1193)
+	* schema: remove duplicate keys (#1195)
+	* config-linux: clarify I/O throttling differences between cgroup v1 and v2 (#1194)
+	* releases: use +dev as in-development suffix (#1198)
+	* features: update Example (#1204)
+	* schema: fix definition for ioPriority (#1206)
+	* features: add a note to avoid confusion about annotations (#1212)
+
+	Documentation, CI & Governance:
+
+	* MAINTAINERS: Add @cyphar as maintainer (#1043)
+	* Add Giuseppe Scrivano as a runtime spec maintainer (#1048)
+	* Remove superfluous 'an' (#1049)
+	* docs: Added enclave OCI runtime rune to implementations (#1055)
+	* Change all references from whitelist to allowlist (#1054)
+	* MAINTAINERS: update vbatts email (#1065)
+	* travis: fix go_import_path (#1072)
+	* Makefile: Fix golint URL used in go get (#1075)
+	* config-linux: fix personality link (#1086)
+	* README: Fix broken link for charter (#1091)
+	* add youki to implementations.md (#1126)
+	* Switch to GitHub Actions, CODEOWNERS, etc. (#1128)
+	* typo: seccompFD -> seccompFd (#1133)
+	* fix RFC link (#1153)
+	* maintainer updates as per #1101 (#1150)
 	* GOVERNANCE: correct the Charter URL (#1157)
 	* CODEOWNERS: sync with MAINTAINERS (#1160)
+	* Update CI to Go 1.20 (#1179)
+	* config-linux: fix url error (#1184)
+	* config-linux: chore: Update `ociVersion` in example (#1199)
+	* MAINTAINERS: add Toru Komatsu (utam0k) (#1201)
+	* glossary: `s/features document/Features structure/g` (#1203)
+	* CODEOWNER: Add Toru Komatsu(@utam0k) to sync with MAINTAINERS (#1207)
+	* README.md: update chat information (#1210)
+	* Remove outdated meeting.ics (#1211)
 
 Changes with v1.0.2:
 

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "+dev"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.3+dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
## Changes (v1.1.0-rc.3 → v1.1.0)

### Minor fixes and documentation:
* README.md: update chat information (#1210)
* Remove outdated meeting.ics (#1211)
* features: add a note to avoid confusion about annotations (#1212)

## Changes (v1.1.0-rc.2 → v1.1.0-rc.3)

### Additions:

* config: add scheduler entity (#1188)
* config: Add I/O Priority Configuration for process group in Linux Containers (#1191)

### Minor fixes and documentation:

* config-linux: clarify I/O throttling differences between cgroup v1 and v2 (#1194)
* config-linux: chore: Update `ociVersion` in example (#1199)
* releases: use +dev as in-development suffix (#1198)
* MAINTAINERS: add Toru Komatsu (utam0k) (#1201)
* glossary: `s/features document/Features structure/g` (#1203)
* features: update Example (#1204)
* schema: fix definition for ioPriority (#1206)
* CODEOWNER: Add Toru Komatsu(@utam0k) to sync with MAINTAINERS (#1207)


## Changes (v1.1.0-rc.1 → v1.1.0-rc.2)
### Additions

* config-linux: add support for rsvd hugetlb cgroup (#1116)
* features: add `features.md` to formalize the `runc features` JSON (#1130)
* config-linux: add support for time namespace (#1151)

###  Minor fixes and documentation

* config-linux: clarify where device nodes can be created (#1148)
* runtime: remove `When serialized in JSON, the format MUST adhere to the following pattern` (#1178)
* Update CI to Go 1.20 (#1179)
* config: clarify Linux mount options (#1181)
* config-linux: fix url error (#1184)
* schema: fix schema for timeOffsets (#1193)
* schema: remove duplicate keys (#1195)

## Changes (v1.0.2 → v1.1.0-rc.1)

### Breaking changes (but rather conforms to the existing runc implementation)

* config: change prestart hook spec to match reality (#1169)

### Deprecations

* config-linux: mark memory.kernel[TCP] as NOT RECOMMENDED (#1093)

### Additions

* cgroup: add cgroup v2 support (#1040)
* seccomp: allow to override errno return code (#1041)
* seccomp: Add support for SCMP_ACT_KILL_PROCESS (#1044)
* Update seccomp architectures to support RISCV64 (#1059)
* Add support for SCMP_ACT_KILL_THREAD (#1064)
* Add Seccomp Notify support using UNIX sockets and container metadata (#1074)
* config-linux: Add Intel RDT CMT and MBM Linux support (#1076)
* seccomp: allow to override default errno return code (#1087)
* Introduce zos as platform (#1095)
* config-linux: add idle option for container cgroup (#1136)
* config-linux: add CFS bandwidth burst (#1120)
* IDMapping field for mount point (#1143)
* schema: add cpu idle (#1145)
* add domainname spec entity (#1156)
* config-linux: add memory.checkBeforeUpdate (#1158)
* seccomp: Add flag SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV (#1161)

### Minor fixes and documentation

* seccomp: fix go-specs for errnoRet (#1042)
* MAINTAINERS: Add @cyphar as maintainer (#1043)
* Define State for container and runtime namespace (#1045)
* Add Giuseppe Scrivano as a runtime spec maintainer (#1048)
* Remove superfluous 'an' (#1049)
* Add State status constants to spec-go (#1046)
* config.go: make umask a pointer (#1058)
* Update State structure to use the new ContainerState type (#1056)
* docs: Added enclave OCI runtime rune to implementations (#1055)
* Change all references from whitelist to allowlist (#1054)
* Fix int64 and uint64 type value ranges (#1060)
* MAINTAINERS: update vbatts email (#1065)
* travis: fix go_import_path (#1072)
* Makefile: Fix golint URL used in go get (#1075)
* config-linux: fix personality link (#1086)
* README: Fix broken link for charter (#1091)
* Fix seccomp notify inconsistencies (#1096)
* runtime should WARN / ignore capabilities that cannot be granted (#1094)
* config-linux: clarify the handling of ClosID RDT parameter (#1104)
* defs-zos: [Fix] prevent schema parsers from hitting recursion-loop while resolving types. (#1117)
* fix the lifecycle reference in the states listing (#1118)
* add youki to implementations.md (#1126)
* Switch to GitHub Actions, CODEOWNERS, etc. (#1128)
* specify cgroup ownership semantics (#1123)
* config-linux: MAY reject an unfit cgroup (#1125)
* cgroup ownership: clarify that some files may not exist (#1137)
* typo: seccompFD -> seccompFd (#1133)
* schema: update README.md (#1083)
* schema: make with golang 1.16 (#1084)
* Update Windows CPU comments (#1144)
* specs-go: export LinuxBlockIODevice (#1103)
* config-linux: update type of LinuxCPU.Idle to *int64 (#1146)
* fix RFC link (#1153)
* Add available LinuxSeccompFlags (#1138)
* maintainer updates as per (#1101 (#1150)
* GOVERNANCE: correct the Charter URL (#1157)
* CODEOWNERS: sync with MAINTAINERS (#1160)

- - -
[`[runtime-spec VOTE] tag ac7bb22 as v1.1.0 (closes Mon Jul 3 06:02:25 AM UTC 2023)`](https://groups.google.com/a/opencontainers.org/g/dev/c/nzk4OnQvxlI) (at least **8** of 12 maintainers needed for this resolution to pass):
- [ ] @crosbymichael
- [ ] @mrunalp
- [x] @vbatts
- [ ] @dqminh
- [x] @tianon
- [x] @hqhq
- [x] @cyphar
- [x] @giuseppe
- [X] @AkihiroSuda
- [ ] @kolyshkin
- [x] @thaJeztah
- [x] @utam0k

Closes #1052