### PR TITLE
Correct `prestart` hook description in summary

### DIFF
--- a/config.md
+++ b/config.md
@@ -647,7 +647,7 @@ See the below table for a summary of hooks and when they are called:
 
 |           Name          | Namespace |                                                            When                                                                    |
 | ----------------------- | --------- | -----------------------------------------------------------------------------------------------------------------------------------|
-| `prestart` (Deprecated) | runtime   | After the start  operation is called but before the user-specified program command is executed.                                    |
+| `prestart` (Deprecated) | runtime   | During the create operation, after the runtime environment has been created and before the pivot root or any equivalent operation. |
 | `createRuntime`         | runtime   | During the create operation, after the runtime environment has been created and before the pivot root or any equivalent operation. |
 | `createContainer`       | container | During the create operation, after the runtime environment has been created and before the pivot root or any equivalent operation. |
 | `startContainer`        | container | After the start operation is called but before the user-specified program command is executed.                                     |


### PR DESCRIPTION
Correct `prestart` hook description in summary

It looks like the previous description was copied from the wrong line.   Update the `prestart (Deprecated)` hook's timing from being called "after the start operation is invoked but before the user-specified command executes"  to "during the create operation, after the runtime environment is created and before pivot root or any equivalent operation."