### PR TITLE
config-linux: define default clos for linux.intelRdt

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -742,6 +742,8 @@ If `intelRdt` is not set, the runtime MUST NOT manipulate any `resctrl` pseudo-f
 The following parameters can be specified for the container:
 
 * **`closID`** *(string, OPTIONAL)* - specifies the identity for RDT Class of Service (CLOS).
+  As a special case, value `/` means that the container MUST be assigned to the default CLOS (the
+  root of the resctrl filesystem).
 
 * **`l3CacheSchema`** *(string, OPTIONAL)* - specifies the schema for L3 cache id and capacity bitmask (CBM).
     The value SHOULD start with `L3:` and SHOULD NOT contain newlines.


### PR DESCRIPTION
Specify "/" as an explicit value for linux.intelRdt.closID to assign a container to the default CLOS, corresponding to the root of the resctrl filesystem.

This addition is important after the recently introduced intelRdt.enableMonitoring field. There is no way to express "enable monitoring but keep the container in the default CLOS". Users would otherwise have to rely on pre-created CLOSes or may quickly exhaust available CLOS entries - in some configurations the number of available CLOSes (on top of the default) may be as low as three.

> [!NOTE]
> Alternative names I considered were e.g. `.`, `/default`, `/root`, `default/`, `root/` (i.e. something that is not a possible/valid > name in the resctrl fs).