### PR TITLE
schema: fix json

### DIFF
--- a/schema/defs.json
+++ b/schema/defs.json
@@ -75,7 +75,7 @@
                 "type": "string"
             }
         },
-	"ArrayOfUint32": {
+        "ArrayOfUint32": {
             "type": "array",
             "items": {
                 "$ref": "#definitions/uint32"


### PR DESCRIPTION
Fix a bad indentation in json after PR #1209 (commit af0d16d).

For some reason CI didn't catch that before the merge.