### PR TITLE
Define Linux Network Devices

### DIFF
--- a/features-linux.md
+++ b/features-linux.md
@@ -228,3 +228,17 @@ Irrelevant to the availability of Intel RDT on the host operating system.
   }
 }
 ```
+
+## <a name="linuxFeaturesNetDevices" />NetDevices
+
+**`netDevices`** (object, OPTIONAL) represents the runtime's implementation status of Linux network devices.
+
+* **`enabled`** (bool, OPTIONAL) represents whether the runtime supports the capability to move Linux network devices into the container's network namespace.
+
+### Example
+
+```json
+"netDevices": {
+  "enabled": true
+}
+```

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -9,6 +9,12 @@
                     "$ref": "defs-linux.json#/definitions/Device"
                 }
             },
+            "netDevices": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "defs-linux.json#/definitions/NetDevice"
+                }
+            },
             "uidMappings": {
                 "type": "array",
                 "items": {

--- a/schema/defs-linux.json
+++ b/schema/defs-linux.json
@@ -189,6 +189,14 @@
                 }
             }
         },
+        "NetDevice": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "weight": {
             "$ref": "defs.json#/definitions/uint16"
         },

--- a/schema/features-linux.json
+++ b/schema/features-linux.json
@@ -110,6 +110,14 @@
                         }
                     }
                 }
+            },
+            "netDevices": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "type": "boolean"
+                    }
+                }
             }
         }
     }

--- a/schema/test/config/bad/linux-netdevice.json
+++ b/schema/test/config/bad/linux-netdevice.json
@@ -1,0 +1,13 @@
+{
+    "ociVersion": "1.0.0",
+    "root": {
+        "path": "rootfs"
+    },
+    "linux": {
+        "netDevices": {
+            "eth0": {
+                "name": 23
+            }
+        }
+    }
+}

--- a/schema/test/config/good/linux-netdevice.json
+++ b/schema/test/config/good/linux-netdevice.json
@@ -1,0 +1,15 @@
+{
+    "ociVersion": "1.0.0",
+    "root": {
+        "path": "rootfs"
+    },
+    "linux": {
+        "netDevices": {
+            "eth0": {
+                "name": "container_eth0"
+            },
+            "ens4": {},
+            "ens5": {}
+        }
+    }
+}

--- a/schema/test/features/good/runc.json
+++ b/schema/test/features/good/runc.json
@@ -182,6 +182,9 @@
         },
         "selinux": {
             "enabled": true
+        },
+        "netDevices": {
+            "enabled": true
         }
     },
     "annotations": {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -236,6 +236,8 @@ type Linux struct {
 	Namespaces []LinuxNamespace `json:"namespaces,omitempty"`
 	// Devices are a list of device nodes that are created for the container
 	Devices []LinuxDevice `json:"devices,omitempty"`
+	// NetDevices are key-value pairs, keyed by network device name on the host, moved to the container's network namespace.
+	NetDevices map[string]LinuxNetDevice `json:"netDevices,omitempty"`
 	// Seccomp specifies the seccomp security settings for the container.
 	Seccomp *LinuxSeccomp `json:"seccomp,omitempty"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container.
@@ -489,6 +491,12 @@ type LinuxDevice struct {
 	UID *uint32 `json:"uid,omitempty"`
 	// Gid of the device.
 	GID *uint32 `json:"gid,omitempty"`
+}
+
+// LinuxNetDevice represents a single network device to be added to the container's network namespace
+type LinuxNetDevice struct {
+	// Name of the device in the container namespace
+	Name string `json:"name,omitempty"`
 }
 
 // LinuxDeviceCgroup represents a device rule for the devices specified to

--- a/specs-go/features/features.go
+++ b/specs-go/features/features.go
@@ -48,6 +48,7 @@ type Linux struct {
 	Selinux         *Selinux         `json:"selinux,omitempty"`
 	IntelRdt        *IntelRdt        `json:"intelRdt,omitempty"`
 	MountExtensions *MountExtensions `json:"mountExtensions,omitempty"`
+	NetDevices      *NetDevices      `json:"netDevices,omitempty"`
 }
 
 // Cgroup represents the "cgroup" field.
@@ -140,6 +141,13 @@ type MountExtensions struct {
 type IDMap struct {
 	// Enabled represents whether idmap mounts supports is compiled in.
 	// Unrelated to whether the host supports it or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// NetDevices represents the "netDevices" field.
+type NetDevices struct {
+	// Enabled is true if network devices support is compiled in.
 	// Nil value means "unknown", not "false".
 	Enabled *bool `json:"enabled,omitempty"`
 }


### PR DESCRIPTION
The proposed "netdevices" field provides a declarative way to specify which host network devices should be moved into a container's network namespace.

This approach is similar than the existing "devices" field used for block devices but uses a dictionary keyed by the interface name instead.

The proposed scheme is based on the existing representation of network device by the `struct net_device`
https://docs.kernel.org/networking/netdevices.html.

This proposal focuses solely on moving existing network devices into the container namespace. It does not cover the complexities of network configuration or network interface creation, emphasizing the separation of device management and network configuration.

A list of real use cases that justify this proposal is:

1.  **Pre-Configuring Physical Devices:**

    * Scenario: A container requires a specific physical network interface with a complex IP configuration, RDMA or SR-IOV
    * Implementation:
        * Configure the physical interface on the host with the desired IP addresses, routing, and other settings. In kubernetes this can be done with DRA or Device Plugins.
        * Use `netDevices` to move the pre-configured interface into the container.

2.  **Creating and Moving Virtual Interfaces:**

    * Scenario: A container needs to have its own unique MAC address on an existing physical network, without bridging.
    * Implementation:
        * Create the `macvlan` interface on the host, based on an existing physical interface.
        * Use `netDevices` to move the MACVLAN interface into the container.

3.  **Network Function Containers:**

    * Scenario: A container acts as a network router or firewall.
    * Implementation:
        * Use `netDevices` to move multiple physical or virtual interfaces into the container.
        * The container's processes manage the network configuration, routing, and firewall rules.

### References

- [Linux network namespaces and interfaces](https://gist.github.com/aojea/a5371456177ae85765714fd52db55fdf)
- [runc implementation](https://github.com/opencontainers/runc/pull/4538)

Fixes: https://github.com/opencontainers/runtime-spec/issues/1239