### PR TITLE
specs-go/features: add linux.intelRdt.schemata field

### DIFF
--- a/specs-go/features/features.go
+++ b/specs-go/features/features.go
@@ -130,6 +130,9 @@ type IntelRdt struct {
 	// Unrelated to whether the host supports Intel RDT or not.
 	// Nil value means "unknown", not "false".
 	Enabled *bool `json:"enabled,omitempty"`
+	// Schemata is true if the "linux.intelRdt.enableMonitoring" field of the
+	// spec is implemented.
+	Schemata *bool `json:"schemata,omitempty"`
 }
 
 // MountExtensions represents the "mountExtensions" field.


### PR DESCRIPTION
Accidentally left out from d2f4f9097a834934fd8232cfc54ddc3679a44764 which added the "linux.intelRdt.schemata" field to the config.