### PR TITLE
Add Go v1.21 and v1.22 to GitHub Actions CI matrix

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.56.1
           args: --verbose
 
       - name: run tests

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.19.x, 1.20.x]
+        go: [1.21.x, 1.22.x]
 
     steps:
       - name: checkout source code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.56.1
           args: --verbose
 
       - name: run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.19.x, 1.20.x]
+        go: [1.21.x, 1.22.x]
 
     steps:
       - name: checkout source code


### PR DESCRIPTION
### Issue:
N/A

### Description:
This change adds Go v1.21 and v1.22 to GitHub actions CI matrix and drops Go v1.19 and v1.20 which will no longer receives updates. Additionally it updates golangci-lint version to v1.56.1 which has Go v1.22 support.

### Additional resources:
- https://go.dev/doc/go1.21
- https://go.dev/doc/go1.22