### PR TITLE
Add CPU affinity to executed processes

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -395,8 +395,8 @@ The following parameters can be specified to set up the controller:
 * **`period`** *(uint64, OPTIONAL)* - specifies a period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated (CFS scheduler only)
 * **`realtimeRuntime`** *(int64, OPTIONAL)* - specifies a period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources
 * **`realtimePeriod`** *(uint64, OPTIONAL)* - same as **`period`** but applies to realtime scheduler only
-* **`cpus`** *(string, OPTIONAL)* - list of CPUs the container will run in
-* **`mems`** *(string, OPTIONAL)* - list of Memory Nodes the container will run in
+* **`cpus`** *(string, OPTIONAL)* - list of CPUs the container will run on. This is a comma-separated list, with dashes to represent ranges. For example, `0-3,7` represents CPUs 0,1,2,3, and 7.
+* **`mems`** *(string, OPTIONAL)* - list of memory nodes the container will run on. This is a comma-separated list, with dashes to represent ranges. For example, `0-3,7` represents memory nodes 0,1,2,3, and 7.
 * **`idle`** *(int64, OPTIONAL)* - cgroups are configured with minimum weight, 0: default behavior, 1: SCHED_IDLE.
 
 #### Example

--- a/config.md
+++ b/config.md
@@ -340,6 +340,17 @@ For Linux-based systems, the `process` object supports the following process-spe
 
     * **`class`** (string, REQUIRED) specifies the I/O scheduling class. Possible values are `IOPRIO_CLASS_RT`, `IOPRIO_CLASS_BE`, and `IOPRIO_CLASS_IDLE`.
     * **`priority`** (int, REQUIRED) specifies the priority level within the class. The value should be an integer ranging from 0 (highest) to 7 (lowest).
+* **`execCPUAffinity`** (object, OPTIONAL) specifies CPU affinity used to execute the process.
+    This setting is not applicable to the container's init process.
+    The following properties are available:
+    * **`initial`** (string, OPTIONAL) is a list of CPUs a runtime parent
+      process to be run on initially, before the transition to container's
+      cgroup. This is a a comma-separated list, with dashes to represent
+      ranges. For example, `0-3,7` represents CPUs 0,1,2,3, and 7.
+    * **`final`** (string, OPTIONAL) is a list of CPUs the process will be run
+      on after the transition to container's cgroup. The format is the same as
+      for `initial`. If omitted or empty, the container's default CPU affinity,
+      as defined by [cpu.cpus property](./config.md#configLinuxCPUs)), is used.
 
 ### <a name="configUser" />User
 
@@ -416,7 +427,11 @@ _Note: symbolic name for uid and gid, such as uname and gname respectively, are 
             "hard": 1024,
             "soft": 1024
         }
-    ]
+    ],
+    "execCPUAffinity": {
+        "initial": "7",
+        "final": "0-3,7"
+    }
 }
 ```
 ### Example (Solaris)

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -220,7 +220,20 @@
                             }
                         }
                     }
-                }
+                },
+                "execCPUAffinity": {
+                    "type": "object",
+                    "properties": {
+                        "initial": {
+                            "type": "string",
+			    "pattern": "^[0-9, -]*$"
+                        },
+                        "final": {
+                            "type": "string",
+			    "pattern": "^[0-9, -]*$"
+                        }
+                    }
+		}
             }
         },
         "linux": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -94,6 +94,8 @@ type Process struct {
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 	// IOPriority contains the I/O priority settings for the cgroup.
 	IOPriority *LinuxIOPriority `json:"ioPriority,omitempty" platform:"linux"`
+	// ExecCPUAffinity specifies CPU affinity for exec processes.
+	ExecCPUAffinity *CPUAffinity `json:"execCPUAffinity,omitempty" platform:"linux"`
 }
 
 // LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
@@ -126,6 +128,12 @@ const (
 	IOPRIO_CLASS_BE   IOPriorityClass = "IOPRIO_CLASS_BE"
 	IOPRIO_CLASS_IDLE IOPriorityClass = "IOPRIO_CLASS_IDLE"
 )
+
+// CPUAffinity specifies process' CPU affinity.
+type CPUAffinity struct {
+	Initial string `json:"initial,omitempty"`
+	Final   string `json:"final,omitempty"`
+}
 
 // Box specifies dimensions of a rectangle. Used for specifying the size of a console.
 type Box struct {


### PR DESCRIPTION
This allows to set initial and final CPU affinity for a process being run in a container, which is needed to solve the issue described in https://github.com/opencontainers/runc/issues/3922.

This is an alternative to #1252.