### PR TITLE
config: simplify final CPU affinity rule

### DIFF
--- a/config.md
+++ b/config.md
@@ -349,8 +349,9 @@ For Linux-based systems, the `process` object supports the following process-spe
       ranges. For example, `0-3,7` represents CPUs 0,1,2,3, and 7.
     * **`final`** (string, OPTIONAL) is a list of CPUs the process will be run
       on after the transition to container's cgroup. The format is the same as
-      for `initial`. If omitted or empty, the container's default CPU affinity,
-      as defined by [cpu.cpus property](./config.md#configLinuxCPUs)), is used.
+      for `initial`. If omitted or empty, runtime SHOULD NOT change process'
+      CPU affinity after the process is moved to container's cgroup, and the
+      final affinity is determined by the Linux kernel.
 
 ### <a name="configUser" />User
 


### PR DESCRIPTION
Description of `execCPUAffinity.final` field (added in #1253) said that if it's not set or empty, the final affinity is the one of container's cgroup. This was done because we thought the kernel changes process' CPU affinity to one of cgroup. It's not the case ([see here](https://github.com/opencontainers/runtime-spec/pull/1253/commits/119ae426a12298a57b5d0828017c878f34fb7cf0#r1635517428)).

To keep runtimes simple, it makes sense to not do anything if the final affinity is not explicitly set. This change does just that.