### PR TITLE
specs-go: Respect semver 2.0.0

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 1
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "+dev"
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
According to semver.org, the 2.0.0 spec, the pre-release info should be delimited by a "-" ("+" is for build info) and we already released 1.1.0, so increment the minor so this version compares to something bigger than 1.1.0.

Updates: #1220 