### PR TITLE
features-linux: expose IntelRdt monitoring support

### DIFF
--- a/features-linux.md
+++ b/features-linux.md
@@ -234,13 +234,16 @@ Irrelevant to the availability of Intel RDT on the host operating system.
 * **`enabled`** (bool, OPTIONAL) represents whether the runtime supports Intel RDT.
 * **`schemata`** (bool, OPTIONAL) represents whether the
   (`schemata` field of `linux.intelRdt` in `config.json`)[config-linux.md#intelrdt] is supported.
+* **`monitoring`** (bool, OPTIONAL) represents whether the
+  (`enableMonitoring` field of `linux.intelRdt` in `config.json`)[config-linux.md#intelrdt] is supported.
 
 ### Example
 
 ```json
 "intelRdt": {
   "enabled": true,
-  "schemata": true
+  "schemata": true,
+  "monitoring": true
 }
 ```
 

--- a/features.md
+++ b/features.md
@@ -372,7 +372,8 @@ Here is a full example for reference.
     },
     "intelRdt": {
       "enabled": true,
-      "schemata": true
+      "schemata": true,
+      "monitoring": true
     }
   },
   "annotations": {

--- a/specs-go/features/features.go
+++ b/specs-go/features/features.go
@@ -134,6 +134,10 @@ type IntelRdt struct {
 	// Schemata is true if the "linux.intelRdt.enableMonitoring" field of the
 	// spec is implemented.
 	Schemata *bool `json:"schemata,omitempty"`
+	// Monitoring is true if the "linux.intelRdt.enableMonitoring" field of the
+	// spec is implemented.
+	// Nil value means "unknown", not "false".
+	Monitoring *bool `json:"monitoring,omitempty"`
 }
 
 // MemoryPolicy represents the "memoryPolicy" field.


### PR DESCRIPTION
Commit 34a39b90707d979c56f834071c77ef60941d7688 introduced the "linux.intelRdt.enableMonitoring" field. This patch supplements it by adding "linux.intelRdt.monitoring" field in the features.json to check if the runtime implementation supports the new field of the spec.

Refs: #1287 