### PR TITLE
runtime: fail when a poststart hook fails

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -70,7 +70,7 @@ The lifecycle describes the timeline of events that happen from when a container
     If any `startContainer` hook fails, the runtime MUST [generate an error](#errors), stop the container, and continue the lifecycle at step 12.
 8. The runtime MUST run the user-specified program, as specified by [`process`](config.md#process).
 9. The [`poststart` hooks](config.md#poststart) MUST be invoked by the runtime.
-    If any `poststart` hook fails, the runtime MUST [log a warning](#warnings), but the remaining hooks and lifecycle continue as if the hook had succeeded.
+    If any `poststart` hook fails, the runtime MUST [generate an error](#errors), stop the container, and continue the lifecycle at step 12.
 10. The container process exits.
     This MAY happen due to erroring out, exiting, crashing or the runtime's [`kill`](runtime.md#kill) operation being invoked.
 11. Runtime's [`delete`](runtime.md#delete) command is invoked with the unique identifier of the container.


### PR DESCRIPTION
Poststart hooks exist in runc since 2015 [1], and since that time until today, if a hook returned an error, runc kills the container.

In 2020, commit c1662686cff159 (PR #1008) added the following text (which became part of runtime-spec release v1.0.2):

> 9. The `poststart` MUST be invoked by the runtime. If any
> `poststart` hook fails, the runtime MUST log a warning, but the
> remaining hooks and lifecycle continue as if the hook had succeeded.

Now, this text conflicted with the pre-existing runtime (runc) behavior, and it still conflicts with the current runc behavior.

At this point, we can either fix runtimes or the spec.

To my mind, fixing the spec is a better approach, because:
 - initial implementation predates the spec wording by a few years;
 - the wording in the spec was never implemented (in runc);
 - returning an error (and stopping the container) seems like a more versatile approach, since a hook can usually choose whether to return an error or not.

[1]: https://github.com/opencontainers/runc/pull/392