### PR TITLE
Add support for windows CPU affinity

### DIFF
--- a/config-windows.md
+++ b/config-windows.md
@@ -82,6 +82,14 @@ The following parameters can be specified (mutually exclusive):
 * **`count`** *(uint64, OPTIONAL)* - specifies the number of CPUs available to the container. It represents the fraction of the configured processor `count` in a container in relation to the processors available in the host. The fraction ultimately determines the portion of processor cycles that the threads in a container can use during each scheduling interval, as the number of cycles per 10,000 cycles.
 * **`shares`** *(uint16, OPTIONAL)* - limits the share of processor time given to the container relative to other workloads on the processor. The processor `shares` (`weight` at the platform level) is a value between 0 and 10,000.
 * **`maximum`** *(uint16, OPTIONAL)* - determines the portion of processor cycles that the threads in a container can use during each scheduling interval, as the number of cycles per 10,000 cycles. Set processor `maximum` to a percentage times 100.
+* **`affinity`** *(array of objects, OPTIONAL)* - specifies the set of CPU to affinitize for this container.
+
+  Each entry has the following structure:
+
+  Ref: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/miniport/ns-miniport-_group_affinity
+
+  * **`mask`** *(uint64, REQUIRED)* - specifies the CPU mask relative to this CPU group.
+  * **`group`** *(uint32, REQUIRED)* - specifies the processor group this mask refers to, as returned by GetLogicalProcessorInformationEx.
 
 Ref: https://docs.microsoft.com/en-us/virtualization/api/hcs/schemareference#Container_Processor
 

--- a/schema/config-windows.json
+++ b/schema/config-windows.json
@@ -38,6 +38,17 @@
                             },
                             "maximum": {
                                 "$ref": "defs.json#/definitions/uint16"
+                            },
+                            "affinity": {
+                                "type": "object",
+                                "properties": {
+                                    "mask": {
+                                        "$ref": "defs.json#/definitions/uint64"
+                                    },
+                                    "group": {
+                                        "$ref": "defs.json#/definitions/uint32"
+                                    }
+                                }
                             }
                         }
                     },

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -635,6 +635,17 @@ type WindowsCPUResources struct {
 	// cycles per 10,000 cycles. Set processor `maximum` to a percentage times
 	// 100.
 	Maximum *uint16 `json:"maximum,omitempty"`
+	// Set of CPUs to affinitize for this container.
+	Affinity []WindowsCPUGroupAffinity `json:"affinity,omitempty"`
+}
+
+// Similar to _GROUP_AFFINITY struct defined in
+// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/miniport/ns-miniport-_group_affinity
+type WindowsCPUGroupAffinity struct {
+	// CPU mask relative to this CPU group.
+	Mask uint64 `json:"mask,omitempty"`
+	// Processor group the mask refers to, as returned by GetLogicalProcessorInformationEx.
+	Group uint32 `json:"group,omitempty"`
 }
 
 // WindowsStorageResources contains storage resource management settings.


### PR DESCRIPTION
This PR adds support for certain CRI fields in OCI runtime spec for supporting CPU affinity for windows containers.

CRI PR : https://github.com/kubernetes/kubernetes/pull/124285 
Github issue: https://github.com/kubernetes/kubernetes/issues/125262
KEP: https://github.com/kubernetes/kubernetes/issues/125262 