### PR TITLE
specs-go: sync SCMP_ARCH_* constants with libseccomp main

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -743,6 +743,17 @@ The following parameters can be specified to set up seccomp:
     * `SCMP_ARCH_PARISC64`
     * `SCMP_ARCH_RISCV64`
 
+<!--
+The following constants are defined in the main branch of libseccomp,
+but not included in its latest release (v2.5) yet:
+https://github.com/seccomp/libseccomp/commits/main/include/seccomp.h.in
+
+* SCMP_ARCH_LOONGARCH64
+* SCMP_ARCH_M68K
+* SCMP_ARCH_SH
+* SCMP_ARCH_SHEB
+-->
+
 * **`flags`** *(array of strings, OPTIONAL)* - list of flags to use with seccomp(2).
 
     A valid list of constants is shown below.

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -35,6 +35,8 @@
                 "SCMP_ARCH_X32",
                 "SCMP_ARCH_ARM",
                 "SCMP_ARCH_AARCH64",
+                "SCMP_ARCH_LOONGARCH64",
+                "SCMP_ARCH_M68K",
                 "SCMP_ARCH_MIPS",
                 "SCMP_ARCH_MIPS64",
                 "SCMP_ARCH_MIPS64N32",
@@ -46,6 +48,8 @@
                 "SCMP_ARCH_PPC64LE",
                 "SCMP_ARCH_S390",
                 "SCMP_ARCH_S390X",
+                "SCMP_ARCH_SH",
+                "SCMP_ARCH_SHEB",
                 "SCMP_ARCH_PARISC",
                 "SCMP_ARCH_PARISC64",
                 "SCMP_ARCH_RISCV64"

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -743,6 +743,18 @@ const (
 	ArchRISCV64     Arch = "SCMP_ARCH_RISCV64"
 )
 
+// The following constants are defined in the main branch of libseccomp,
+// but not included in its latest release (v2.5) yet.
+// https://github.com/seccomp/libseccomp/commits/main/include/seccomp.h.in
+//
+// Will be included in libseccomp v2.6.
+const (
+	ArchLOONGARCH64 Arch = "SCMP_ARCH_LOONGARCH64"
+	ArchM68K        Arch = "SCMP_ARCH_M68K"
+	ArchSH          Arch = "SCMP_ARCH_SH"
+	ArchSHEB        Arch = "SCMP_ARCH_SHEB"
+)
+
 // LinuxSeccompAction taken upon Seccomp rule match
 type LinuxSeccompAction string
 


### PR DESCRIPTION
The following constants are defined in the main branch of libseccomp, but not included in its latest release (v2.5) yet:

* `SCMP_ARCH_LOONGARCH64`  (seccomp/libseccomp@6966ec7)
* `SCMP_ARCH_M68K`         (seccomp/libseccomp@dd5c9c2)
* `SCMP_ARCH_SH`              (seccomp/libseccomp@c12945d)
* `SCMP_ARCH_SHEB`         (seccomp/libseccomp@c12945d)

These constant names are unlikely to change before v2.6 GA, so we can safely refer to them in specs-go.

Replaces:
- https://github.com/opencontainers/runtime-spec/pull/1187