### PR TITLE
Release v1.2.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,34 @@
 OpenContainers Specifications
 
+Changes with v1.2.1:
+
+	Additions:
+
+	* zos updates (#1273)
+	* Add support for windows CPU affinity (#1258)
+	* specs-go: sync SCMP_ARCH_* constants with libseccomp main (#1229)
+	* Add CPU affinity to executed processes (#1253, #1261)
+	* config-linux: describe the format of cpus and mems (#1253)
+
+	Minor fixes:
+
+	* Fix description of errnoRet in Seccomp (#1277)
+	* config-linux: update for libseccomp v2.6.0 (#1276)
+	* Correct `prestart` hook description in summary (#1275)
+
+	Documentation, CI & Governance:
+
+	* ci: Add a github actions workflow for lint (#1257)
+	* update http links to https (#1269)
+	* doc: fix the invalid hyperlink naming-a-volume (#1268)
+	* ci: remove redundunt actions (#1256)
+	* chore: format JSON file `make -C schema fmt` (#1255)
+	* CODEOWNERS: remove vbatts (#1248)
+	* MAINTAINERS: move vbatts to EMERITUS (#1248)
+	* Update golangci-lint to v1.56.1 in CI (#1245)
+	* Add Go v1.21 and v1.22 to GitHub Actions CI matrix (#1245)
+	* Update GitHub Actions packages to resolve warnings in CI (#1244)
+
 Changes with v1.2.0:
 
 	Additions:

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "+dev"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 2
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "+dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
**Changes with v1.2.1:**

Previous release: https://github.com/opencontainers/runtime-spec/pull/1242

	Additions:

	* zos updates (#1273)
	* Add support for windows CPU affinity (#1258)
	* specs-go: sync SCMP_ARCH_* constants with libseccomp main (#1229)
	* Add CPU affinity to executed processes (#1253)
	* config-linux: describe the format of cpus and mems (#1253)

	Minor fixes:

	Documentation, CI & Governance:

	* Fix description of errnoRet in Seccomp (#1277)
	* config-linux: update for libseccomp v2.6.0 (#1276)
	* Correct `prestart` hook description in summary (#1275)
	* ci: Add a github actions workflow for lint (#1257)
	* update http links to https (#1269)
	* doc: fix the invalid hyperlink naming-a-volume (#1268)
	* ci: remove redundunt actions (#1256)
	* chore: format JSON file `make -C schema fmt` (#1255)
	* config: simplify final CPU affinity rule (#1261)
	* CODEOWNERS: remove vbatts (#1248)
	* MAINTAINERS: move vbatts to EMERITUS (#1248)
	* Update golangci-lint to v1.56.1 in CI (#1245)
	* Add Go v1.21 and v1.22 to GitHub Actions CI matrix (#1245)
	* Update GitHub Actions packages to resolve warnings in CI (#1244)

<hr>

This release requires a two-thirds majority maintainers vote (8 of 11):

 * [ ] Michael Crosby <michael@docker.com> (@crosbymichael)
 * [x] Mrunal Patel <mpatel@redhat.com> (@mrunalp)
 * [ ] Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)
 * [ ] Tianon Gravi <admwiggin@gmail.com> (@tianon)
 * [x] Qiang Huang <h.huangqiang@huawei.com> (@hqhq)
 * [x] Aleksa Sarai <asarai@suse.de> (@cyphar)
 * [x] Giuseppe Scrivano <gscrivan@redhat.com> (@giuseppe)
 * [x] Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (@AkihiroSuda)
 * [x] Kir Kolyshkin <kolyshkin@gmail.com> (@kolyshkin)
 * [ ] Sebastiaan van Stijn <github@gone.nl> (@thaJeztah)
 * [x] Toru Komatsu <k0ma@utam0k.jp> (@utam0k)