### PR TITLE
Adding vTPM specification

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -483,6 +483,41 @@ The following parameters can be specified to set up the controller:
 }
 ```
 
+### <a name="configLinuxVTPMs" />vTPMs
+
+**`vtpms`** (array of objects, OPTIONAL) lists a number of emulated TPMs that will be made available to the container.
+
+Each entry has the following structure:
+
+* **`statePath`** *(string, REQUIRED)* - Unique path where vTPM writes its state into.
+* **`statePathIsManaged`** *(string, OPTIONAL)* - Whether runc is allowed to delete the TPM's state path upon destroying the TPM, defaults to false.
+* **`vtpmVersion`** *(string, OPTIONAL)* - The version of TPM to emulate, either 1.2 or 2, defaults to 1.2.
+* **`createCerts`** *(boolean, OPTIONAL)* - If true then create certificates for the vTPM, defaults to false.
+* **`runAs`** *(string, OPTIONAL)* - Under which user to run the vTPM, e.g.  'tss'.
+Contributor
+@mrunalp mrunalp on Aug 7, 2020
+Does it make sense to run this as the container user or it is typically set to a separate tss user?
+
+@KevinLi1020	Reply...
+* **`pcrBanks`** *(string, OPTIONAL)* - Comma-separated list of PCR banks to activate, default depends on `swtpm`.
+* **`encryptionPassword`** *(string, OPTIONAL)* - Write state encrypted with a key derived from the password, defaults to not encrypted.
+
+#### Example
+
+```json
+    "vtpms": [
+        {
+            "statePath": "/var/lib/runc/myvtpm1",
+            "statePathIsManaged": false,
+            "vtpmVersion": "2",
+            "createCerts": false,
+            "runAs": "tss",
+            "pcrBanks": "sha1,sha512",
+            "encryptionPassword": "mysecret"
+        }
+    ]
+```
+
 ### <a name="configLinuxHugePageLimits" />Huge page limits
 
 **`hugepageLimits`** (array of objects, OPTIONAL) represents the `hugetlb` controller which allows to limit the HugeTLB reservations (if supported) or usage (page fault).

--- a/config.md
+++ b/config.md
@@ -1069,7 +1069,16 @@ Here is a full example `config.json` for reference.
                         "rate": 300
                     }
                 ]
-            }
+            },
+            "vtpms": [
+                {
+                    "statePath": "/var/lib/runc/myvtpm1",
+                    "vtpmVersion": "2",
+                    "createCerts": false,
+                    "runAs": "tss",
+                    "pcrBanks": "sha1,sha512"
+                }
+            ]
         },
         "rootfsPropagation": "slave",
         "seccomp": {

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -43,6 +43,12 @@
                             "$ref": "defs-linux.json#/definitions/DeviceCgroup"
                         }
                     },
+                    "vtpms" : {
+                        "type": "array",
+                        "items": {
+                            "$ref": "defs-linux.json#/definitions/VTPM"
+                        }
+                    },
                     "pids": {
                         "type": "object",
                         "properties": {

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -144,6 +144,14 @@
             "description": "minor device number",
             "$ref": "defs.json#/definitions/int64"
         },
+        "TPMVersion": {
+            "description": "The TPM version",
+            "type": "string",
+            "enum": [
+                "1.2",
+                "2"
+            ]
+        },
         "FileMode": {
             "description": "File permissions mode (typically an octal value)",
             "type": "integer",
@@ -235,6 +243,35 @@
                         }
                     }
                 }
+            ]
+        },
+        "VTPM" : {
+            "type": "object",
+            "properties" : {
+                "statePath": {
+                    "type": "string"
+                },
+                "statePathIsManaged": {
+                    "type": "boolean"
+                },
+                "vtpmVersion": {
+                    "$ref": "#/definitions/TPMVersion"
+                },
+                "createCerts": {
+                    "type": "boolean"
+                },
+                "runAs": {
+                    "type": "string"
+                },
+                "pcrBanks": {
+                    "type": "string"
+                },
+                "encryptionPassword": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "statePath"
             ]
         },
         "DeviceCgroup": {

--- a/schema/test/config/good/spec-example.json
+++ b/schema/test/config/good/spec-example.json
@@ -345,7 +345,25 @@
                         "rate": 300
                     }
                 ]
-            }
+            },
+            "vtpms": [
+                {
+                    "statePath": "/var/lib/runc/myvtpm1",
+                    "vtpmVersion": "2",
+                    "createCerts": false,
+                    "runAs": "tss",
+                    "pcrBanks": "sha1,sha512"
+                },
+                {
+                    "statePath": "/var/lib/runc/myvtpm2",
+                    "statePathIsManaged": true,
+                    "vtpmVersion": "1.2",
+                    "createCerts": true,
+                    "runAs": "root",
+                    "pcrBanks": "sha1,sha512",
+                    "encryptionPassword": "mysecret"
+                }
+            ]
         },
         "rootfsPropagation": "slave",
         "seccomp": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -449,6 +449,24 @@ type LinuxRdma struct {
 	HcaObjects *uint32 `json:"hcaObjects,omitempty"`
 }
 
+// LinuxVTPM for vTPM definition
+type LinuxVTPM struct {
+	// Path on host where vTPM writes state to
+	StatePath string `json:"statePath,omitempty"`
+	// Whether runc is allowed to delete the 'Statepath' once the TPM is destroyed
+	StatePathIsManaged bool `json:"statePathIsManaged,omitempty"`
+	// Version of the TPM that is emulated
+	TPMVersion string `json:"vtpmVersion,omitempty"`
+	// Whether to create certificates upon first start of vTPM
+	CreateCertificates bool `json:"createCerts,omitempty"`
+	// The PCR banks to enable
+	PcrBanks string `json:"pcrBanks,omitempty"`
+	// Under what user to run the vTPM process
+	RunAs string `json:"runAs,omitempty"`
+	// The password to derive the encryption key from
+	EncryptionPassword string `json:"encryptionPassword,omitempty"`
+}
+
 // LinuxResources has container runtime resource constraints
 type LinuxResources struct {
 	// Devices configures the device allowlist.
@@ -471,6 +489,8 @@ type LinuxResources struct {
 	Rdma map[string]LinuxRdma `json:"rdma,omitempty"`
 	// Unified resources.
 	Unified map[string]string `json:"unified,omitempty"`
+	// VTPM configuration
+	VTPMs []LinuxVTPM `json:"vtpms,omitempty"`
 }
 
 // LinuxDevice represents the mknod information for a Linux special device file
@@ -478,7 +498,9 @@ type LinuxDevice struct {
 	// Path to the device.
 	Path string `json:"path"`
 	// Device type, block, char, etc.
-	Type string `json:"type"`
+	// Path of passed-through device on host
+	Devpath string `json:"devpath"`
+	Type    string `json:"type"`
 	// Major is the device's major number.
 	Major int64 `json:"major"`
 	// Minor is the device's minor number.


### PR DESCRIPTION
Add vTPM specification to runtime-spec for runc.

The following is an example of vtpm

 "vtpms": [
    {
        "statePath": "/var/lib/runc/myvtpm2",
        "statePathIsManaged": true,
        "vtpmVersion": "1.2",
        "createCerts": true,
        "runAs": "root",
        "pcrBanks": "sha1,sha512",
        "encryptionPassword": "mysecret"
    }
]
Signed-off-by: Wenhai Li lwh20053276@163.com