### PR TITLE
ci: Add a github actions workflow for lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  check-format:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Run make -C schema fmt
+      run: make -C schema fmt
+    - name: Check for changes
+      run: git diff --exit-code

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -226,14 +226,14 @@
                     "properties": {
                         "initial": {
                             "type": "string",
-			    "pattern": "^[0-9, -]*$"
+                            "pattern": "^[0-9, -]*$"
                         },
                         "final": {
                             "type": "string",
-			    "pattern": "^[0-9, -]*$"
+                            "pattern": "^[0-9, -]*$"
                         }
                     }
-		}
+                }
             }
         },
         "linux": {


### PR DESCRIPTION
In order to prevent like https://github.com/opencontainers/runtime-spec/pull/1255

It works fine: https://github.com/utam0k/runtime-spec/actions/runs/9534058439/job/26278029545