### PR TITLE
config-linux: add intelRdt.enableMonitoring

### DIFF
--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -278,10 +278,7 @@
                         "type": "string",
                         "pattern": "^MB:[^\\n]*$"
                     },
-                    "enableCMT": {
-                        "type": "boolean"
-                    },
-                    "enableMBM": {
+                    "enableMonitoring": {
                         "type": "boolean"
                     }
                 }

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -855,13 +855,9 @@ type LinuxIntelRdt struct {
 	// NOTE: Should not be specified if Schemata is non-empty.
 	MemBwSchema string `json:"memBwSchema,omitempty"`
 
-	// EnableCMT is the flag to indicate if the Intel RDT CMT is enabled. CMT (Cache Monitoring Technology) supports monitoring of
-	// the last-level cache (LLC) occupancy for the container.
-	EnableCMT bool `json:"enableCMT,omitempty"`
-
-	// EnableMBM is the flag to indicate if the Intel RDT MBM is enabled. MBM (Memory Bandwidth Monitoring) supports monitoring of
-	// total and local memory bandwidth for the container.
-	EnableMBM bool `json:"enableMBM,omitempty"`
+	// EnableMonitoring enables resctrl monitoring for the container. This will
+	// create a dedicated resctrl monitoring group for the container.
+	EnableMonitoring bool `json:"enableMonitoring,omitempty"`
 }
 
 // ZOS contains platform-specific configuration for z/OS based containers.


### PR DESCRIPTION
Add a parameter for enabling per-container resctrl monitoring.

This supersedes the previous `enableCMT` and `enableMBM` settings whose functionality was very vaguely specified. Separate parameter for every monitoring metric does not seem to make much sense, in particular because in the resctrl filesystem it is not possible to selectively enable a subset of the monitoring features. You always get all the metrics that the system provides. Also, with separate settings (and corresponding check if the specific metric is available) the user cannot specify "enable whatever is available" - setting everything to "true" might fail because one of the metrics is not available on the platform. In addition, having separate parameters is very future-unproof, making support for new monitoring metrics unnecessarily cumbersome to add. New metrics are certain to be added in new hardware generations, e.g. perf/energy monitoring in the near future (https://lkml.org/lkml/2025/5/21/1631), and requiring an update to the runtime-spec for each one of them feels like an overkill without much benefits. It is easier to have one switch for "enable container-specific metrics" and let the user read whatever metrics the platform provides.

Moreover, it is not even possible to turn off monitoring (from the resctrl filesystem). For example, you always get the metrics for all CTRL_MON groups (closIDs). However, that is not always very useful as there likely are a lot of applications packed in the same group. The new intelRdt.enableMontoring parameter will enable creation of a MON group specific to a single container allowing monitoring of resctrl metrics on per-container granularity.


The `intelRdt.enableCMT` and `intelRdt.enableMBM` are removed from the spec. They are vaguely specified, problematic and have no known implementations.

**NOTE:** I checked all the runtimes listed in [`implementeations.md`](https://github.com/opencontainers/runtime-spec/blob/main/implementations.md) and none of them have implemented the `enableCMT` and `enableMBM` so I wonder if there would be an option to just drop those(?)