### PR TITLE
Release v1.2.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,26 @@
 OpenContainers Specifications
 
+Changes with v1.2.0:
+
+	Additions:
+
+	* config: add idmap and ridmap mount options (#1222)
+	* config.md: allow empty mappings for [r]idmap (#1224)
+	* features-linux: Expose idmap information (#1219)
+	* mount: Allow relative mount destinations on Linux (#1225)
+	* features: add potentiallyUnsafeConfigAnnotations (#1205)
+	* config: add support for org.opencontainers.image annotations #1197
+
+	Minor fixes:
+
+	* config: improve bind mount and propagation doc (#1228)
+
+	Documentation, CI & Governance:
+
+	* fix link to hooks in features (#1226)
+	* specs-go: add missing deprecation comment for Hooks.Prestart (#1232)
+	* specs-go: mark LinuxMemory.Kernel as deprecated ()#1233)
+
 Changes with v1.1.0:
 
 	Breaking changes (but rather conforms to the existing runc implementation):

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 1
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 1
+	VersionMinor = 2
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "+dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "+dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
It's time we release the new patch version since we have met the milestone for ~~v1.1.1~~ `v1.2.0`
 https://github.com/opencontainers/runtime-spec/milestone/19

Previous release: https://github.com/opencontainers/runtime-spec/pull/1213

# Changes

Additions:
* config: add idmap and ridmap mount options (#1222)
* config.md: allow empty mappings for [r]idmap (#1224)
* features-linux: Expose idmap information (#1219)
* mount: Allow relative mount destinations on Linux (#1225)
* features: add potentiallyUnsafeConfigAnnotations (#1205)
* config: add support for org.opencontainers.image annotations #1197

Minor fixes:

* config: improve bind mount and propagation doc (#1228)

Documentation, CI & Governance:

* fix link to hooks in features (#1226)
* specs-go: add missing deprecation comment for Hooks.Prestart (#1232)
* specs-go: mark LinuxMemory.Kernel as deprecated ()#1233)

---

[`[runtime-spec VOTE] tag 68346ed as v1.1.1`](https://groups.google.com/a/opencontainers.org/g/dev/c/OcamRt4-gAA) (at least 8 of 12 maintainers needed for this resolution to pass):

- [ ] @crosbymichael
- [x] @mrunalp
- [ ] @vbatts
- [ ] @dqminh
- [ ] @tianon
- [x] @hqhq
- [x] @cyphar
- [x] @giuseppe
- [x] @AkihiroSuda
- [x] @kolyshkin
- [x] @thaJeztah
- [X] @utam0k