### PR TITLE
specs-go: add missing deprecation comment for Hooks.Prestart

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -187,6 +187,10 @@ type Hook struct {
 type Hooks struct {
 	// Prestart is Deprecated. Prestart is a list of hooks to be run before the container process is executed.
 	// It is called in the Runtime Namespace
+	//
+	// Deprecated: use [Hooks.CreateRuntime], [Hooks.CreateContainer], and
+	// [Hooks.StartContainer] instead, which allow more granular hook control
+	// during the create and start phase.
 	Prestart []Hook `json:"prestart,omitempty"`
 	// CreateRuntime is a list of hooks to be run after the container has been created but before pivot_root or any equivalent operation has been called
 	// It is called in the Runtime Namespace


### PR DESCRIPTION
- relates to / update https://github.com/opencontainers/runtime-spec/pull/1008

Hooks.Prestart was deprecated in c1662686cff159595277b79322d0272f5182941b (v1.0.2), but the field did not have a correctly formatted deprecation comment.

This patch updates the field's GoDoc to have a correctly formatted deprecation comment, which will allow linters and IDEs to detect the deprecation status of this feature.