### PR TITLE
features-linux: Expose idmap information

### DIFF
--- a/features-linux.md
+++ b/features-linux.md
@@ -209,3 +209,22 @@ Irrelevant to the availability of Intel RDT on the host operating system.
   "enabled": true
 }
 ```
+
+## <a name="linuxFeaturesMountExtensions" />MountExtensions
+
+**`mountExtensions`** (object, OPTIONAL) represents whether the runtime supports certain mount features, irrespective of the availability of the features on the host operating system.
+
+* **`idmap`** (object, OPTIONAL) represents whether the runtime supports idmap mounts using the `uidMappings` and `gidMappings` properties of the mount.
+  * **`enabled`** (bool, OPTIONAL) represents whether the runtime parses and attempts to use the `uidMappings` and `gidMappings` properties of mounts if provided.
+    Note that it is possible for runtimes to have partial implementations of id-mapped mounts support (such as only allowing mounts which have mappings matching the container's user namespace, or only allowing the id-mapped bind-mounts).
+    In such cases, runtimes MUST still set this value to `true`, to indicate that the runtime recognises the `uidMappings` and `gidMappings` properties.
+
+### Example
+
+```json
+"mountExtensions": {
+  "idmap":{
+    "enabled": true
+  }
+}
+```

--- a/schema/features-linux.json
+++ b/schema/features-linux.json
@@ -97,6 +97,19 @@
                         "type": "boolean"
                     }
                 }
+            },
+            "mountExtensions": {
+                "type": "object",
+                "properties": {
+                    "idmap": {
+                        "type": "object",
+                        "properties": {
+			    "enabled": {
+                                "type": "boolean"
+                            }
+                       }
+                    }
+                }
             }
         }
     }

--- a/specs-go/features/features.go
+++ b/specs-go/features/features.go
@@ -36,11 +36,12 @@ type Linux struct {
 	// Nil value means "unknown", not "no support for any capability".
 	Capabilities []string `json:"capabilities,omitempty"`
 
-	Cgroup   *Cgroup   `json:"cgroup,omitempty"`
-	Seccomp  *Seccomp  `json:"seccomp,omitempty"`
-	Apparmor *Apparmor `json:"apparmor,omitempty"`
-	Selinux  *Selinux  `json:"selinux,omitempty"`
-	IntelRdt *IntelRdt `json:"intelRdt,omitempty"`
+	Cgroup          *Cgroup          `json:"cgroup,omitempty"`
+	Seccomp         *Seccomp         `json:"seccomp,omitempty"`
+	Apparmor        *Apparmor        `json:"apparmor,omitempty"`
+	Selinux         *Selinux         `json:"selinux,omitempty"`
+	IntelRdt        *IntelRdt        `json:"intelRdt,omitempty"`
+	MountExtensions *MountExtensions `json:"mountExtensions,omitempty"`
 }
 
 // Cgroup represents the "cgroup" field.
@@ -120,6 +121,19 @@ type Selinux struct {
 type IntelRdt struct {
 	// Enabled is true if Intel RDT support is compiled in.
 	// Unrelated to whether the host supports Intel RDT or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// MountExtensions represents the "mountExtensions" field.
+type MountExtensions struct {
+	// IDMap represents the status of idmap mounts support.
+	IDMap *IDMap `json:"idmap,omitempty"`
+}
+
+type IDMap struct {
+	// Enabled represents whether idmap mounts supports is compiled in.
+	// Unrelated to whether the host supports it or not.
 	// Nil value means "unknown", not "false".
 	Enabled *bool `json:"enabled,omitempty"`
 }


### PR DESCRIPTION
High level container runtimes sometimes need to know if the OCI runtime supports idmap mounts or not, as the OCI runtime silently ignores unknown fields.

This means that if it doesn't support idmap mounts, a container with userns will be started, without idmap mounts, and the files created on the volumes will have a "garbage" owner/group. Furthermore, as the userns mapping is not guaranteed to be stable over time, it will be completely unusable.

Let's expose idmap support in the features subcommand, so high level container runtimes use the feature safely.

---
cc @giuseppe @AkihiroSuda 