### PR TITLE
Update GitHub Actions packages to resolve warnings in CI

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup go environment
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       
@@ -30,7 +30,7 @@ jobs:
           go get -d ./schema/...
 
       - name: run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.51.2
           args: --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup go environment
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -30,7 +30,7 @@ jobs:
           go get -d ./schema/...
 
       - name: run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.51.2
           args: --verbose


### PR DESCRIPTION
### Issue:
N/A

### Description:
This change updates actions/checkout to v4, actions/setup-go to v5, and golangci/golangci-lint-action to v4 to resolve NodeJS 16 deprecation warnings in CI.

### Testing:
CI checks pass without deprecation warnings

#### Before
![image](https://github.com/opencontainers/runtime-spec/assets/55906459/d790502d-6bee-4d60-98da-35b8207693d9)

#### After
<img width="1326" alt="image" src="https://github.com/opencontainers/runtime-spec/assets/55906459/e4181707-dc28-4e82-8272-a8ec99a7b608">

### Additional Resources:
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/