### PR TITLE
ci: use supported Go versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.21.x, 1.22.x]
+        go: [oldstable, stable]
 
     steps:
       - name: checkout source code


### PR DESCRIPTION
The upside is, we don't have to bump the versions here every 6 months.
    
The downside is, CI might break once the new Go is out.
    
Overall I think it is net positive.

PS I can't do something like @tianon did in https://github.com/opencontainers/image-spec/pull/1229 as this repo lacks go.mod file 🤷🏻 
