### PR TITLE
specs-go: mark LinuxMemory.Kernel as deprecated

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -371,6 +371,12 @@ type LinuxMemory struct {
 	// Total memory limit (memory + swap).
 	Swap *int64 `json:"swap,omitempty"`
 	// Kernel memory limit (in bytes).
+	//
+	// Deprecated: kernel-memory limits are not supported in cgroups v2, and
+	// were obsoleted in [kernel v5.4]. This field should no longer be used,
+	// as it may be ignored by runtimes.
+	//
+	// [kernel v5.4]: https://github.com/torvalds/linux/commit/0158115f702b0ba208ab0
 	Kernel *int64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
 	KernelTCP *int64 `json:"kernelTCP,omitempty"`


### PR DESCRIPTION
- updates https://github.com/opencontainers/runtime-spec/pull/1093

Support for kernel-memory limits was deprecated in the kernel, and documented as "NOT RECOMMENDED" (or "SHOULD NOT" use) in  v1.1.0-rc.1 through commit f02cd4a4273f5cf4898df4feee7dcf0d08756029.

This patch marks the field as deprecated in the go implementation of the spec, so that linters and editors produces a warning and consumers get notified of its status.