### PR TITLE
MAINTAINERS: move vbatts to EMERITUS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @AkihiroSuda @crosbymichael @cyphar @dqminh @giuseppe @hqhq @kolyshkin @mrunalp @thaJeztah @tianon @vbatts @utam0k
+* @AkihiroSuda @crosbymichael @cyphar @dqminh @giuseppe @hqhq @kolyshkin @mrunalp @thaJeztah @tianon @utam0k

--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -1,0 +1,12 @@
+# Emeritus
+
+We would like to acknowledge previous OCI runtime spec maintainers and their huge contributions to our collective success:
+
+- Rohit Jnagal (@rjnagal)
+- Victor Marmol (@vmarmol)
+- Alexander Morozov (@LK4D4)
+- Vishnu Kannan (@vishh)
+- Brandon Philips (@philips)
+- Vincent Batts (@vbatts)
+
+We thank these members for their service to the OCI community.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,5 @@
 Michael Crosby <michael@docker.com> (@crosbymichael)
 Mrunal Patel <mpatel@redhat.com> (@mrunalp)
-Vincent Batts <vbatts@hashbangbash.com> (@vbatts)
 Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)
 Tianon Gravi <admwiggin@gmail.com> (@tianon)
 Qiang Huang <h.huangqiang@huawei.com> (@hqhq)


### PR DESCRIPTION
Happy to still be brought into conversations, but do not want to slow progress of the active maintainers.

🐐🧁🧡

Also, building out the EMERITUS from the past folks that have already retired out of being maintainers.